### PR TITLE
docs: fix JSON syntax error in verifier service README

### DIFF
--- a/ncn/verifier-service/README.md
+++ b/ncn/verifier-service/README.md
@@ -167,7 +167,7 @@ Example response:
   "stake_accounts": [],
   "vote_accounts": [
     {
-      "active_stake": :33334695348563,
+      "active_stake": 33334695348563,
       "vote_account": "1vgZrjS88D7RA1CbcSAovvyd6cSVqk3Ag1Ty2kSrJVd"
     }
   ],


### PR DESCRIPTION
Fixes a double colon typo in the `/voter/:voting_wallet` example response:

`"active_stake": :33334695348563` → `"active_stake": 33334695348563`
