### PR TITLE
docs: clarify Rust 1.89.0 requirement and add dependency-patch warning

### DIFF
--- a/ncn/README.md
+++ b/ncn/README.md
@@ -85,6 +85,7 @@ rustup toolchain install 1.89.0 // install
 rustup default 1.89.0 // set as default
 rustc --version // verify version
 ```
+> **Why Rust 1.89.0?** The NCN program depends on nightly features used by the `jito-tip-router` and Solana SDK crates. Stable Rust will not compile these dependencies. Install with `rustup toolchain install 1.89.0` or set a directory override with `rustup override set 1.89.0`.
 
 2. (Optional - when using Anchor CLI) Install Solana CLI version 3.0 or higher. The bundled rustc in older Solana CLI versions may not be compatible with some dependencies.
 

--- a/ncn/README.md
+++ b/ncn/README.md
@@ -315,6 +315,7 @@ RUST_LOG=info cargo run --bin cli -- \
 ## Troubleshooting
 
 > ⚠️ **Warning:** Some workarounds below involve modifying source code in dependency crates (e.g., `jito-solana`). These changes are fragile — they will be lost on `cargo update` and may mask real errors. Use only for local development and testing, not production deployments. If you encounter these issues in production, [file an issue](https://github.com/solana-foundation/solana-governance/issues).
+
 ### Dependency Version Conflicts When Upgrading jito-tip-router
 
 When upgrading the `jito-tip-router` dependency to a newer version, you may encounter dependency version conflicts. If you see compilation errors related to version mismatches, run these commands:

--- a/ncn/README.md
+++ b/ncn/README.md
@@ -314,6 +314,25 @@ RUST_LOG=info cargo run --bin cli -- \
 
 ## Troubleshooting
 
+> ⚠️ **Warning:** Some workarounds below involve modifying source code in dependency crates (e.g., `jito-solana`). These changes are fragile — they will be lost on `cargo update` and may mask real errors. Use only for local development and testing, not production deployments. If you encounter these issues in production, [file an issue](https://github.com/solana-foundation/solana-governance/issues).
+### Dependency Version Conflicts When Upgrading jito-tip-router
+
+When upgrading the `jito-tip-router` dependency to a newer version, you may encounter dependency version conflicts. If you see compilation errors related to version mismatches, run these commands:
+
+- **Update Cargo.lock to force `solana-sysvar` version 3.0.0**: Some dependencies may pull in `solana-sysvar` version 3.1.1, which can cause compilation errors due to missing serde trait implementations. To force the use of version 3.0.0, run:
+
+  ```bash
+  cargo update -p solana-sysvar:3.1.1 --precise 3.0.0
+  ```
+
+- **Update Cargo.lock to force `solana-epoch-rewards-hasher` version 3.0.0**: Some dependencies may pull in `solana-epoch-rewards-hasher` version 3.1.0, which requires `solana-hash` version 4.0.1. However, jito-solana dependencies use `solana-hash` version 3.0.0, causing type mismatch errors. To force the use of version 3.0.0, run:
+
+  ```bash
+  cargo update -p solana-epoch-rewards-hasher:3.1.0 --precise 3.0.0
+  ```
+
+Note: Do not manually edit `Cargo.lock` - always use `cargo update` to modify dependency versions.
+
 ### Missing Incrementatal Snapshot
 
 If you encounter an error similar to:

--- a/ncn/README.md
+++ b/ncn/README.md
@@ -85,7 +85,8 @@ rustup toolchain install 1.89.0 // install
 rustup default 1.89.0 // set as default
 rustc --version // verify version
 ```
-> **Why Rust 1.89.0?** The NCN program depends on nightly features used by the `jito-tip-router` and Solana SDK crates. Stable Rust will not compile these dependencies. Install with `rustup toolchain install 1.89.0` or set a directory override with `rustup override set 1.89.0`.
+> **Why Rust 1.89.0?** The `jito-tip-router` and Solana SDK dependency versions pinned by this repo require Rust 1.89.0; older toolchains fail to compile them. Use `rustup override set 1.89.0` in the repo directory to avoid changing your system default.
+
 
 2. (Optional - when using Anchor CLI) Install Solana CLI version 3.0 or higher. The bundled rustc in older Solana CLI versions may not be compatible with some dependencies.
 

--- a/ncn/README.md
+++ b/ncn/README.md
@@ -85,7 +85,7 @@ rustup toolchain install 1.89.0 // install
 rustup default 1.89.0 // set as default
 rustc --version // verify version
 ```
-> **Why Rust 1.89.0?** The `jito-tip-router` and Solana SDK dependency versions pinned by this repo require Rust 1.89.0; older toolchains fail to compile them. Use `rustup override set 1.89.0` in the repo directory to avoid changing your system default.
+> **Why Rust 1.89.0?** The `jito-tip-router` and Solana SDK dependency versions pinned by this repo require Rust 1.89.0; older toolchains fail to compile them. Alternatively, use `rustup override set 1.89.0` in the repo directory if you prefer not to change your system default.
 
 
 2. (Optional - when using Anchor CLI) Install Solana CLI version 3.0 or higher. The bundled rustc in older Solana CLI versions may not be compatible with some dependencies.


### PR DESCRIPTION
Closes #22
Closes #20

## Summary
The NCN README pins Rust 1.89.0 as a prerequisite but doesn't explain why, and the troubleshooting section didn't warn that some workarounds modify dependency source code.

## Changes
- Added a note explaining the 1.89.0 requirement (dependency versions pinned by jito-tip-router and the Solana SDK; older toolchains fail to compile), with a `rustup override` tip to avoid changing the system default
- Added a warning to Troubleshooting that source-level dependency patches are fragile, lost on `cargo update`, and unsuitable for production (consolidated from #33)

Fixes #22