### PR TITLE
docs: replace hardcoded devnet RPC URLs with placeholder

### DIFF
--- a/docs/src/content/ncn/cli/index.mdx
+++ b/docs/src/content/ncn/cli/index.mdx
@@ -184,7 +184,7 @@ Initializes the on-chain `ProgramConfig` singleton. Must be run once per deploym
 ncn-cli \
   --payer-path ~/.config/solana/id.json \
   --authority-path ~/.config/solana/id.json \
-  --rpc-url https://api.devnet.solana.com \
+  --rpc-url <RPC_URL> \
   init-program-config \
   --svmgov-program-id <PUBKEY>
 ```
@@ -203,7 +203,7 @@ Updates mutable fields on the on-chain `ProgramConfig`. All arguments are option
 ncn-cli \
   --payer-path ~/.config/solana/id.json \
   --authority-path ~/.config/solana/id.json \
-  --rpc-url https://api.devnet.solana.com \
+  --rpc-url <RPC_URL> \
   update-program-config \
   --min-consensus-threshold-bps 6667 \
   --vote-duration 86400 \
@@ -253,7 +253,7 @@ ncn-cli \
 ncn-cli \
   --payer-path <PATH_TO_PAYER_KEYPAIR> \
   --authority-path <PATH_TO_AUTHORITY_KEYPAIR> \
-  --rpc-url https://api.devnet.solana.com \
+  --rpc-url <RPC_URL> \
   update-operator-whitelist \
   -r PUBKEY_OLD
 
@@ -261,7 +261,7 @@ ncn-cli \
 ncn-cli \
   --payer-path ~/.config/solana/id.json \
   --authority-path ~/.config/solana/id.json \
-  --rpc-url https://api.devnet.solana.com \
+  --rpc-url <RPC_URL> \
   update-operator-whitelist \
   -a PUBKEY_NEW \
   -r PUBKEY_OLD
@@ -284,7 +284,7 @@ Casts an operator vote on a ballot box using an explicit Merkle root and snapsho
 ncn-cli \
   --payer-path ~/.config/solana/id.json \
   --authority-path ~/.config/solana/id.json \
-  --rpc-url https://api.devnet.solana.com \
+  --rpc-url <RPC_URL> \
   cast-vote \
   --snapshot-slot 300000000 \
   --root <BASE58_ROOT> \
@@ -307,7 +307,7 @@ Casts an operator vote using a local `MetaMerkleSnapshot` file. Reads the root a
 ncn-cli \
   --payer-path ~/.config/solana/id.json \
   --authority-path ~/.config/solana/id.json \
-  --rpc-url https://api.devnet.solana.com \
+  --rpc-url <RPC_URL> \
   cast-vote-from-snapshot \
   --snapshot-slot 300000000 \
   --read-path ./meta_merkle-300000000.zip \
@@ -330,7 +330,7 @@ Removes the caller's vote from a `BallotBox`. Only permitted before consensus is
 ncn-cli \
   --payer-path ~/.config/solana/id.json \
   --authority-path ~/.config/solana/id.json \
-  --rpc-url https://api.devnet.solana.com \
+  --rpc-url <RPC_URL> \
   remove-vote --snapshot-slot <SLOT>
 ```
 
@@ -350,7 +350,7 @@ Resolves a stalled ballot by writing an explicit winning ballot. The provided `-
 ncn-cli \
   --payer-path ~/.config/solana/id.json \
   --authority-path ~/.config/solana/id.json \
-  --rpc-url https://api.devnet.solana.com \
+  --rpc-url <RPC_URL> \
   set-tie-breaker --snapshot-slot <SLOT> \
   --root <MERKLE_ROOT> --hash <SNAPSHOT_HASH>
 ```
@@ -371,7 +371,7 @@ Resets a bricked `BallotBox`. Permitted only when the ballot box's vote window h
 ncn-cli \
   --payer-path ~/.config/solana/id.json \
   --authority-path ~/.config/solana/id.json \
-  --rpc-url https://api.devnet.solana.com \
+  --rpc-url <RPC_URL> \
   reset-ballot-box --snapshot-slot <SLOT>
 ```
 
@@ -388,7 +388,7 @@ Finalizes the winning ballot for a snapshot slot. Closes voting for `--snapshot-
 ```bash
 ncn-cli \
   --payer-path ~/.config/solana/id.json \
-  --rpc-url https://api.devnet.solana.com \
+  --rpc-url <RPC_URL> \
   finalize-ballot --snapshot-slot <SLOT>
 ```
 
@@ -413,22 +413,22 @@ Dumps the raw `Debug` representation of an on-chain account. Selects the account
 ```bash
 # View ProgramConfig
 ncn-cli \
-  --rpc-url https://api.devnet.solana.com log \
+  --rpc-url <RPC_URL> log \
   --ty program-config
 
 # View a BallotBox
 ncn-cli \
-  --rpc-url https://api.devnet.solana.com log \
+  --rpc-url <RPC_URL> log \
   --ty ballot-box --snapshot-slot <SLOT>
 
 # View a ConsensusResult
 ncn-cli \
-  --rpc-url https://api.devnet.solana.com log \
+  --rpc-url <RPC_URL> log \
   --ty consensus-result --snapshot-slot <SLOT>
 
 # View a MetaMerkleProof
 ncn-cli \
-  --rpc-url https://api.devnet.solana.com log \
+  --rpc-url <RPC_URL> log \
   --ty proof \
   --snapshot-slot <SLOT> \
   --vote-account <VOTE_ACCOUNT_PUBKEY>
@@ -450,7 +450,7 @@ Prints the on-chain `ProgramConfig` singleton.
 
 ```bash
 ncn-cli \
-  --rpc-url https://api.devnet.solana.com \
+  --rpc-url <RPC_URL> \
   get-program-config
 ```
 
@@ -462,7 +462,7 @@ Prints the operator whitelist from `ProgramConfig`.
 
 ```bash
 ncn-cli \
-  --rpc-url https://api.devnet.solana.com \
+  --rpc-url <RPC_URL> \
   get-operator-whitelist
 ```
 
@@ -474,7 +474,7 @@ Prints the on-chain `BallotBox` for a snapshot slot, including tallies and opera
 
 ```bash
 ncn-cli \
-  --rpc-url https://api.devnet.solana.com \
+  --rpc-url <RPC_URL> \
   get-ballot \
   --snapshot-slot <SLOT>
 ```
@@ -491,7 +491,7 @@ Prints a single operator's vote within a ballot box.
 
 ```bash
 ncn-cli \
-  --rpc-url https://api.devnet.solana.com \
+  --rpc-url <RPC_URL> \
   get-operator-vote \
   --snapshot-slot <SLOT> \
   --operator <OPERATOR_PUBKEY>
@@ -510,7 +510,7 @@ Prints the `ConsensusResult` PDA for a snapshot slot.
 
 ```bash
 ncn-cli \
-  --rpc-url https://api.devnet.solana.com \
+  --rpc-url <RPC_URL> \
   get-consensus-result \
   --snapshot-slot <SLOT>
 ```
@@ -527,7 +527,7 @@ Prints the `MetaMerkleProof` PDA for a vote account.
 
 ```bash
 ncn-cli \
-  --rpc-url https://api.devnet.solana.com \
+  --rpc-url <RPC_URL> \
   get-proof \
   --snapshot-slot <SLOT> \
   --vote-account <VOTE_ACCOUNT_PUBKEY>
@@ -546,7 +546,7 @@ Checks whether a `BallotBox` exists for a snapshot slot.
 
 ```bash
 ncn-cli \
-  --rpc-url https://api.devnet.solana.com \
+  --rpc-url <RPC_URL> \
   ballot-exists \
   --snapshot-slot <SLOT>
 ```
@@ -563,7 +563,7 @@ Prints a combined status report: program config, ballot box, and consensus resul
 
 ```bash
 ncn-cli \
-  --rpc-url https://api.devnet.solana.com \
+  --rpc-url <RPC_URL> \
   --cluster mainnet \
   status \
   --snapshot-slot <SLOT>

--- a/ncn/README.md
+++ b/ncn/README.md
@@ -134,14 +134,14 @@ Use `RUST_LOG=info` to enable logs.
 RUST_LOG=info cargo run --bin cli -- \
   --payer-path ~/.config/solana/id.json \
   --authority-path ~/.config/solana/id.json \
-  --rpc-url https://api.devnet.solana.com \
+  --rpc-url <RPC_URL> \
   init-program-config
 
 # Add or remove operators from whitelist
 RUST_LOG=info cargo run --bin cli -- \
   --payer-path ~/.config/solana/id.json \
   --authority-path ~/.config/solana/id.json \
-  --rpc-url https://api.devnet.solana.com \
+  --rpc-url <RPC_URL> \
   update-operator-whitelist -a key1,key2,key3 -r key4,key5
 
 # Update config (all arguments are optional):
@@ -149,7 +149,7 @@ RUST_LOG=info cargo run --bin cli -- \
 RUST_LOG=info cargo run --bin cli -- \
   --payer-path ~/.config/solana/id.json \
   --authority-path ~/.config/solana/id.json \
-  --rpc-url https://api.devnet.solana.com \
+  --rpc-url <RPC_URL> \
   update-program-config \
   --min-consensus-threshold-bps 6000 \
   --vote-duration 180 \
@@ -160,7 +160,7 @@ RUST_LOG=info cargo run --bin cli -- \
 RUST_LOG=info cargo run --bin cli -- \
   --payer-path ~/.config/solana/id.json \
   --authority-path <PATH_TO_PROPOSED_AUTHORITY_KEYPAIR> \
-  --rpc-url https://api.devnet.solana.com \
+  --rpc-url <RPC_URL> \
   finalize-proposed-authority
 ```
 
@@ -240,17 +240,17 @@ cargo run --release --bin cli -- \
 ````bash
 # Log ProgramConfig
 RUST_LOG=info cargo run --bin cli -- \
-  --rpc-url https://api.devnet.solana.com log \
+  --rpc-url <RPC_URL> log \
   --ty program-config
 
 # Log BallotBox (by snapshot_slot)
 RUST_LOG=info cargo run --bin cli -- \
-  --rpc-url https://api.devnet.solana.com log \
+  --rpc-url <RPC_URL> log \
   --ty ballot-box --snapshot-slot <SLOT>
 
 # Log ConsensusResult (by snapshot_slot)
 RUST_LOG=info cargo run --bin cli -- \
-  --rpc-url https://api.devnet.solana.com log \
+  --rpc-url <RPC_URL> log \
   --ty consensus-result --snapshot-slot <SLOT>
 
 ---
@@ -262,7 +262,7 @@ RUST_LOG=info cargo run --bin cli -- \
 RUST_LOG=info cargo run --bin cli -- \
   --payer-path ~/.config/solana/id.json \
   --authority-path ~/.config/solana/id.json \
-  --rpc-url https://api.devnet.solana.com \
+  --rpc-url <RPC_URL> \
   cast-vote --snapshot-slot <SLOT> \
   --root ByVtRpEnLyD1eVS8Bq21VvDnMffsqPAypaMT9KMZCZcJ \
   --hash 4seYTnZyZNby5ZQTy8ajAapDiMgUYrvYx4hzYRXVn4zH
@@ -271,7 +271,7 @@ RUST_LOG=info cargo run --bin cli -- \
 RUST_LOG=info cargo run --bin cli -- \
   --payer-path ~/.config/solana/id.json \
   --authority-path ~/.config/solana/id.json \
-  --rpc-url https://api.devnet.solana.com \
+  --rpc-url <RPC_URL> \
   cast-vote-from-snapshot --snapshot-slot <SLOT> \
   --read-path ./meta_merkle-340850340.zip
 
@@ -279,7 +279,7 @@ RUST_LOG=info cargo run --bin cli -- \
 RUST_LOG=info cargo run --bin cli -- \
   --payer-path ~/.config/solana/id.json \
   --authority-path ~/.config/solana/id.json \
-  --rpc-url https://api.devnet.solana.com \
+  --rpc-url <RPC_URL> \
   remove-vote --snapshot-slot <SLOT>
 ````
 
@@ -292,7 +292,7 @@ RUST_LOG=info cargo run --bin cli -- \
 RUST_LOG=info cargo run --bin cli -- \
   --payer-path ~/.config/solana/id.json \
   --authority-path ~/.config/solana/id.json \
-  --rpc-url https://api.devnet.solana.com \
+  --rpc-url <RPC_URL> \
   finalize-ballot --snapshot-slot <SLOT>
 
 # Set tie-breaking result if consensus was not reached
@@ -300,7 +300,7 @@ RUST_LOG=info cargo run --bin cli -- \
 RUST_LOG=info cargo run --bin cli -- \
   --payer-path ~/.config/solana/id.json \
   --authority-path ~/.config/solana/id.json \
-  --rpc-url https://api.devnet.solana.com \
+  --rpc-url <RPC_URL> \
   set-tie-breaker --snapshot-slot <SLOT> \
   --root <MERKLE_ROOT> --hash <SNAPSHOT_HASH>
 
@@ -308,7 +308,7 @@ RUST_LOG=info cargo run --bin cli -- \
 RUST_LOG=info cargo run --bin cli -- \
   --payer-path ~/.config/solana/id.json \
   --authority-path ~/.config/solana/id.json \
-  --rpc-url https://api.devnet.solana.com \
+  --rpc-url <RPC_URL> \
   reset-ballot-box --snapshot-slot <SLOT>
 ```
 


### PR DESCRIPTION
Closes #21

## Summary
All NCN CLI examples hardcoded `https://api.devnet.solana.com` as the RPC endpoint. The governance program is not deployed on devnet — these examples would fail for any operator trying to use them.

## Changes
- Replaced all devnet RPC URLs with `<RPC_URL>` placeholder in `docs/src/content/ncn/cli/index.mdx` (~22 instances)
- Same replacement in `ncn/README.md` (~13 instances)

Fixes #21
