### PR TITLE
docs: add provider-agnostic requirements to DEPLOYMENT.md

### DIFF
--- a/ncn/verifier-service/DEPLOYMENT.md
+++ b/ncn/verifier-service/DEPLOYMENT.md
@@ -5,6 +5,26 @@ This guide walks an operator through provisioning an AWS EC2 instance and runnin
 [← Back to Project README](../README.md)
 [→ Verifier Service README](README.md)
 
+## General Requirements
+
+While this guide uses AWS as the reference deployment, the verifier service runs on any Linux server meeting these minimum requirements:
+
+| Requirement | Minimum | Recommended |
+|-------------|---------|-------------|
+| CPU | 2 cores | 4+ cores |
+| RAM | 4 GB | 8 GB |
+| Storage | 100 GB SSD | 200 GB NVMe |
+| Network | 100 Mbps | 1 Gbps |
+| OS | Ubuntu 22.04+ | Ubuntu 24.04 LTS |
+
+### Non-AWS Deployment Notes
+
+- **SSL/TLS:** If not using Cloudflare or AWS ALB, configure a reverse proxy (nginx or caddy) with [Let's Encrypt](https://letsencrypt.org/) for HTTPS termination
+- **DNS:** Point your verifier domain to your server's public IP via an A record
+- **Firewall:** Open ports 443 (HTTPS) and any custom ports for the verifier API. Restrict SSH (port 22) to known IPs
+- **Process management:** Use systemd for automatic restarts (see [Monitoring & Alerting](#monitoring--alerting) section)
+- **Bare metal / VPS providers:** Tested on Leaseweb, OVH, Hetzner, and Contabo. Any provider with the above specs will work
+
 ### Prerequisites
 
 - AWS account with permissions to create EC2 instances, Security Groups, and Elastic IPs

--- a/ncn/verifier-service/DEPLOYMENT.md
+++ b/ncn/verifier-service/DEPLOYMENT.md
@@ -24,7 +24,7 @@ The 40 GB minimum matches the AWS gp3 sizing in step 1; provision more headroom 
 - **SSL/TLS:** If not using Cloudflare or AWS ALB, configure a reverse proxy (nginx or caddy) with [Let's Encrypt](https://letsencrypt.org/) for HTTPS termination
 - **DNS:** Point your verifier domain to your server's public IP via an A record
 - **Firewall:** Open ports 80 (HTTP, required for Let's Encrypt HTTP-01 challenge and HTTP→HTTPS redirects) and 443 (HTTPS) and any custom ports for the verifier API. Restrict SSH (port 22) to known IPs
-- **Process management:** The recommended Docker deployment (`setup.sh`) already uses `--restart unless-stopped`, so Docker handles crash and reboot recovery. Only if you run the binary natively do you need a systemd unit — see [Process Management](#process-management) below for a working unit file
+- **Process management:** The recommended Docker deployment (`setup.sh`) already uses `--restart unless-stopped`, so Docker handles crash and reboot recovery. A systemd unit is only needed if you run the binary natively
 - **Bare metal / VPS providers:** Tested on Leaseweb. Any provider with the above specs will work
 
 ### Prerequisites

--- a/ncn/verifier-service/DEPLOYMENT.md
+++ b/ncn/verifier-service/DEPLOYMENT.md
@@ -17,14 +17,14 @@ While this guide uses AWS as the reference deployment, the verifier service runs
 | Network | 100 Mbps | 1 Gbps |
 | OS | Ubuntu 22.04+ | Ubuntu 24.04 LTS |
 
-The 40 GB minimum matches the AWS gp3 sizing in step 1; provision more headroom on providers without elastic volume expansion.
+The 40 GB minimum matches the AWS gp3 sizing in step 1; provision more headroom on providers without elastic volume expansion. Storage grows with the database and retained snapshot uploads: `governance.db` reaches a few GB over months of operation, and each uploaded MetaMerkleSnapshot is up to the `UPLOAD_BODY_LIMIT` (100 MB default). Monitor `storage.free_storage_mb` via `/admin/stats`.
 
 ### Non-AWS Deployment Notes
 
 - **SSL/TLS:** If not using Cloudflare or AWS ALB, configure a reverse proxy (nginx or caddy) with [Let's Encrypt](https://letsencrypt.org/) for HTTPS termination
 - **DNS:** Point your verifier domain to your server's public IP via an A record
 - **Firewall:** Open ports 80 (HTTP, required for Let's Encrypt HTTP-01 challenge and HTTP→HTTPS redirects) and 443 (HTTPS) and any custom ports for the verifier API. Restrict SSH (port 22) to known IPs
-- **Process management:** Run the service as a systemd unit with `Restart=on-failure` so it recovers automatically after crashes or reboots
+- **Process management:** The recommended Docker deployment (`setup.sh`) already uses `--restart unless-stopped`, so Docker handles crash and reboot recovery. Only if you run the binary natively do you need a systemd unit — see [Process Management](#process-management) below for a working unit file
 - **Bare metal / VPS providers:** Tested on Leaseweb. Any provider with the above specs will work
 
 ### Prerequisites

--- a/ncn/verifier-service/DEPLOYMENT.md
+++ b/ncn/verifier-service/DEPLOYMENT.md
@@ -21,7 +21,7 @@ While this guide uses AWS as the reference deployment, the verifier service runs
 
 - **SSL/TLS:** If not using Cloudflare or AWS ALB, configure a reverse proxy (nginx or caddy) with [Let's Encrypt](https://letsencrypt.org/) for HTTPS termination
 - **DNS:** Point your verifier domain to your server's public IP via an A record
-- **Firewall:** Open ports 443 (HTTPS) and any custom ports for the verifier API. Restrict SSH (port 22) to known IPs
+- **Firewall:** Open ports 80 (HTTP, required for Let's Encrypt HTTP-01 challenge and HTTP→HTTPS redirects) and 443 (HTTPS) and any custom ports for the verifier API. Restrict SSH (port 22) to known IPs
 - **Process management:** Run the service as a systemd unit with `Restart=on-failure` so it recovers automatically after crashes or reboots
 - **Bare metal / VPS providers:** Tested on Leaseweb. Any provider with the above specs will work
 

--- a/ncn/verifier-service/DEPLOYMENT.md
+++ b/ncn/verifier-service/DEPLOYMENT.md
@@ -13,9 +13,11 @@ While this guide uses AWS as the reference deployment, the verifier service runs
 |-------------|---------|-------------|
 | CPU | 2 cores | 4+ cores |
 | RAM | 4 GB | 8 GB |
-| Storage | 100 GB SSD | 200 GB NVMe |
+| Storage | 40 GB SSD | 100+ GB NVMe |
 | Network | 100 Mbps | 1 Gbps |
 | OS | Ubuntu 22.04+ | Ubuntu 24.04 LTS |
+
+The 40 GB minimum matches the AWS gp3 sizing in step 1; provision more headroom on providers without elastic volume expansion.
 
 ### Non-AWS Deployment Notes
 

--- a/ncn/verifier-service/DEPLOYMENT.md
+++ b/ncn/verifier-service/DEPLOYMENT.md
@@ -22,8 +22,8 @@ While this guide uses AWS as the reference deployment, the verifier service runs
 - **SSL/TLS:** If not using Cloudflare or AWS ALB, configure a reverse proxy (nginx or caddy) with [Let's Encrypt](https://letsencrypt.org/) for HTTPS termination
 - **DNS:** Point your verifier domain to your server's public IP via an A record
 - **Firewall:** Open ports 443 (HTTPS) and any custom ports for the verifier API. Restrict SSH (port 22) to known IPs
-- **Process management:** Use systemd for automatic restarts (see [Monitoring & Alerting](#monitoring--alerting) section)
-- **Bare metal / VPS providers:** Tested on Leaseweb, OVH, Hetzner, and Contabo. Any provider with the above specs will work
+- **Process management:** Run the service as a systemd unit with `Restart=on-failure` so it recovers automatically after crashes or reboots
+- **Bare metal / VPS providers:** Tested on Leaseweb. Any provider with the above specs will work
 
 ### Prerequisites
 


### PR DESCRIPTION
Closes #23

## Summary
DEPLOYMENT.md only covered AWS-based deployment. Operators using other providers (Leaseweb, OVH, Hetzner, bare metal) had no guidance on minimum requirements or alternative setup steps.

## Changes
- Added General Requirements section with minimum hardware specs table
- Added Non-AWS Deployment Notes covering SSL/TLS, DNS, firewall, and process management for non-AWS environments
- Placed above existing AWS-specific instructions so operators can assess compatibility before diving into provider-specific steps
- Follow-up commits from review: added port 80 to the firewall guidance (Let's Encrypt HTTP-01) and reconciled the storage minimum to 40 GB to match the AWS section

Fixes #23
