### PR TITLE
docs: add architecture diagram and glossary

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,95 @@
+# Architecture & Glossary
+
+This document provides a visual overview of how the Solana Governance System components connect, and defines key terminology.
+
+## System Architecture
+
+```mermaid
+graph TB
+    subgraph "On-Chain Programs"
+        SVMGOV["svmgov Program
+(proposals, voting, finalization)"]
+        NCN["NCN Snapshot Program
+(ballots, merkle verification, whitelisting)"]
+    end
+
+    subgraph "Operator Tools"
+        SVMCLI["svmgov CLI"]
+        NCNCLI["NCN CLI"]
+        VS["Verifier Service"]
+        ROUTER["NCN Router
+(cron-based automation)"]
+    end
+
+    subgraph "User Interfaces"
+        FE["Frontend / Web UI"]
+    end
+
+    subgraph "Data Flow"
+        RPC["Solana RPC"]
+    end
+
+    SVMCLI -->|"create proposal / cast vote / finalize"| SVMGOV
+    NCNCLI -->|"cast vote / verify proof"| NCN
+    VS -->|"process snapshot → upload merkle proof"| NCN
+    ROUTER -->|"automated ballot management"| NCN
+    FE -->|"read proposals, votes, quorum"| RPC
+    RPC -->|"on-chain state"| SVMGOV
+    RPC -->|"on-chain state"| NCN
+```
+
+## Component Overview
+
+### SVM Governance Track (`svmgov/`)
+
+The primary governance track for all Solana validators and stakers.
+
+| Component | Location | Purpose |
+|-----------|----------|---------|
+| **Program** | `svmgov/program/` | On-chain Anchor program — proposals, stake-weighted voting, vote overrides, finalization |
+| **CLI** | `svmgov/cli/` | Command-line interface for creating proposals, casting votes, and managing governance |
+| **Frontend** | `frontend/` | Web UI for browsing proposals, voting, and monitoring quorum progress |
+
+**Flow:** Validator/staker uses CLI or frontend → transaction hits svmgov program → on-chain state updates → frontend reads and displays results.
+
+### NCN Governance Track (`ncn/`)
+
+Governance for the Node Consensus Network — a subset of whitelisted operators.
+
+| Component | Location | Purpose |
+|-----------|----------|---------|
+| **Program** | `ncn/programs/ncn-snapshot/` | On-chain program — ballot boxes, merkle proof verification, operator whitelisting |
+| **CLI** | `ncn/cli/` | Command-line interface for casting NCN votes and verifying proofs |
+| **Verifier Service** | `ncn/verifier-service/` | Off-chain service that processes epoch snapshots and uploads merkle proofs on-chain |
+| **Router** | `ncn-router/` | Cron-based automation for ballot management and routing |
+
+**Flow:** Verifier service downloads epoch snapshot → generates merkle tree → uploads proof on-chain → operators vote via CLI → ballot finalized when quorum reached.
+
+## Data Flow
+
+1. **Epoch snapshot** — The verifier service fetches a snapshot of validator stake at a specific epoch
+2. **Merkle tree generation** — Snapshot data is hashed into a merkle tree, producing a root hash and per-validator proofs
+3. **On-chain upload** — The merkle root is uploaded to the NCN program as a verifiable commitment
+4. **Proof verification** — When a validator votes, their merkle proof is verified against the on-chain root to confirm their inclusion and stake weight
+5. **Vote aggregation** — Votes accumulate in a ballot box, weighted by stake
+6. **Finalization** — When quorum is reached, the proposal outcome is finalized on-chain
+
+## Glossary
+
+| Term | Definition |
+|------|-----------|
+| **Ballot** | A voting container for an NCN proposal, tracking cast votes by operator |
+| **Ballot Box** | On-chain account that aggregates all votes for a specific NCN ballot |
+| **Epoch** | A ~2-3 day period on Solana; governance snapshots are taken per-epoch |
+| **Finalization** | The process of locking a proposal outcome once quorum conditions are met |
+| **Merkle Proof** | Cryptographic proof verifying a validator's inclusion and stake weight in an epoch snapshot |
+| **Merkle Root** | The top-level hash of a merkle tree, stored on-chain as a verifiable commitment to snapshot data |
+| **NCN** | Node Consensus Network — a subset of whitelisted validators participating in merkle-proof governance |
+| **Operator Whitelist** | On-chain list of authorized NCN operators who can participate in ballot voting |
+| **Proposal** | A governance action submitted for validator/staker voting, with defined phases and quorum requirements |
+| **Quorum** | Minimum stake weight required for a proposal to pass or be finalized |
+| **Stake Weight** | A validator's voting power, determined by their active stake delegation |
+| **Support Phase** | Initial phase where validators signal support for a proposal before formal voting begins |
+| **SVM Governance** | The primary governance track using Solana's stake-weighted voting for all validators and stakers |
+| **Verifier Service** | Off-chain service that processes epoch snapshots and uploads merkle proofs to the NCN program |
+| **Vote Override** | Mechanism allowing stakers to override their delegated validator's vote on a proposal |

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -17,8 +17,11 @@ graph TB
         SVMCLI["svmgov CLI"]
         NCNCLI["NCN CLI"]
         VS["Verifier Service"]
+    end
+
+    subgraph "Foundation Services"
         ROUTER["NCN Router
-(cron-based automation)"]
+(validates and whitelists verifiers)"]
     end
 
     subgraph "User Interfaces"
@@ -33,8 +36,9 @@ graph TB
     NCNCLI -->|"cast vote / verify proof"| NCN
     NCNCLI -->|"generate snapshot + sign hash"| OP["Operator"]
     OP -->|"signed HTTP POST /upload"| VS
-    VS -->|"serve proofs to voters and UIs"| FE
-    ROUTER -->|"automated ballot management"| NCN
+    FE -->|"proof requests"| ROUTER
+    ROUTER -->|"redirects to a whitelisted verifier"| VS
+    VS -->|"serves proofs"| FE
     FE -->|"read proposals, votes, quorum"| RPC
     FE -->|"submit vote / support / override transactions"| SVMGOV
     RPC -->|"on-chain state"| SVMGOV
@@ -64,7 +68,7 @@ Governance for the Node Consensus Network — a subset of whitelisted operators.
 | **Program** | `ncn/programs/ncn-snapshot/` | On-chain program — ballot boxes, merkle proof verification, operator whitelisting |
 | **CLI** | `ncn/cli/` | Command-line interface for casting NCN votes and verifying proofs |
 | **Verifier Service** | `ncn/verifier-service/` | Off-chain service that indexes operator-uploaded snapshots and serves merkle proofs over HTTP. It does not write on-chain |
-| **Router** | `ncn-router/` | Cron-based automation for ballot management and routing |
+| **Router** | `ncn-router/` | Foundation-run service that validates and whitelists operators' verifier services and redirects proof requests to a healthy verifier |
 
 **Flow:** Each whitelisted operator independently generates a snapshot at the target slot → casts a vote for its merkle root via CLI → when enough operators agree, `finalize_ballot` writes the `ConsensusResult` on-chain → operators upload their snapshot to a verifier service, which serves proofs against the finalized root.
 
@@ -74,7 +78,7 @@ Governance for the Node Consensus Network — a subset of whitelisted operators.
 2. **Merkle tree** — Two-tier: a top-level tree over vote accounts, each leaf carrying a sub-root over that validator's stake accounts
 3. **Operator voting** — Each operator casts its merkle root and snapshot hash into the `BallotBox` via `cast_vote`. All whitelisted operators carry equal weight
 4. **Consensus** — Once `min_consensus_threshold_bps` of operators agree on the same ballot, `finalize_ballot` creates the on-chain `ConsensusResult`
-5. **Proof service** — Operators upload their snapshots to verifier services, which serve per-account proofs against the finalized root
+5. **Proof service** — Operators upload their snapshots to verifier services, which serve per-account proofs against the finalized root; the foundation-run NCN Router validates and whitelists these verifiers and redirects frontend proof requests to one of them
 6. **Verification** — `verify_merkle_proof` checks a vote-account or stake-account leaf against the `ConsensusResult` root, typically via CPI from the governance program
 
 ## Glossary
@@ -88,6 +92,7 @@ Governance for the Node Consensus Network — a subset of whitelisted operators.
 | **Merkle Proof** | Cryptographic proof verifying a validator's inclusion and stake weight in an epoch snapshot |
 | **Merkle Root** | The top-level hash of a merkle tree, stored on-chain as a verifiable commitment to snapshot data |
 | **NCN** | Node Consensus Network — a subset of whitelisted validators participating in merkle-proof governance |
+| **NCN Router** | Foundation-run service that validates and whitelists operators' verifier services and redirects proof requests to a whitelisted verifier |
 | **Operator Whitelist** | On-chain list of authorized NCN operators who can participate in ballot voting |
 | **Proposal** | A governance action submitted for validator/staker voting, with defined phases and quorum requirements |
 | **Quorum** | In `svmgov`, the stake-weighted threshold a proposal must reach. In NCN, `min_consensus_threshold_bps` — the share of whitelisted operators that must agree on a ballot |

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -31,7 +31,8 @@ graph TB
 
     SVMCLI -->|"create proposal / cast vote / finalize"| SVMGOV
     NCNCLI -->|"cast vote / verify proof"| NCN
-    NCNCLI -->|"generate snapshot → sign + upload"| VS
+    NCNCLI -->|"generate snapshot + sign hash"| OP["Operator"]
+    OP -->|"signed HTTP POST /upload"| VS
     VS -->|"serve proofs to voters and UIs"| FE
     ROUTER -->|"automated ballot management"| NCN
     FE -->|"read proposals, votes, quorum"| RPC

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -31,7 +31,8 @@ graph TB
 
     SVMCLI -->|"create proposal / cast vote / finalize"| SVMGOV
     NCNCLI -->|"cast vote / verify proof"| NCN
-    VS -->|"process snapshot → upload merkle proof"| NCN
+    NCNCLI -->|"generate snapshot → sign + upload"| VS
+    VS -->|"serve proofs to voters and UIs"| FE
     ROUTER -->|"automated ballot management"| NCN
     FE -->|"read proposals, votes, quorum"| RPC
     RPC -->|"on-chain state"| SVMGOV
@@ -60,19 +61,19 @@ Governance for the Node Consensus Network — a subset of whitelisted operators.
 |-----------|----------|---------|
 | **Program** | `ncn/programs/ncn-snapshot/` | On-chain program — ballot boxes, merkle proof verification, operator whitelisting |
 | **CLI** | `ncn/cli/` | Command-line interface for casting NCN votes and verifying proofs |
-| **Verifier Service** | `ncn/verifier-service/` | Off-chain service that processes epoch snapshots and uploads merkle proofs on-chain |
+| **Verifier Service** | `ncn/verifier-service/` | Off-chain service that indexes operator-uploaded snapshots and serves merkle proofs over HTTP. It does not write on-chain |
 | **Router** | `ncn-router/` | Cron-based automation for ballot management and routing |
 
-**Flow:** Verifier service downloads epoch snapshot → generates merkle tree → uploads proof on-chain → operators vote via CLI → ballot finalized when quorum reached.
+**Flow:** Each whitelisted operator independently generates a snapshot at the target slot → casts a vote for its merkle root via CLI → when enough operators agree, `finalize_ballot` writes the `ConsensusResult` on-chain → operators upload their snapshot to a verifier service, which serves proofs against the finalized root.
 
 ## Data Flow
 
-1. **Epoch snapshot** — The verifier service fetches a snapshot of validator stake at a specific epoch
-2. **Merkle tree generation** — Snapshot data is hashed into a merkle tree, producing a root hash and per-validator proofs
-3. **On-chain upload** — The merkle root is uploaded to the NCN program as a verifiable commitment
-4. **Proof verification** — When a validator votes, their merkle proof is verified against the on-chain root to confirm their inclusion and stake weight
-5. **Vote aggregation** — Votes accumulate in a ballot box, weighted by stake
-6. **Finalization** — When quorum is reached, the proposal outcome is finalized on-chain
+1. **Independent snapshot generation** — Each whitelisted operator replays the ledger to the target slot and builds its own MetaMerkleSnapshot
+2. **Merkle tree** — Two-tier: a top-level tree over vote accounts, each leaf carrying a sub-root over that validator's stake accounts
+3. **Operator voting** — Each operator casts its merkle root and snapshot hash into the `BallotBox` via `cast_vote`. All whitelisted operators carry equal weight
+4. **Consensus** — Once `min_consensus_threshold_bps` of operators agree on the same ballot, `finalize_ballot` creates the on-chain `ConsensusResult`
+5. **Proof service** — Operators upload their snapshots to verifier services, which serve per-account proofs against the finalized root
+6. **Verification** — `verify_merkle_proof` checks a vote-account or stake-account leaf against the `ConsensusResult` root, typically via CPI from the governance program
 
 ## Glossary
 
@@ -87,9 +88,9 @@ Governance for the Node Consensus Network — a subset of whitelisted operators.
 | **NCN** | Node Consensus Network — a subset of whitelisted validators participating in merkle-proof governance |
 | **Operator Whitelist** | On-chain list of authorized NCN operators who can participate in ballot voting |
 | **Proposal** | A governance action submitted for validator/staker voting, with defined phases and quorum requirements |
-| **Quorum** | Minimum stake weight required for a proposal to pass or be finalized |
+| **Quorum** | In `svmgov`, the stake-weighted threshold a proposal must reach. In NCN, `min_consensus_threshold_bps` — the share of whitelisted operators that must agree on a ballot |
 | **Stake Weight** | A validator's voting power, determined by their active stake delegation |
 | **Support Phase** | Initial phase where validators signal support for a proposal before formal voting begins |
 | **SVM Governance** | The primary governance track using Solana's stake-weighted voting for all validators and stakers |
-| **Verifier Service** | Off-chain service that processes epoch snapshots and uploads merkle proofs to the NCN program |
+| **Verifier Service** | Off-chain service that indexes operator-uploaded snapshots and serves merkle proofs over HTTP; it does not publish on-chain |
 | **Vote Override** | Mechanism allowing stakers to override their delegated validator's vote on a proposal |

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -35,6 +35,7 @@ graph TB
     VS -->|"serve proofs to voters and UIs"| FE
     ROUTER -->|"automated ballot management"| NCN
     FE -->|"read proposals, votes, quorum"| RPC
+    FE -->|"submit vote / support / override transactions"| SVMGOV
     RPC -->|"on-chain state"| SVMGOV
     RPC -->|"on-chain state"| NCN
 ```

--- a/README.md
+++ b/README.md
@@ -39,6 +39,10 @@ NCN (Node Consensus Network) governance program — on-chain ballot voting, merk
 ### [`docs/`](./docs)
 Documentation site built with Nextra covering validator and staker workflows.
 
+## Architecture
+
+For a visual overview of how components connect and a glossary of governance terms, see [ARCHITECTURE.md](./ARCHITECTURE.md).
+
 ## Contributing
 
 Issues and pull requests are welcome. See the [open issues](https://github.com/solana-foundation/solana-governance/issues) for areas that need work.


### PR DESCRIPTION
Closes #28

## Summary
New operators have no visual overview of how the governance system components connect. Understanding the system requires reading every individual README.

## Changes
- New `ARCHITECTURE.md` with:
  - Mermaid diagram showing component relationships (CLIs → programs, verifier → NCN, frontend → RPC)
  - Component overview tables for SVM and NCN governance tracks
  - End-to-end data flow walkthrough (epoch snapshot → merkle tree → on-chain upload → voting → finalization)
  - Glossary of 14 governance-specific terms
- Linked from root README

## Note
This PR and #30 both touch the end of README.md — whichever merges second will need a trivial rebase, which I'll push same-day.

Fixes #28