### PR TITLE
docs: add conceptual overview and quick start to root README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,25 @@
 # Solana Validator Governance System
 
-A decentralized governance platform for Solana validators featuring merkle proof verification, stake-weighted voting, and real-time event monitoring.
+A decentralized governance platform enabling Solana validators and stakers to create, vote on, and finalize on-chain proposals using stake-weighted voting and merkle proof verification.
+
+## Overview
+
+The Solana Governance System provides two governance tracks:
+
+- **SVM Governance (`svmgov/`)** — Validator and staker proposals with stake-weighted voting, vote overrides for delegated stake, and on-chain finalization
+- **NCN Governance (`ncn/`)** — Node Consensus Network ballot voting with merkle proof verification, operator whitelisting, and a verifier service for automated snapshot processing
+
+Both tracks use stake weight to determine voting power, ensuring that governance decisions reflect the economic commitments of participants.
+
+## Quick Start
+
+| I want to... | Go to |
+|---|---|
+| **Vote as a validator** | [Validator Guide](./docs/src/content/svmgov/validators/index.mdx) |
+| **Vote as a staker** | [Staker Guide](./docs/src/content/svmgov/stakers/index.mdx) |
+| **Run the NCN verifier** | [Verifier Service](./ncn/verifier-service/README.md) |
+| **Use the CLI** | [CLI Reference](./docs/src/content/ncn/cli/index.mdx) |
+| **Read the full docs** | [Documentation](./docs/) |
 
 ## Project Structure
 
@@ -18,3 +37,11 @@ NCN (Node Consensus Network) governance program — on-chain ballot voting, merk
 
 ### [`docs/`](./docs)
 Documentation site built with Nextra covering validator and staker workflows.
+
+## Contributing
+
+Issues and pull requests are welcome. See the [open issues](https://github.com/solana-foundation/solana-governance/issues) for areas that need work.
+
+## License
+
+See [LICENSE](./LICENSE) for details.

--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@ The two tracks weight votes differently. In `svmgov/`, voting power is stake-wei
 | **Vote as a validator** | [Validator Guide](./docs/src/content/svmgov/validators/index.mdx) |
 | **Vote as a staker** | [Staker Guide](./docs/src/content/svmgov/stakers/index.mdx) |
 | **Run the NCN verifier** | [Verifier Service](./ncn/verifier-service/README.md) |
-| **Use the CLI** | [CLI Reference](./docs/src/content/ncn/cli/index.mdx) |
+| **Use the NCN operator CLI** | [NCN CLI Reference](./docs/src/content/ncn/cli/index.mdx) |
+| **Use the svmgov CLI** | [svmgov CLI Reference](./docs/src/content/svmgov/index.mdx) |
 | **Read the full docs** | [Documentation](./docs/) |
 
 ## Project Structure

--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@ A decentralized governance platform enabling Solana validators and stakers to cr
 The Solana Governance System provides two governance tracks:
 
 - **SVM Governance (`svmgov/`)** — Validator and staker proposals with stake-weighted voting, vote overrides for delegated stake, and on-chain finalization
-- **NCN Governance (`ncn/`)** — Node Consensus Network ballot voting with merkle proof verification, operator whitelisting, and a verifier service for automated snapshot processing
+- **NCN Governance (`ncn/`)** — whitelisted operators independently generate stake snapshots and vote on a canonical merkle root, with proof verification and a verifier service for serving proofs
 
-Both tracks use stake weight to determine voting power, ensuring that governance decisions reflect the economic commitments of participants.
+The two tracks weight votes differently. In `svmgov/`, voting power is stake-weighted, and delegators can override their validator's vote with their own stake. In `ncn/`, all whitelisted operators have equal voting weight — the consensus threshold is a percentage of operators, not of stake. The NCN track establishes *which* stake snapshot is canonical; `svmgov` then uses that snapshot to weight proposal votes.
 
 ## Quick Start
 


### PR DESCRIPTION
Closes #18

## Summary
The root README only listed project directories with no explanation of what the governance system does, how the pieces fit together, or how to get started.

## Changes
- Added one-paragraph overview explaining the two governance tracks (SVM + NCN)
- Added quick-start table linking to key docs by use case
- Added contributing section pointing to open issues
- Retained existing project structure section

## Note
This PR and #36 both touch the end of README.md — whichever merges second will need a trivial rebase, which I'll push same-day.

Fixes #18