### PR TITLE
docs: replace boilerplate frontend README with project-specific content

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,36 +1,48 @@
-This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-app`](https://nextjs.org/docs/app/api-reference/cli/create-next-app).
+# Solana Governance Frontend
+
+Next.js web interface for the Solana Validator Governance System. Provides a dashboard for viewing proposals, casting votes, and monitoring governance status.
+
+## Features
+
+- View active and historical governance proposals
+- Cast and modify votes (validator and staker workflows)
+- Real-time vote tracking and quorum progress
+- Stake-weighted vote visualization
+- Wallet integration via Solana wallet adapters
+
+## Prerequisites
+
+- Node.js (see `.nvmrc` for version)
+- pnpm (package manager)
+- A Solana RPC endpoint
 
 ## Getting Started
 
-First, run the development server:
+1. Copy the environment template:
+   ```bash
+   cp .env.example .env.local
+2. Configure your RPC endpoint in .env.local
+3. Install dependencies:
 
-```bash
-npm run dev
-# or
-yarn dev
-# or
+pnpm install
+
+4. Start the development server:
+
 pnpm dev
-# or
-bun dev
-```
 
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+5. Open http://localhost:3000
 
-You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
+Environment Variables
 
-This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
+See .env.example for required configuration.
 
-## Learn More
+Project Structure
 
-To learn more about Next.js, take a look at the following resources:
+• src/app/ — Next.js app router pages
+• src/components/ — React components (governance, proposals, UI)
+• src/chain/ — Solana program interaction (IDL, instructions, types)
+• src/hooks/ — Custom React hooks for data fetching and state
+• src/data/ — API and data layer
+• src/contexts/ — React contexts (wallet, endpoints, modals)
 
-- [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
-- [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
 
-You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js) - your feedback and contributions are welcome!
-
-## Deploy on Vercel
-
-The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
-
-Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -21,28 +21,31 @@ Next.js web interface for the Solana Validator Governance System. Provides a das
 1. Copy the environment template:
    ```bash
    cp .env.example .env.local
-2. Configure your RPC endpoint in .env.local
-3. Install dependencies:
+   ```
 
-pnpm install
+2. Configure your RPC endpoint in `.env.local`
+
+3. Install dependencies:
+   ```bash
+   pnpm install
+   ```
 
 4. Start the development server:
+   ```bash
+   pnpm dev
+   ```
 
-pnpm dev
+5. Open [http://localhost:3000](http://localhost:3000)
 
-5. Open http://localhost:3000
+### Environment Variables
 
-Environment Variables
+See [`.env.example`](./.env.example) for required configuration.
 
-See .env.example for required configuration.
+### Project Structure
 
-Project Structure
-
-• src/app/ — Next.js app router pages
-• src/components/ — React components (governance, proposals, UI)
-• src/chain/ — Solana program interaction (IDL, instructions, types)
-• src/hooks/ — Custom React hooks for data fetching and state
-• src/data/ — API and data layer
-• src/contexts/ — React contexts (wallet, endpoints, modals)
-
-
+- `src/app/` — Next.js app router pages
+- `src/components/` — React components (governance, proposals, UI)
+- `src/chain/` — Solana program interaction (IDL, instructions, types)
+- `src/hooks/` — Custom React hooks for data fetching and state
+- `src/data/` — API and data layer
+- `src/contexts/` — React contexts (wallet, endpoints, modals)


### PR DESCRIPTION
Closes #19

## Summary
The frontend README was the default `create-next-app` template — generic Next.js getting started text with no information about the governance frontend.

## Changes
- Replaced with project-specific overview, features list, and setup instructions
- Added environment variable reference and project structure guide
- References actual tooling (pnpm, .nvmrc, .env.example)
