### PR TITLE
docs: fix Cloudflare SSL mode to Full (Strict) in DEPLOYMENT.md

### DIFF
--- a/ncn/verifier-service/DEPLOYMENT.md
+++ b/ncn/verifier-service/DEPLOYMENT.md
@@ -99,7 +99,7 @@ TTL: Auto
 ```
 
 5. Replace current nameserver with Cloudflare nameserver
-6. In SSL/TLS Overview, set mode to Flexible.
+6. In SSL/TLS Overview, set mode to Full (Strict). This requires a valid TLS certificate on the origin server (e.g., via Let's Encrypt or a Cloudflare Origin Certificate).
 7. In Security -> Security Rules, create new Rate Limiting Rule for each API path. Note that the free tier only allows 1 rule, with granularity of requests per 10s, and blocking duration of 10s.
 
 ### 8) Start the database cleanup cron


### PR DESCRIPTION
Step 7 of the deployment guide contains a contradiction:

> "Decide TLS mode (Full Strict recommended)" (early in step 7)
> "In SSL/TLS Overview, set mode to Flexible." (step-by-step instructions)

Flexible mode means traffic between Cloudflare and the origin is unencrypted HTTP — a concern for the `/upload` endpoint handling governance snapshot data with Ed25519 signature verification.

Changed the step-by-step instruction to "Full (Strict)" to match the earlier recommendation, with a note about origin TLS requirements.
