### PR TITLE
docs: add monitoring and alerting guidance for verifier service

### DIFF
--- a/ncn/verifier-service/DEPLOYMENT.md
+++ b/ncn/verifier-service/DEPLOYMENT.md
@@ -176,3 +176,61 @@ Notes:
 
 - No changes are required for the cleanup cron; it runs on the host and continues to manage `/srv/verifier/data/governance.db`.
 - For zero-downtime, you can adapt the script to start a secondary container (different port) and flip traffic via a proxy/ALB once healthy.
+
+## Monitoring & Alerting
+
+### Health Checks
+
+The verifier service includes a metrics module ([`src/metrics.rs`](./src/metrics.rs)) for monitoring. Key indicators to track:
+
+- **Service uptime** — Is the verifier process running?
+- **Snapshot processing** — Are new epoch snapshots being processed successfully?
+- **Merkle proof uploads** — Are proofs being uploaded to the on-chain program?
+- **RPC connectivity** — Can the service reach its configured RPC endpoint?
+- **Disk usage** — Is snapshot storage filling up?
+
+### Recommended Alerts
+
+| Alert | Condition | Severity |
+|-------|-----------|----------|
+| Service down | Process not running for >5 min | Critical |
+| Snapshot stalled | No new snapshot processed in >2 epochs | Warning |
+| Upload failures | Consecutive upload errors >3 | Warning |
+| RPC unreachable | Connection timeouts >5 min | Critical |
+| Disk space | Snapshot storage >80% full | Warning |
+
+### Logging
+
+The verifier service logs to stdout. In production, capture logs with systemd journal or redirect to a file:
+
+```bash
+# If running as a systemd service
+journalctl -u ncn-verifier -f
+
+# If running manually
+./ncn-verifier 2>&1 | tee -a /var/log/ncn-verifier.log
+
+Process Management
+
+For production deployments, run the verifier service as a systemd unit:
+
+[Unit]
+Description=NCN Verifier Service
+After=network.target
+
+[Service]
+User=sol
+ExecStart=/path/to/ncn-verifier
+Restart=on-failure
+RestartSec=10
+LimitNOFILE=65535
+
+[Install]
+WantedBy=multi-user.target
+
+Enable and start:
+
+sudo systemctl enable ncn-verifier
+sudo systemctl start ncn-verifier
+
+

--- a/ncn/verifier-service/DEPLOYMENT.md
+++ b/ncn/verifier-service/DEPLOYMENT.md
@@ -186,7 +186,15 @@ The verifier service provides these monitoring surfaces:
 - `GET /healthz` — liveness check (no auth)
 - `GET /version` — crate version and git hash
 - `GET /meta` — metadata for the most recent snapshot, including its slot
-- `GET /metrics` — requires the `x-metrics-token` header; returns `upload_total` (by outcome), `proofs_not_found_total` (by proof kind), and `free_storage_mb` (absolute free space in MB at the data path, from [`src/metrics.rs`](./src/metrics.rs))
+- `GET /admin/stats` — requires the `x-metrics-token` header, matched against the `METRICS_AUTH_TOKEN` environment variable. Returns `401` if the token is missing or wrong, and `503` if `METRICS_AUTH_TOKEN` is unset on the service. Response shape (from [`src/metrics.rs`](./src/metrics.rs)):
+
+  - `upload_total` — array of `{outcome, count}`; outcomes are `success`, `bad_request`, `unauthorized`, `internal`
+  - `proofs_not_found_total` — array of `{kind, count}`; kinds are `vote`, `stake`
+  - `storage.free_storage_mb` — free space in MB on the filesystem holding `DB_PATH`
+  - `storage.db_size_mb` — current size of the SQLite database
+  - `storage.db_path` — resolved database path
+
+  Note the storage fields are nested under `storage`, not top level.
 
 ### Recommended Alerts
 
@@ -196,10 +204,11 @@ All conditions below are derivable from the endpoints above plus container statu
 |-------|--------|-----------|----------|
 | Service down | `docker ps` / `/healthz` | Container not running or `/healthz` failing for >5 min | Critical |
 | Snapshot stale | `/meta` | Most recent snapshot slot older than ~2 epochs behind cluster tip | Warning |
-| Upload errors | `/metrics` `upload_total` | Error-outcome count increases across consecutive scrape intervals | Warning |
-| Low disk | `/metrics` `free_storage_mb` | Free space below a fixed floor (e.g., < 20480 MB) | Warning |
+| Upload errors | `/admin/stats` `upload_total` | Error-outcome count increases across consecutive scrape intervals | Warning |
+| Low disk | `/admin/stats` `storage.free_storage_mb` | Free space below a fixed floor (e.g., < 20480 MB) | Warning |
+| DB growth | `/admin/stats` `storage.db_size_mb` | Sustained growth beyond expected snapshot retention | Info |
 
-Note: `free_storage_mb` is an absolute value, not a percentage — set the threshold against your provisioned volume size. Upload errors are cumulative counters; alert on the delta between scrapes rather than a "consecutive failures" count, which the service does not track.
+Note: `storage.free_storage_mb` is an absolute value, not a percentage — set the threshold against your provisioned volume size. The counters are cumulative and held in process memory, so a container restart zeroes them: alert on the delta between scrapes rather than a "consecutive failures" count, which the service does not track, and treat a counter going backwards as a restart rather than an error.
 
 ### Logging
 

--- a/ncn/verifier-service/DEPLOYMENT.md
+++ b/ncn/verifier-service/DEPLOYMENT.md
@@ -179,41 +179,41 @@ Notes:
 
 ## Monitoring & Alerting
 
-### Health Checks
+### What the service exposes
 
-The verifier service includes a metrics module ([`src/metrics.rs`](./src/metrics.rs)) for monitoring. Key indicators to track:
+The verifier service provides these monitoring surfaces:
 
-- **Service uptime** — Is the verifier process running?
-- **Snapshot processing** — Are new epoch snapshots being processed successfully?
-- **Merkle proof uploads** — Are proofs being uploaded to the on-chain program?
-- **RPC connectivity** — Can the service reach its configured RPC endpoint?
-- **Disk usage** — Is snapshot storage filling up?
+- `GET /healthz` — liveness check (no auth)
+- `GET /version` — crate version and git hash
+- `GET /meta` — metadata for the most recent snapshot, including its slot
+- `GET /metrics` — requires the `x-metrics-token` header; returns `upload_total` (by outcome), `proofs_not_found_total` (by proof kind), and `free_storage_mb` (absolute free space in MB at the data path, from [`src/metrics.rs`](./src/metrics.rs))
 
 ### Recommended Alerts
 
-| Alert | Condition | Severity |
-|-------|-----------|----------|
-| Service down | Process not running for >5 min | Critical |
-| Snapshot stalled | No new snapshot processed in >2 epochs | Warning |
-| Upload failures | Consecutive upload errors >3 | Warning |
-| RPC unreachable | Connection timeouts >5 min | Critical |
-| Disk space | Snapshot storage >80% full | Warning |
+All conditions below are derivable from the endpoints above plus container status:
+
+| Alert | Source | Condition | Severity |
+|-------|--------|-----------|----------|
+| Service down | `docker ps` / `/healthz` | Container not running or `/healthz` failing for >5 min | Critical |
+| Snapshot stale | `/meta` | Most recent snapshot slot older than ~2 epochs behind cluster tip | Warning |
+| Upload errors | `/metrics` `upload_total` | Error-outcome count increases across consecutive scrape intervals | Warning |
+| Low disk | `/metrics` `free_storage_mb` | Free space below a fixed floor (e.g., < 20480 MB) | Warning |
+
+Note: `free_storage_mb` is an absolute value, not a percentage — set the threshold against your provisioned volume size. Upload errors are cumulative counters; alert on the delta between scrapes rather than a "consecutive failures" count, which the service does not track.
 
 ### Logging
 
-The verifier service logs to stdout. In production, capture logs with systemd journal or redirect to a file:
+Under the recommended Docker deployment (`setup.sh`), logs go to the container:
 
 ```bash
-# If running as a systemd service
-journalctl -u ncn-verifier -f
-
-# If running manually
-./ncn-verifier 2>&1 | tee -a /var/log/ncn-verifier.log
+sudo docker logs --tail=200 -f verifier
 ```
 
 ### Process Management
 
-For production deployments, run the verifier service as a systemd unit:
+`setup.sh` already starts the container with `--restart unless-stopped`, so Docker handles crash and reboot recovery — no additional process manager is needed for the standard deployment.
+
+If you instead run the binary natively (outside Docker), use a systemd unit, and note that the environment variables from section 6 (e.g., `OPERATOR_PUBKEY`) must be supplied via an `EnvironmentFile`:
 
 ```ini
 [Unit]
@@ -222,6 +222,7 @@ After=network.target
 
 [Service]
 User=sol
+EnvironmentFile=/etc/ncn-verifier/env
 ExecStart=/path/to/ncn-verifier
 Restart=on-failure
 RestartSec=10
@@ -231,10 +232,7 @@ LimitNOFILE=65535
 WantedBy=multi-user.target
 ```
 
-Enable and start:
-
 ```bash
-sudo systemctl enable ncn-verifier
-sudo systemctl start ncn-verifier
+sudo systemctl enable --now ncn-verifier
+journalctl -u ncn-verifier -f
 ```
-

--- a/ncn/verifier-service/DEPLOYMENT.md
+++ b/ncn/verifier-service/DEPLOYMENT.md
@@ -209,11 +209,13 @@ journalctl -u ncn-verifier -f
 
 # If running manually
 ./ncn-verifier 2>&1 | tee -a /var/log/ncn-verifier.log
+```
 
-Process Management
+### Process Management
 
 For production deployments, run the verifier service as a systemd unit:
 
+```ini
 [Unit]
 Description=NCN Verifier Service
 After=network.target
@@ -227,10 +229,12 @@ LimitNOFILE=65535
 
 [Install]
 WantedBy=multi-user.target
+```
 
 Enable and start:
 
+```bash
 sudo systemctl enable ncn-verifier
 sudo systemctl start ncn-verifier
-
+```
 


### PR DESCRIPTION
Closes #25

## Summary
The verifier service deployment docs explain setup but provide no guidance on monitoring, alerting, or crash recovery.

## Changes
- Documented the service's actual monitoring surfaces: /healthz, /version, /meta, and the token-gated /metrics endpoint (upload_total, proofs_not_found_total, free_storage_mb)
- Added an alerts table where every condition maps to an emitted signal, with notes that free_storage_mb is absolute MB and upload errors are cumulative counters (alert on deltas)
- Documented Docker logging and noted setup.sh's --restart unless-stopped as the default recovery path
- Scoped the systemd unit example to native-binary deployments, with the required EnvironmentFile for section-6 variables

Revised after review feedback to align all guidance with what src/metrics.rs and the deployment model actually support.