### PR TITLE
make the await message more clear

### DIFF
--- a/ncn/cli/src/main.rs
+++ b/ncn/cli/src/main.rs
@@ -865,7 +865,7 @@ fn main() -> Result<()> {
 
                 if !exists_ge {
                     info!(
-                        "Target slot {} not yet passed; sleeping for {} minutes...",
+                        "Incremental snapshot for target slot {} not yet found; sleeping for {} minutes...",
                         slot, scan_interval
                     );
                     thread::sleep(sleep_duration);


### PR DESCRIPTION
I was filing in for an engineer today and haven't kept up with all the changes. So when I saw the slot had passed in the cluster but the await command hadn't moved I thought something was wrong. Then looking at the source code I confirmed an assumption that it was waiting not for the slot to pass, but actually for an incremental snapshot with that slot. 

I've updated the await messaging to save the future me (and maybe others).