### PR TITLE
fix: add error context when reading keypair

### DIFF
--- a/ncn/cli/src/main.rs
+++ b/ncn/cli/src/main.rs
@@ -554,7 +554,12 @@ fn main() -> Result<()> {
         client.program(ncn_snapshot::id()).unwrap()
     }
 
-    fn cast_vote_shared(cli: Cli, snapshot_slot: u64, root: [u8; 32], hash: [u8; 32]) -> Result<()> {
+    fn cast_vote_shared(
+        cli: Cli,
+        snapshot_slot: u64,
+        root: [u8; 32],
+        hash: [u8; 32],
+    ) -> Result<()> {
         let payer = read_signer_keypair(&cli.payer_path, "--payer-path")
             .context("loading payer keypair")?;
         let authority = read_signer_keypair(&cli.authority_path, "--authority-path")
@@ -578,7 +583,10 @@ fn main() -> Result<()> {
         )?;
         info!("Transaction sent: {}", tx);
 
-        info!("== Voted For Ballot Box (snapshot_slot: {}) ==", snapshot_slot);
+        info!(
+            "== Voted For Ballot Box (snapshot_slot: {}) ==",
+            snapshot_slot
+        );
         info!("Merkle Root: {}", bs58::encode(root).into_string());
         info!("Snapshot Hash: {}", bs58::encode(hash).into_string());
 
@@ -616,18 +624,30 @@ fn main() -> Result<()> {
         println!("  Snapshot Slot: {}", ballot_box.snapshot_slot);
         println!("  Epoch: {}", ballot_box.epoch);
         println!("  Slot Created: {}", ballot_box.slot_created);
-        println!("  Slot Consensus Reached: {}", ballot_box.slot_consensus_reached);
+        println!(
+            "  Slot Consensus Reached: {}",
+            ballot_box.slot_consensus_reached
+        );
         println!(
             "  Min Consensus Threshold (bps): {}",
             ballot_box.min_consensus_threshold_bps
         );
-        println!("  Vote Expiry Timestamp: {}", ballot_box.vote_expiry_timestamp);
+        println!(
+            "  Vote Expiry Timestamp: {}",
+            ballot_box.vote_expiry_timestamp
+        );
         println!(
             "  Tie Breaker Consensus: {}",
             ballot_box.tie_breaker_consensus
         );
-        println!("  Total Operator Votes: {}", ballot_box.operator_votes.len());
-        println!("  Total Ballot Tallies: {}", ballot_box.ballot_tallies.len());
+        println!(
+            "  Total Operator Votes: {}",
+            ballot_box.operator_votes.len()
+        );
+        println!(
+            "  Total Ballot Tallies: {}",
+            ballot_box.ballot_tallies.len()
+        );
 
         let (winning_root, winning_hash) = format_ballot(&ballot_box.winning_ballot);
         println!("Winning Ballot");
@@ -675,18 +695,25 @@ fn main() -> Result<()> {
                     println!("{:?}", data);
                 }
                 LogType::BallotBox => {
-                    let data: BallotBox =
-                        program.account(BallotBox::pda(snapshot_slot.expect("Missing --snapshot-slot argument")).0)?;
+                    let data: BallotBox = program.account(
+                        BallotBox::pda(snapshot_slot.expect("Missing --snapshot-slot argument")).0,
+                    )?;
                     println!("{:?}", data);
                 }
                 LogType::ConsensusResult => {
-                    let data: ConsensusResult = program
-                        .account(ConsensusResult::pda(snapshot_slot.expect("Missing --snapshot-slot argument")).0)?;
+                    let data: ConsensusResult = program.account(
+                        ConsensusResult::pda(
+                            snapshot_slot.expect("Missing --snapshot-slot argument"),
+                        )
+                        .0,
+                    )?;
                     println!("{:?}", data);
                 }
                 LogType::MetaMerkleProof => {
-                    let consensus_result_pda =
-                        ConsensusResult::pda(snapshot_slot.expect("Missing --snapshot-slot argument")).0;
+                    let consensus_result_pda = ConsensusResult::pda(
+                        snapshot_slot.expect("Missing --snapshot-slot argument"),
+                    )
+                    .0;
                     let data: MetaMerkleProof = program.account(
                         MetaMerkleProof::pda(
                             &consensus_result_pda,
@@ -781,7 +808,11 @@ fn main() -> Result<()> {
             let tx = send_finalize_proposed_authority(tx_sender)?;
             info!("Transaction sent: {}", tx);
         }
-        Commands::CastVote { snapshot_slot, root, hash } => cast_vote_shared(cli, snapshot_slot, root, hash)?,
+        Commands::CastVote {
+            snapshot_slot,
+            root,
+            hash,
+        } => cast_vote_shared(cli, snapshot_slot, root, hash)?,
         Commands::CastVoteFromSnapshot {
             snapshot_slot,
             ref read_path,
@@ -813,7 +844,11 @@ fn main() -> Result<()> {
             let tx = send_remove_vote(tx_sender, ballot_box_pda)?;
             info!("Transaction sent: {}", tx);
         }
-        Commands::SetTieBreaker { snapshot_slot, root, hash } => {
+        Commands::SetTieBreaker {
+            snapshot_slot,
+            root,
+            hash,
+        } => {
             info!("SetTieBreaker...");
 
             let payer = read_signer_keypair(&cli.payer_path, "--payer-path")
@@ -1008,7 +1043,10 @@ fn main() -> Result<()> {
                     println!("Consensus Result");
                     println!("  PDA: {}", consensus_pda);
                     println!("  Exists: true");
-                    println!("  Tie Breaker Consensus: {}", consensus.tie_breaker_consensus);
+                    println!(
+                        "  Tie Breaker Consensus: {}",
+                        consensus.tie_breaker_consensus
+                    );
                     println!("  Meta Merkle Root (base58): {}", root);
                     println!("  Snapshot Hash (base58): {}", hash);
                 }

--- a/ncn/cli/src/main.rs
+++ b/ncn/cli/src/main.rs
@@ -17,36 +17,96 @@ use tip_router_operator_cli::{
 };
 use tokio::runtime::Builder;
 
+/// Solana Governance Voter Snapshot CLI.
+///
+/// Operator-facing tool for generating stake snapshots (ledger snapshot ->
+/// MetaMerkleSnapshot) and interacting with the on-chain `ncn-snapshot`
+/// program (initializing config, managing the operator whitelist, casting and
+/// removing votes, finalizing ballots, setting tie-breakers, and inspecting
+/// on-chain state).
 #[derive(Clone, Parser)]
-#[command(author, version, about)]
+#[command(author, version, about, long_about = None)]
 struct Cli {
+    /// Path to the keypair file that pays transaction fees and rent.
+    ///
+    /// This signer is used as the fee payer for all on-chain instructions
+    /// issued by this CLI. It does not need to match the program authority
+    /// or operator authority.
     #[arg(short, long, env, default_value = "/")]
     pub payer_path: PathBuf,
 
+    /// Path to the keypair file that signs privileged actions.
+    ///
+    /// Only consulted by subcommands that submit on-chain transactions or
+    /// sign messages off-chain. The role this keypair plays is documented
+    /// in the description of each such subcommand
+    /// (see `<subcommand> --help`). Read-only and snapshot-only
+    /// subcommands ignore this flag. The default `/` is a placeholder and
+    /// must be overridden whenever the chosen subcommand actually needs to
+    /// sign.
     #[arg(short, long, env, default_value = "/")]
     pub authority_path: PathBuf,
 
+    /// Operator pubkey (base58) used to tag generated snapshots.
+    ///
+    /// Stamped into the snapshot metadata so downstream tooling can
+    /// attribute a snapshot to a specific operator. Defaults to the system
+    /// program address as a placeholder when not provided.
     #[arg(short, long, env, default_value = "11111111111111111111111111111111")]
     pub operator_address: String,
 
+    /// Solana JSON-RPC endpoint used for all on-chain interactions.
+    ///
+    /// Example: `https://api.mainnet-beta.solana.com`,
+    /// `https://api.devnet.solana.com`, or a local validator URL.
     #[arg(short, long, env, default_value = "http://localhost:8899")]
     pub rpc_url: String,
 
+    /// Path to a Solana validator ledger directory.
+    ///
+    /// Required by snapshot-related subcommands (`snapshot-slot`,
+    /// `generate-meta-merkle`, `await-snapshot`). This should point at the
+    /// validator's `--ledger` directory containing rocksdb and snapshots.
     #[arg(short, long, env)]
     pub ledger_path: Option<PathBuf>,
 
+    /// Directory containing full Solana ledger snapshots
+    /// (`snapshot-<slot>-<hash>.tar.zst`).
+    ///
+    /// Defaults to `--ledger-path` when not provided. Used by
+    /// `snapshot-slot` to locate the base full snapshot to replay from.
     #[arg(short, long, env)]
     pub full_snapshots_path: Option<PathBuf>,
 
+    /// One or more accounts-db directories used during ledger replay.
+    ///
+    /// Pass a comma-separated list to spread accounts across multiple
+    /// disks. When omitted, the ledger directory is used as the single
+    /// accounts path.
     #[arg(long, env)]
     pub account_paths: Option<Vec<PathBuf>>,
 
+    /// Directory where generated snapshots (full + incremental) are written
+    /// and read.
+    ///
+    /// `snapshot-slot` writes new snapshots here, and `generate-meta-merkle`
+    /// expects to find the snapshot for the target slot in this directory.
     #[arg(short, long, env)]
     pub backup_snapshots_dir: Option<PathBuf>,
 
+    /// Solana cluster name passed through to bank loading.
+    ///
+    /// One of: `mainnet`, `devnet`, `testnet`, `development`. Affects
+    /// cluster-specific feature activation during ledger replay.
     #[arg(long, env, default_value = "mainnet")]
     pub cluster: String,
 
+    /// Optional priority fee (in micro-lamports per compute unit) attached
+    /// to outgoing transactions.
+    ///
+    /// When set, a `ComputeBudgetInstruction::SetComputeUnitPrice` is
+    /// prepended to each transaction. Useful for landing transactions
+    /// during periods of congestion.
     #[arg(long, env)]
     pub micro_lamports: Option<u64>,
 
@@ -74,156 +134,404 @@ impl Cli {
 
 #[derive(clap::Subcommand, Clone)]
 pub enum Commands {
+    /// Generate a Solana ledger snapshot for a specific target slot.
+    ///
+    /// Replays the validator bank up to `--slot` and writes a full snapshot
+    /// into `--backup-snapshots-dir`. Requires `--ledger-path` and
+    /// `--full-snapshots-path` (or defaults derived from `--ledger-path`).
     SnapshotSlot {
-        #[arg(long, env)]
+        /// Target slot to snapshot. Must be a slot that has already been
+        /// rooted in the ledger.
+        #[arg(long, env, help = "Target slot to snapshot")]
         slot: u64,
     },
+    /// Build a MetaMerkleSnapshot from an existing full ledger snapshot.
+    ///
+    /// Loads the bank at `--slot` from `--backup-snapshots-dir` and emits a
+    /// compressed `meta_merkle-<slot>.zip` containing the stake-weighted
+    /// merkle tree used for on-chain voting.
     GenerateMetaMerkle {
-        #[arg(long, env)]
+        /// Target slot. A full snapshot for this exact slot must already
+        /// exist in `--backup-snapshots-dir`.
+        #[arg(long, env, help = "Target slot for the MetaMerkleSnapshot")]
         slot: u64,
 
+        /// Directory in which `meta_merkle-<slot>.zip` will be written.
         #[arg(
             long,
             env,
             default_value = "./",
-            help = "Path to save meta merkle tree"
+            help = "Directory to write the compressed MetaMerkleSnapshot to"
         )]
         save_path: PathBuf,
     },
+    /// Print the merkle root, snapshot hash, and a signature over them from a
+    /// MetaMerkleSnapshot file.
+    ///
+    /// Useful for sharing the snapshot identity with other operators before
+    /// voting on-chain. `--authority-path` signs an off-chain message
+    /// containing the snapshot slot and meta merkle root; no on-chain
+    /// transaction is sent.
     LogMetaMerkleHash {
-        #[arg(long, env, help = "Path to read meta merkle tree")]
+        /// Path to a MetaMerkleSnapshot file (compressed `.zip` or raw).
+        #[arg(long, env, help = "Path to the MetaMerkleSnapshot file to read")]
         read_path: PathBuf,
 
-        #[arg(long, default_value = "true")]
+        /// Whether the input file is the compressed `.zip` produced by
+        /// `generate-meta-merkle`.
+        #[arg(
+            long,
+            default_value = "true",
+            help = "Set to true when `--read-path` points to a compressed `.zip`"
+        )]
         is_compressed: bool,
     },
+    /// Wait for a target slot to pass and snapshot it from on-disk snapshots.
+    ///
+    /// Polls `--snapshots-dir` until a full + incremental snapshot pair
+    /// covering `--slot` is available, copies them and the relevant ledger
+    /// range into the backup directories, replays to produce a snapshot at
+    /// `--slot`, and optionally generates the MetaMerkleSnapshot.
     AwaitSnapshot {
-        #[arg(long, help = "Scan interval in minutes")]
+        /// Polling interval, in minutes, between directory scans.
+        #[arg(
+            long,
+            help = "Polling interval (in minutes) between snapshot directory scans"
+        )]
         scan_interval: u64,
 
-        #[arg(long, help = "Target slot to snapshot")]
+        /// Target slot to snapshot once it has been rooted.
+        #[arg(long, help = "Target slot to snapshot once it has been rooted")]
         slot: u64,
 
-        #[arg(long, help = "Directory to scan for snapshots")]
+        /// Directory to scan for live validator snapshots.
+        #[arg(long, help = "Directory to scan for live validator snapshots")]
         snapshots_dir: PathBuf,
 
-        #[arg(long, help = "Directory to copy matching snapshots to")]
+        /// Directory into which the matching full + incremental snapshots
+        /// are copied and the new snapshot at `--slot` is written.
+        #[arg(
+            long,
+            help = "Directory to copy matching snapshots into and write the new snapshot to"
+        )]
         backup_snapshots_dir: PathBuf,
 
-        #[arg(long, help = "Directory to copy ledger range to")]
+        /// Directory into which the relevant ledger range is copied via
+        /// `agave-ledger-tool`.
+        #[arg(
+            long,
+            help = "Directory to copy the ledger range required for replay into"
+        )]
         backup_ledger_dir: PathBuf,
 
-        #[arg(long, help = "Path to agave-ledger-tool binary")]
+        /// Absolute path to the `agave-ledger-tool` binary used to copy the
+        /// ledger range.
+        #[arg(long, help = "Absolute path to the `agave-ledger-tool` binary")]
         agave_ledger_tool_path: PathBuf,
 
-        #[arg(long, help = "Path to live ledger directory (-l)")]
+        /// Path to the live validator ledger directory
+        /// (the same path passed to the validator's `-l`/`--ledger` flag).
+        #[arg(
+            long,
+            help = "Path to the live validator ledger directory (validator's `-l`)"
+        )]
         ledger_path: PathBuf,
 
-        #[arg(long, help = "Generate MetaMerkleSnapshot after snapshot")]
+        /// When set, also generate the MetaMerkleSnapshot after the full
+        /// snapshot at `--slot` has been written.
+        #[arg(
+            long,
+            help = "Also generate the MetaMerkleSnapshot after taking the snapshot"
+        )]
         generate_meta_merkle: bool,
     },
+    /// Initialize the on-chain `ProgramConfig` singleton.
+    ///
+    /// Must be run once per deployment. The signer of `--authority-path`
+    /// becomes the initial program authority and is recorded as
+    /// `ProgramConfig.authority`.
     InitProgramConfig {},
+    /// Add or remove operator pubkeys from the on-chain whitelist.
+    ///
+    /// Only whitelisted operators are allowed to cast votes.
+    /// `--authority-path` must be the current program authority (enforced
+    /// by `has_one = authority` on `ProgramConfig`).
     UpdateOperatorWhitelist {
-        #[arg(short, long, value_delimiter = ',', value_parser = parse_pubkey)]
+        /// Comma-separated operator pubkeys (base58) to add to the whitelist.
+        #[arg(
+            short,
+            long,
+            value_delimiter = ',',
+            value_parser = parse_pubkey,
+            help = "Comma-separated operator pubkeys (base58) to add to the whitelist"
+        )]
         add: Option<Vec<Pubkey>>,
 
-        #[arg(short, long, value_delimiter = ',', value_parser = parse_pubkey)]
+        /// Comma-separated operator pubkeys (base58) to remove from the
+        /// whitelist.
+        #[arg(
+            short,
+            long,
+            value_delimiter = ',',
+            value_parser = parse_pubkey,
+            help = "Comma-separated operator pubkeys (base58) to remove from the whitelist"
+        )]
         remove: Option<Vec<Pubkey>>,
     },
+    /// Update mutable fields on the on-chain `ProgramConfig`.
+    ///
+    /// All arguments are optional; only the provided fields are updated.
+    /// `--authority-path` must be the current program authority (enforced
+    /// by `has_one = authority` on `ProgramConfig`). Updating
+    /// `--proposed-authority` starts a two-step authority handover that
+    /// must be completed via `finalize-proposed-authority`.
     UpdateProgramConfig {
-        #[arg(long, env)]
+        /// Proposed new program authority (base58). Becomes active only
+        /// after `finalize-proposed-authority` is run by this pubkey.
+        #[arg(
+            long,
+            env,
+            help = "Proposed new program authority (base58); activated via `finalize-proposed-authority`"
+        )]
         proposed_authority: Option<Pubkey>,
 
-        #[arg(long)]
+        /// Minimum stake-weighted consensus threshold, expressed in basis
+        /// points (10000 = 100%). Example: `6000` for 60%.
+        #[arg(
+            long,
+            help = "Minimum consensus threshold in basis points (e.g. 6000 for 60%)"
+        )]
         min_consensus_threshold_bps: Option<u16>,
 
-        #[arg(long, value_parser = parse_pubkey)]
+        /// New tie-breaker admin pubkey (base58). This admin can resolve a
+        /// stalled ballot box via `set-tie-breaker`.
+        #[arg(
+            long,
+            value_parser = parse_pubkey,
+            help = "New tie-breaker admin pubkey (base58)"
+        )]
         tie_breaker_admin: Option<Pubkey>,
 
-        #[arg(long)]
+        /// Vote duration in seconds. Operators have this long after a
+        /// ballot box is created to cast votes.
+        #[arg(long, help = "Voting window duration, in seconds")]
         vote_duration: Option<i64>,
     },
+    /// Complete a pending two-step authority handover.
+    ///
+    /// `--authority-path` must be the *proposed* authority previously
+    /// staged via `update-program-config --proposed-authority`; the
+    /// on-chain constraint requires `signer == proposed_authority`. On
+    /// success the signer becomes the active program authority and
+    /// `proposed_authority` is cleared.
     FinalizeProposedAuthority {},
+    /// Finalize the winning ballot for a snapshot slot.
+    ///
+    /// Closes voting for `--snapshot-slot` once consensus has been reached
+    /// (or the vote window has expired with a clear winner) and writes the
+    /// `ConsensusResult` PDA. The on-chain instruction is permissionless,
+    /// so `--authority-path` is used purely as the fee payer for the new
+    /// PDA and does not need to hold any privileged role.
     FinalizeBallot {
-        #[arg(long, help = "Snapshot slot of ballot box")]
+        /// Snapshot slot identifying the ballot box to finalize.
+        #[arg(long, help = "Snapshot slot identifying the ballot box to finalize")]
         snapshot_slot: u64,
     },
+    /// Print the on-chain `BallotBox` for a snapshot slot.
     GetBallot {
-        #[arg(long, help = "Snapshot slot of ballot box")]
+        /// Snapshot slot identifying the ballot box to fetch.
+        #[arg(long, help = "Snapshot slot identifying the ballot box to fetch")]
         snapshot_slot: u64,
     },
+    /// Print the on-chain `ProgramConfig` singleton.
     GetProgramConfig {},
+    /// Print the operator whitelist from `ProgramConfig`.
     GetOperatorWhitelist {},
+    /// Print a single operator's vote within a ballot box.
     GetOperatorVote {
-        #[arg(long, help = "Snapshot slot of ballot box")]
+        /// Snapshot slot identifying the ballot box.
+        #[arg(long, help = "Snapshot slot identifying the ballot box")]
         snapshot_slot: u64,
-        #[arg(long, value_parser = parse_pubkey, help = "Operator pubkey")]
+        /// Operator pubkey (base58) whose vote should be looked up.
+        #[arg(
+            long,
+            value_parser = parse_pubkey,
+            help = "Operator pubkey (base58) whose vote should be looked up"
+        )]
         operator: Pubkey,
     },
+    /// Print the `ConsensusResult` PDA for a snapshot slot.
     GetConsensusResult {
-        #[arg(long, help = "Snapshot slot for consensus result")]
+        /// Snapshot slot identifying the consensus result to fetch.
+        #[arg(long, help = "Snapshot slot identifying the consensus result to fetch")]
         snapshot_slot: u64,
     },
+    /// Print the `MetaMerkleProof` PDA for a vote account.
     GetProof {
-        #[arg(long, help = "Snapshot slot for consensus result")]
+        /// Snapshot slot identifying the consensus result the proof belongs
+        /// to.
+        #[arg(
+            long,
+            help = "Snapshot slot identifying the consensus result the proof belongs to"
+        )]
         snapshot_slot: u64,
-        #[arg(long, value_parser = parse_pubkey, help = "Validator vote account")]
+        /// Validator vote account (base58) whose proof should be fetched.
+        #[arg(
+            long,
+            value_parser = parse_pubkey,
+            help = "Validator vote account (base58) whose proof should be fetched"
+        )]
         vote_account: Pubkey,
     },
+    /// Check whether a ballot box exists for a snapshot slot.
     BallotExists {
-        #[arg(long, help = "Snapshot slot of ballot box")]
+        /// Snapshot slot to check for a `BallotBox` PDA.
+        #[arg(long, help = "Snapshot slot to check for a `BallotBox` PDA")]
         snapshot_slot: u64,
     },
+    /// Print a combined status report: program config, ballot box, and
+    /// consensus result for a snapshot slot.
     Status {
-        #[arg(long, help = "Snapshot slot of ballot box")]
+        /// Snapshot slot to summarize.
+        #[arg(long, help = "Snapshot slot to summarize")]
         snapshot_slot: u64,
     },
+    /// Cast a vote on a ballot box using an explicit root + hash.
+    ///
+    /// Prefer `cast-vote-from-snapshot` when voting from a local snapshot.
+    /// `--authority-path` signs as a whitelisted operator; the handler
+    /// verifies the signer appears in
+    /// `ProgramConfig.whitelisted_operators` before recording the vote in
+    /// the `BallotBox`.
     CastVote {
-        #[arg(long, help = "Snapshot slot of ballot box")]
+        /// Snapshot slot identifying the ballot box to vote in.
+        #[arg(long, help = "Snapshot slot identifying the ballot box to vote in")]
         snapshot_slot: u64,
 
-        #[arg(long, value_parser = parse_base_58_32, help = "Meta merkle tree root, base-58 encoded.")]
+        /// Meta merkle tree root, base-58 encoded (32 bytes).
+        #[arg(
+            long,
+            value_parser = parse_base_58_32,
+            help = "Meta merkle tree root, base-58 encoded (32 bytes)"
+        )]
         root: [u8; 32],
 
-        #[arg(long, value_parser = parse_base_58_32, help = "SHA256 hash of the meta merkle snapshot, base-58 encoded.")]
+        /// SHA-256 hash of the MetaMerkleSnapshot file, base-58 encoded
+        /// (32 bytes).
+        #[arg(
+            long,
+            value_parser = parse_base_58_32,
+            help = "SHA-256 hash of the MetaMerkleSnapshot file, base-58 encoded (32 bytes)"
+        )]
         hash: [u8; 32],
     },
+    /// Cast a vote on a ballot box using a local MetaMerkleSnapshot file.
+    ///
+    /// Reads the root and computes the snapshot hash from `--read-path`,
+    /// then submits the vote. `--authority-path` signs as a whitelisted
+    /// operator; the handler verifies the signer appears in
+    /// `ProgramConfig.whitelisted_operators` before recording the vote in
+    /// the `BallotBox`.
     CastVoteFromSnapshot {
-        #[arg(long, help = "Snapshot slot of ballot box")]
+        /// Snapshot slot identifying the ballot box to vote in.
+        #[arg(long, help = "Snapshot slot identifying the ballot box to vote in")]
         snapshot_slot: u64,
 
-        #[arg(long, env, help = "Path to read meta merkle tree")]
+        /// Path to a MetaMerkleSnapshot file (compressed `.zip` or raw)
+        /// produced by `generate-meta-merkle`.
+        #[arg(long, env, help = "Path to the MetaMerkleSnapshot file to vote with")]
         read_path: PathBuf,
 
-        #[arg(long, default_value = "true")]
+        /// Whether the input file is the compressed `.zip` produced by
+        /// `generate-meta-merkle`.
+        #[arg(
+            long,
+            default_value = "true",
+            help = "Set to true when `--read-path` points to a compressed `.zip`"
+        )]
         is_compressed: bool,
     },
+    /// Remove the caller's vote from a ballot box.
+    ///
+    /// Only permitted before consensus is reached and before the vote
+    /// window expires. `--authority-path` must be the operator that
+    /// originally cast the vote; the handler removes only that signer's
+    /// tally entry.
     RemoveVote {
-        #[arg(long, help = "Snapshot slot of ballot box")]
+        /// Snapshot slot identifying the ballot box to remove the vote from.
+        #[arg(
+            long,
+            help = "Snapshot slot identifying the ballot box to remove the vote from"
+        )]
         snapshot_slot: u64,
     },
+    /// Resolve a stalled ballot by writing an explicit winning ballot.
+    ///
+    /// The provided `--root` / `--hash` are not required to match any cast
+    /// ballot. `--authority-path` must be the tie-breaker admin recorded
+    /// in `ProgramConfig` (enforced by `has_one = tie_breaker_admin`).
     SetTieBreaker {
-        #[arg(long, help = "Snapshot slot of ballot box")]
+        /// Snapshot slot identifying the ballot box to tie-break.
+        #[arg(long, help = "Snapshot slot identifying the ballot box to tie-break")]
         snapshot_slot: u64,
 
-        #[arg(long, value_parser = parse_base_58_32, help = "Meta merkle tree root, base-58 encoded.")]
+        /// Meta merkle tree root, base-58 encoded (32 bytes).
+        #[arg(
+            long,
+            value_parser = parse_base_58_32,
+            help = "Tie-breaking meta merkle tree root, base-58 encoded (32 bytes)"
+        )]
         root: [u8; 32],
 
-        #[arg(long, value_parser = parse_base_58_32, help = "SHA256 hash of the meta merkle snapshot, base-58 encoded.")]
+        /// SHA-256 hash of the corresponding MetaMerkleSnapshot, base-58
+        /// encoded (32 bytes).
+        #[arg(
+            long,
+            value_parser = parse_base_58_32,
+            help = "Tie-breaking snapshot hash (SHA-256), base-58 encoded (32 bytes)"
+        )]
         hash: [u8; 32],
     },
+    /// Reset a bricked ballot box.
+    ///
+    /// Permitted only when the ballot box's vote window has not yet
+    /// expired, consensus has not been reached, and ballot tallies are at
+    /// their maximum capacity. Clears tallies so voting can restart.
+    /// `--authority-path` must be the tie-breaker admin recorded in
+    /// `ProgramConfig` (enforced by `has_one = tie_breaker_admin`).
     ResetBallotBox {
-        #[arg(long, help = "Snapshot slot of ballot box")]
+        /// Snapshot slot identifying the ballot box to reset.
+        #[arg(long, help = "Snapshot slot identifying the ballot box to reset")]
         snapshot_slot: u64,
     },
+    /// Dump the raw `Debug` representation of an on-chain account.
+    ///
+    /// Selects the account type via `--ty`; some types require additional
+    /// arguments such as `--snapshot-slot` and/or `--vote-account`.
     Log {
-        #[arg(long, help = "Snapshot slot of ballot box or consensus result")]
+        /// Snapshot slot identifying the ballot box, consensus result, or
+        /// proof to fetch. Required for every `--ty` except
+        /// `program-config`.
+        #[arg(
+            long,
+            help = "Snapshot slot of the ballot box, consensus result, or proof (required for all `--ty` except `program-config`)"
+        )]
         snapshot_slot: Option<u64>,
 
-        #[arg(long, value_parser = parse_pubkey)]
+        /// Validator vote account (base58). Required when `--ty proof`.
+        #[arg(
+            long,
+            value_parser = parse_pubkey,
+            help = "Validator vote account (base58); required when `--ty proof`"
+        )]
         vote_account: Option<Pubkey>,
 
-        #[arg(long, value_parser = parse_log_type, help = "Account type: program-config | ballot-box | consensus-result | proof")]
+        /// Account type to dump.
+        #[arg(
+            long,
+            value_parser = parse_log_type,
+            help = "Account type to dump: `program-config` | `ballot-box` | `consensus-result` | `proof`"
+        )]
         ty: LogType,
     },
 }

--- a/ncn/cli/src/main.rs
+++ b/ncn/cli/src/main.rs
@@ -252,7 +252,7 @@ fn main() -> Result<()> {
     }
 
     fn cast_vote_shared(cli: Cli, snapshot_slot: u64, root: [u8; 32], hash: [u8; 32]) -> Result<()> {
-        let payer = read_keypair_file(&cli.authority_path).map_err(|err| anyhow!("Failed to read payer keypair at {}: {}", cli.payer_path, err))?;
+        let payer = read_keypair_file(&cli.payer_path).map_err(|err| anyhow!("Failed to read payer keypair at {}: {}", cli.payer_path, err))?;
         let authority = read_keypair_file(&cli.authority_path).map_err(|err| anyhow!("Failed to read authority keypair at {}: {}", cli.authority_path, err))?;
         let program = load_client_program(&payer, cli.rpc_url);
 
@@ -396,7 +396,7 @@ fn main() -> Result<()> {
         Commands::InitProgramConfig {} => {
             info!("InitProgramConfig...");
 
-            let payer = read_keypair_file(&cli.authority_path).map_err(|err| anyhow!("Failed to read payer keypair at {}: {}", cli.payer_path, err))?;
+            let payer = read_keypair_file(&cli.payer_path).map_err(|err| anyhow!("Failed to read payer keypair at {}: {}", cli.payer_path, err))?;
             let authority = read_keypair_file(&cli.authority_path).map_err(|err| anyhow!("Failed to read authority keypair at {}: {}", cli.authority_path, err))?;
             let program = load_client_program(&payer, cli.rpc_url);
 
@@ -412,7 +412,7 @@ fn main() -> Result<()> {
         Commands::UpdateOperatorWhitelist { add, remove } => {
             info!("UpdateOperatorWhitelist...");
 
-            let payer = read_keypair_file(&cli.authority_path).map_err(|err| anyhow!("Failed to read payer keypair at {}: {}", cli.payer_path, err))?;
+            let payer = read_keypair_file(&cli.payer_path).map_err(|err| anyhow!("Failed to read payer keypair at {}: {}", cli.payer_path, err))?;
             let authority = read_keypair_file(&cli.authority_path).map_err(|err| anyhow!("Failed to read authority keypair at {}: {}", cli.authority_path, err))?;
             let program = load_client_program(&payer, cli.rpc_url);
 
@@ -433,7 +433,7 @@ fn main() -> Result<()> {
         } => {
             info!("UpdateProgramConfig...");
 
-            let payer = read_keypair_file(&cli.authority_path).map_err(|err| anyhow!("Failed to read payer keypair at {}: {}", cli.payer_path, err))?;
+            let payer = read_keypair_file(&cli.payer_path).map_err(|err| anyhow!("Failed to read payer keypair at {}: {}", cli.payer_path, err))?;
             let authority = read_keypair_file(&cli.authority_path).map_err(|err| anyhow!("Failed to read authority keypair at {}: {}", cli.authority_path, err))?;
             let program = load_client_program(&payer, cli.rpc_url);
 
@@ -455,7 +455,7 @@ fn main() -> Result<()> {
         Commands::FinalizeProposedAuthority {} => {
             info!("FinalizeProposedAuthority...");
 
-            let payer = read_keypair_file(&cli.authority_path).map_err(|err| anyhow!("Failed to read payer keypair at {}: {}", cli.payer_path, err))?;
+            let payer = read_keypair_file(&cli.payer_path).map_err(|err| anyhow!("Failed to read payer keypair at {}: {}", cli.payer_path, err))?;
             let authority = read_keypair_file(&cli.authority_path).map_err(|err| anyhow!("Failed to read authority keypair at {}: {}", cli.authority_path, err))?;
             let program = load_client_program(&payer, cli.rpc_url);
 
@@ -484,7 +484,7 @@ fn main() -> Result<()> {
         Commands::RemoveVote { snapshot_slot } => {
             info!("RemoveVote...");
 
-            let payer = read_keypair_file(&cli.authority_path).map_err(|err| anyhow!("Failed to read payer keypair at {}: {}", cli.payer_path, err))?;
+            let payer = read_keypair_file(&cli.payer_path).map_err(|err| anyhow!("Failed to read payer keypair at {}: {}", cli.payer_path, err))?;
             let authority = read_keypair_file(&cli.authority_path).map_err(|err| anyhow!("Failed to read authority keypair at {}: {}", cli.authority_path, err))?;
             let program = load_client_program(&payer, cli.rpc_url);
 
@@ -501,7 +501,7 @@ fn main() -> Result<()> {
         Commands::SetTieBreaker { snapshot_slot, root, hash } => {
             info!("SetTieBreaker...");
 
-            let payer = read_keypair_file(&cli.authority_path).map_err(|err| anyhow!("Failed to read payer keypair at {}: {}", cli.payer_path, err))?;
+            let payer = read_keypair_file(&cli.payer_path).map_err(|err| anyhow!("Failed to read payer keypair at {}: {}", cli.payer_path, err))?;
             let authority = read_keypair_file(&cli.authority_path).map_err(|err| anyhow!("Failed to read authority keypair at {}: {}", cli.authority_path, err))?;
             let program = load_client_program(&payer, cli.rpc_url);
             let ballot_box_pda = BallotBox::pda(snapshot_slot).0;
@@ -539,7 +539,7 @@ fn main() -> Result<()> {
         Commands::FinalizeBallot { snapshot_slot } => {
             info!("FinalizeBallot...");
 
-            let payer = read_keypair_file(&cli.authority_path).map_err(|err| anyhow!("Failed to read payer keypair at {}: {}", cli.payer_path, err))?;
+            let payer = read_keypair_file(&cli.payer_path).map_err(|err| anyhow!("Failed to read payer keypair at {}: {}", cli.payer_path, err))?;
             let program = load_client_program(&payer, cli.rpc_url);
 
             let ballot_box_pda = BallotBox::pda(snapshot_slot).0;

--- a/ncn/cli/src/main.rs
+++ b/ncn/cli/src/main.rs
@@ -1,18 +1,13 @@
+use anchor_client::solana_sdk::signature::Signer;
 use anchor_client::{
-    solana_sdk::{
-        bs58,
-        commitment_config::CommitmentConfig,
-        pubkey::Pubkey,
-        signature::{read_keypair_file, Keypair},
-    },
+    solana_sdk::{bs58, commitment_config::CommitmentConfig, pubkey::Pubkey, signature::Keypair},
     Client, Cluster, Program,
 };
 use anyhow::{anyhow, Context, Result};
 use clap::Parser;
 use cli::{generate_meta_merkle_snapshot, utils::*, MetaMerkleSnapshot};
-use ncn_snapshot::{Ballot, BallotBox, ConsensusResult, MetaMerkleProof, ProgramConfig};
 use log::info;
-use anchor_client::solana_sdk::signature::Signer;
+use ncn_snapshot::{Ballot, BallotBox, ConsensusResult, MetaMerkleProof, ProgramConfig};
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::{collections::HashMap, fs, process::Command, thread, time::Duration};
@@ -252,8 +247,10 @@ fn main() -> Result<()> {
     }
 
     fn cast_vote_shared(cli: Cli, snapshot_slot: u64, root: [u8; 32], hash: [u8; 32]) -> Result<()> {
-        let payer = read_keypair_file(&cli.payer_path).map_err(|err| anyhow!("Failed to read payer keypair at {}: {}", cli.payer_path, err))?;
-        let authority = read_keypair_file(&cli.authority_path).map_err(|err| anyhow!("Failed to read authority keypair at {}: {}", cli.authority_path, err))?;
+        let payer = read_signer_keypair(&cli.payer_path, "--payer-path")
+            .context("loading payer keypair")?;
+        let authority = read_signer_keypair(&cli.authority_path, "--authority-path")
+            .context("loading authority keypair")?;
         let program = load_client_program(&payer, cli.rpc_url);
 
         let tx_sender = &TxSender {
@@ -396,8 +393,10 @@ fn main() -> Result<()> {
         Commands::InitProgramConfig {} => {
             info!("InitProgramConfig...");
 
-            let payer = read_keypair_file(&cli.payer_path).map_err(|err| anyhow!("Failed to read payer keypair at {}: {}", cli.payer_path, err))?;
-            let authority = read_keypair_file(&cli.authority_path).map_err(|err| anyhow!("Failed to read authority keypair at {}: {}", cli.authority_path, err))?;
+            let payer = read_signer_keypair(&cli.payer_path, "--payer-path")
+                .context("loading payer keypair")?;
+            let authority = read_signer_keypair(&cli.authority_path, "--authority-path")
+                .context("loading authority keypair")?;
             let program = load_client_program(&payer, cli.rpc_url);
 
             let tx_sender = &TxSender {
@@ -412,8 +411,10 @@ fn main() -> Result<()> {
         Commands::UpdateOperatorWhitelist { add, remove } => {
             info!("UpdateOperatorWhitelist...");
 
-            let payer = read_keypair_file(&cli.payer_path).map_err(|err| anyhow!("Failed to read payer keypair at {}: {}", cli.payer_path, err))?;
-            let authority = read_keypair_file(&cli.authority_path).map_err(|err| anyhow!("Failed to read authority keypair at {}: {}", cli.authority_path, err))?;
+            let payer = read_signer_keypair(&cli.payer_path, "--payer-path")
+                .context("loading payer keypair")?;
+            let authority = read_signer_keypair(&cli.authority_path, "--authority-path")
+                .context("loading authority keypair")?;
             let program = load_client_program(&payer, cli.rpc_url);
 
             let tx_sender = &TxSender {
@@ -433,8 +434,10 @@ fn main() -> Result<()> {
         } => {
             info!("UpdateProgramConfig...");
 
-            let payer = read_keypair_file(&cli.payer_path).map_err(|err| anyhow!("Failed to read payer keypair at {}: {}", cli.payer_path, err))?;
-            let authority = read_keypair_file(&cli.authority_path).map_err(|err| anyhow!("Failed to read authority keypair at {}: {}", cli.authority_path, err))?;
+            let payer = read_signer_keypair(&cli.payer_path, "--payer-path")
+                .context("loading payer keypair")?;
+            let authority = read_signer_keypair(&cli.authority_path, "--authority-path")
+                .context("loading authority keypair")?;
             let program = load_client_program(&payer, cli.rpc_url);
 
             let tx_sender = &TxSender {
@@ -455,8 +458,10 @@ fn main() -> Result<()> {
         Commands::FinalizeProposedAuthority {} => {
             info!("FinalizeProposedAuthority...");
 
-            let payer = read_keypair_file(&cli.payer_path).map_err(|err| anyhow!("Failed to read payer keypair at {}: {}", cli.payer_path, err))?;
-            let authority = read_keypair_file(&cli.authority_path).map_err(|err| anyhow!("Failed to read authority keypair at {}: {}", cli.authority_path, err))?;
+            let payer = read_signer_keypair(&cli.payer_path, "--payer-path")
+                .context("loading payer keypair")?;
+            let authority = read_signer_keypair(&cli.authority_path, "--authority-path")
+                .context("loading authority keypair")?;
             let program = load_client_program(&payer, cli.rpc_url);
 
             let tx_sender = &TxSender {
@@ -484,8 +489,10 @@ fn main() -> Result<()> {
         Commands::RemoveVote { snapshot_slot } => {
             info!("RemoveVote...");
 
-            let payer = read_keypair_file(&cli.payer_path).map_err(|err| anyhow!("Failed to read payer keypair at {}: {}", cli.payer_path, err))?;
-            let authority = read_keypair_file(&cli.authority_path).map_err(|err| anyhow!("Failed to read authority keypair at {}: {}", cli.authority_path, err))?;
+            let payer = read_signer_keypair(&cli.payer_path, "--payer-path")
+                .context("loading payer keypair")?;
+            let authority = read_signer_keypair(&cli.authority_path, "--authority-path")
+                .context("loading authority keypair")?;
             let program = load_client_program(&payer, cli.rpc_url);
 
             let ballot_box_pda = BallotBox::pda(snapshot_slot).0;
@@ -501,8 +508,10 @@ fn main() -> Result<()> {
         Commands::SetTieBreaker { snapshot_slot, root, hash } => {
             info!("SetTieBreaker...");
 
-            let payer = read_keypair_file(&cli.payer_path).map_err(|err| anyhow!("Failed to read payer keypair at {}: {}", cli.payer_path, err))?;
-            let authority = read_keypair_file(&cli.authority_path).map_err(|err| anyhow!("Failed to read authority keypair at {}: {}", cli.authority_path, err))?;
+            let payer = read_signer_keypair(&cli.payer_path, "--payer-path")
+                .context("loading payer keypair")?;
+            let authority = read_signer_keypair(&cli.authority_path, "--authority-path")
+                .context("loading authority keypair")?;
             let program = load_client_program(&payer, cli.rpc_url);
             let ballot_box_pda = BallotBox::pda(snapshot_slot).0;
 
@@ -522,8 +531,10 @@ fn main() -> Result<()> {
         Commands::ResetBallotBox { snapshot_slot } => {
             info!("ResetBallotBox...");
 
-            let payer = read_keypair_file(&cli.payer_path).map_err(|err| anyhow!("Failed to read payer keypair at {}: {}", cli.payer_path, err))?;
-            let authority = read_keypair_file(&cli.authority_path).map_err(|err| anyhow!("Failed to read authority keypair at {}: {}", cli.authority_path, err))?;
+            let payer = read_signer_keypair(&cli.payer_path, "--payer-path")
+                .context("loading payer keypair")?;
+            let authority = read_signer_keypair(&cli.authority_path, "--authority-path")
+                .context("loading authority keypair")?;
             let program = load_client_program(&payer, cli.rpc_url);
             let ballot_box_pda = BallotBox::pda(snapshot_slot).0;
 
@@ -539,7 +550,8 @@ fn main() -> Result<()> {
         Commands::FinalizeBallot { snapshot_slot } => {
             info!("FinalizeBallot...");
 
-            let payer = read_keypair_file(&cli.payer_path).map_err(|err| anyhow!("Failed to read payer keypair at {}: {}", cli.payer_path, err))?;
+            let payer = read_signer_keypair(&cli.payer_path, "--payer-path")
+                .context("loading payer keypair")?;
             let program = load_client_program(&payer, cli.rpc_url);
 
             let ballot_box_pda = BallotBox::pda(snapshot_slot).0;
@@ -763,7 +775,8 @@ fn main() -> Result<()> {
             read_path,
             is_compressed,
         } => {
-            let authority = read_keypair_file(&cli.authority_path).map_err(|err| anyhow!("Failed to read authority keypair at {}: {}", cli.authority_path, err))?;
+            let authority = read_signer_keypair(&cli.authority_path, "--authority-path")
+                .context("loading authority keypair")?;
             let snapshot = MetaMerkleSnapshot::read(read_path.clone(), is_compressed)?;
             let snapshot_hash = MetaMerkleSnapshot::snapshot_hash(read_path, is_compressed)?;
 

--- a/ncn/cli/src/main.rs
+++ b/ncn/cli/src/main.rs
@@ -252,8 +252,8 @@ fn main() -> Result<()> {
     }
 
     fn cast_vote_shared(cli: Cli, snapshot_slot: u64, root: [u8; 32], hash: [u8; 32]) -> Result<()> {
-        let payer = read_keypair_file(&cli.payer_path).unwrap();
-        let authority = read_keypair_file(&cli.authority_path).unwrap();
+        let payer = read_keypair_file(&cli.authority_path).map_err(|err| anyhow!("Failed to read payer keypair at {}: {}", cli.payer_path, err))?;
+        let authority = read_keypair_file(&cli.authority_path).map_err(|err| anyhow!("Failed to read authority keypair at {}: {}", cli.authority_path, err))?;
         let program = load_client_program(&payer, cli.rpc_url);
 
         let tx_sender = &TxSender {
@@ -396,8 +396,8 @@ fn main() -> Result<()> {
         Commands::InitProgramConfig {} => {
             info!("InitProgramConfig...");
 
-            let payer = read_keypair_file(&cli.payer_path).unwrap();
-            let authority = read_keypair_file(&cli.authority_path).unwrap();
+            let payer = read_keypair_file(&cli.authority_path).map_err(|err| anyhow!("Failed to read payer keypair at {}: {}", cli.payer_path, err))?;
+            let authority = read_keypair_file(&cli.authority_path).map_err(|err| anyhow!("Failed to read authority keypair at {}: {}", cli.authority_path, err))?;
             let program = load_client_program(&payer, cli.rpc_url);
 
             let tx_sender = &TxSender {
@@ -412,8 +412,8 @@ fn main() -> Result<()> {
         Commands::UpdateOperatorWhitelist { add, remove } => {
             info!("UpdateOperatorWhitelist...");
 
-            let payer = read_keypair_file(&cli.payer_path).unwrap();
-            let authority = read_keypair_file(&cli.authority_path).unwrap();
+            let payer = read_keypair_file(&cli.authority_path).map_err(|err| anyhow!("Failed to read payer keypair at {}: {}", cli.payer_path, err))?;
+            let authority = read_keypair_file(&cli.authority_path).map_err(|err| anyhow!("Failed to read authority keypair at {}: {}", cli.authority_path, err))?;
             let program = load_client_program(&payer, cli.rpc_url);
 
             let tx_sender = &TxSender {
@@ -433,8 +433,8 @@ fn main() -> Result<()> {
         } => {
             info!("UpdateProgramConfig...");
 
-            let payer = read_keypair_file(&cli.payer_path).unwrap();
-            let authority = read_keypair_file(&cli.authority_path).unwrap();
+            let payer = read_keypair_file(&cli.authority_path).map_err(|err| anyhow!("Failed to read payer keypair at {}: {}", cli.payer_path, err))?;
+            let authority = read_keypair_file(&cli.authority_path).map_err(|err| anyhow!("Failed to read authority keypair at {}: {}", cli.authority_path, err))?;
             let program = load_client_program(&payer, cli.rpc_url);
 
             let tx_sender = &TxSender {
@@ -455,8 +455,8 @@ fn main() -> Result<()> {
         Commands::FinalizeProposedAuthority {} => {
             info!("FinalizeProposedAuthority...");
 
-            let payer = read_keypair_file(&cli.payer_path).unwrap();
-            let authority = read_keypair_file(&cli.authority_path).unwrap();
+            let payer = read_keypair_file(&cli.authority_path).map_err(|err| anyhow!("Failed to read payer keypair at {}: {}", cli.payer_path, err))?;
+            let authority = read_keypair_file(&cli.authority_path).map_err(|err| anyhow!("Failed to read authority keypair at {}: {}", cli.authority_path, err))?;
             let program = load_client_program(&payer, cli.rpc_url);
 
             let tx_sender = &TxSender {
@@ -484,8 +484,8 @@ fn main() -> Result<()> {
         Commands::RemoveVote { snapshot_slot } => {
             info!("RemoveVote...");
 
-            let payer = read_keypair_file(&cli.payer_path).unwrap();
-            let authority = read_keypair_file(&cli.authority_path).unwrap();
+            let payer = read_keypair_file(&cli.authority_path).map_err(|err| anyhow!("Failed to read payer keypair at {}: {}", cli.payer_path, err))?;
+            let authority = read_keypair_file(&cli.authority_path).map_err(|err| anyhow!("Failed to read authority keypair at {}: {}", cli.authority_path, err))?;
             let program = load_client_program(&payer, cli.rpc_url);
 
             let ballot_box_pda = BallotBox::pda(snapshot_slot).0;
@@ -501,8 +501,8 @@ fn main() -> Result<()> {
         Commands::SetTieBreaker { snapshot_slot, root, hash } => {
             info!("SetTieBreaker...");
 
-            let payer = read_keypair_file(&cli.payer_path).unwrap();
-            let authority = read_keypair_file(&cli.authority_path).unwrap();
+            let payer = read_keypair_file(&cli.authority_path).map_err(|err| anyhow!("Failed to read payer keypair at {}: {}", cli.payer_path, err))?;
+            let authority = read_keypair_file(&cli.authority_path).map_err(|err| anyhow!("Failed to read authority keypair at {}: {}", cli.authority_path, err))?;
             let program = load_client_program(&payer, cli.rpc_url);
             let ballot_box_pda = BallotBox::pda(snapshot_slot).0;
 
@@ -522,8 +522,8 @@ fn main() -> Result<()> {
         Commands::ResetBallotBox { snapshot_slot } => {
             info!("ResetBallotBox...");
 
-            let payer = read_keypair_file(&cli.payer_path).unwrap();
-            let authority = read_keypair_file(&cli.authority_path).unwrap();
+            let payer = read_keypair_file(&cli.payer_path).map_err(|err| anyhow!("Failed to read payer keypair at {}: {}", cli.payer_path, err))?;
+            let authority = read_keypair_file(&cli.authority_path).map_err(|err| anyhow!("Failed to read authority keypair at {}: {}", cli.authority_path, err))?;
             let program = load_client_program(&payer, cli.rpc_url);
             let ballot_box_pda = BallotBox::pda(snapshot_slot).0;
 
@@ -539,7 +539,7 @@ fn main() -> Result<()> {
         Commands::FinalizeBallot { snapshot_slot } => {
             info!("FinalizeBallot...");
 
-            let payer = read_keypair_file(&cli.payer_path).unwrap();
+            let payer = read_keypair_file(&cli.authority_path).map_err(|err| anyhow!("Failed to read payer keypair at {}: {}", cli.payer_path, err))?;
             let program = load_client_program(&payer, cli.rpc_url);
 
             let ballot_box_pda = BallotBox::pda(snapshot_slot).0;
@@ -763,7 +763,7 @@ fn main() -> Result<()> {
             read_path,
             is_compressed,
         } => {
-            let authority = read_keypair_file(&cli.authority_path).unwrap();
+            let authority = read_keypair_file(&cli.authority_path).map_err(|err| anyhow!("Failed to read authority keypair at {}: {}", cli.authority_path, err))?;
             let snapshot = MetaMerkleSnapshot::read(read_path.clone(), is_compressed)?;
             let snapshot_hash = MetaMerkleSnapshot::snapshot_hash(read_path, is_compressed)?;
 

--- a/ncn/cli/src/utils/keypair.rs
+++ b/ncn/cli/src/utils/keypair.rs
@@ -1,0 +1,121 @@
+use anchor_client::solana_sdk::signature::{read_keypair_file, Keypair};
+use anyhow::{anyhow, Result};
+use std::path::Path;
+
+/// Read a keypair file used to sign on-chain instructions or off-chain
+/// messages, surfacing actionable errors for the most common
+/// misconfigurations before delegating to `read_keypair_file`.
+///
+/// Three preflight checks are performed in order:
+///   1. The path is not the clap default placeholder `"/"`, which signals the
+///      flag was never overridden by the user.
+///   2. The path does not point at a directory (a common copy/paste mistake
+///      that otherwise surfaces as a cryptic JSON parse error from
+///      `read_keypair_file`).
+///   3. `read_keypair_file` succeeds; if it does not, its message is wrapped
+///      with the offending path and the next step the user should take.
+///
+/// `flag_name` should be the CLI flag the caller obtained the path from
+/// (e.g. `"--payer-path"`) and is included in remediation hints so the user
+/// knows which flag to set. The *role* of the keypair (payer vs authority) is
+/// expected to be added by the caller via `anyhow::Context::with_context`,
+/// keeping this helper agnostic to how the resulting key will be used.
+pub fn read_signer_keypair(path: &Path, flag_name: &str) -> Result<Keypair> {
+    // (1) The clap default; the CLI uses "/" as a placeholder so the args
+    // remain optional at the parser level but still produce a clear error
+    // when a subcommand actually needs the file.
+    if path == Path::new("/") {
+        return Err(anyhow!(
+            "no keypair file specified (got the default placeholder `/`); \
+             pass `{flag}` (or set the matching env var) pointing at a JSON \
+             keypair file",
+            flag = flag_name,
+        ));
+    }
+
+    // (2) Detect directories explicitly; otherwise `read_keypair_file` emits
+    // a confusing JSON-parse error several layers deep.
+    if path.is_dir() {
+        return Err(anyhow!(
+            "keypair path `{path}` (from `{flag}`) is a directory; expected a \
+             JSON keypair file",
+            path = path.display(),
+            flag = flag_name,
+        ));
+    }
+
+    // (3) Defer to the SDK and wrap its error with the path and remediation.
+    read_keypair_file(path).map_err(|err| {
+        anyhow!(
+            "failed to read keypair at `{path}` (from `{flag}`): {err}. \
+             Verify the file exists, is readable, and is a JSON keypair file",
+            path = path.display(),
+            flag = flag_name,
+            err = err,
+        )
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+    use tempfile::TempDir;
+
+    fn setup() -> TempDir {
+        tempfile::tempdir().unwrap()
+    }
+
+    #[test]
+    fn rejects_default_placeholder() {
+        let err = read_signer_keypair(Path::new("/"), "--payer-path").unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("default placeholder"), "got: {msg}");
+        assert!(msg.contains("--payer-path"), "got: {msg}");
+    }
+
+    #[test]
+    fn rejects_directory() {
+        let dir = setup();
+        let err = read_signer_keypair(dir.path(), "--authority-path").unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("is a directory"), "got: {msg}");
+        assert!(msg.contains("--authority-path"), "got: {msg}");
+    }
+
+    #[test]
+    fn rejects_missing_file() {
+        let dir = setup();
+        let missing = dir.path().join("does-not-exist.json");
+        let err = read_signer_keypair(&missing, "--authority-path").unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("failed to read keypair"), "got: {msg}");
+        assert!(msg.contains("--authority-path"), "got: {msg}");
+    }
+
+    #[test]
+    fn rejects_non_keypair_file() {
+        let dir = setup();
+        let path = dir.path().join("not-a-keypair.json");
+        let mut f = std::fs::File::create(&path).unwrap();
+        writeln!(f, "this is not a keypair").unwrap();
+
+        let err = read_signer_keypair(&path, "--payer-path").unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("failed to read keypair"), "got: {msg}");
+        assert!(msg.contains("--payer-path"), "got: {msg}");
+    }
+
+    #[test]
+    fn accepts_valid_keypair_file() {
+        use anchor_client::solana_sdk::signature::write_keypair_file;
+
+        let dir = setup();
+        let path = dir.path().join("kp.json");
+        let kp = Keypair::new();
+        write_keypair_file(&kp, &path).unwrap();
+
+        let loaded = read_signer_keypair(&path, "--authority-path").unwrap();
+        assert_eq!(loaded.to_bytes(), kp.to_bytes());
+    }
+}

--- a/ncn/cli/src/utils/mod.rs
+++ b/ncn/cli/src/utils/mod.rs
@@ -2,8 +2,10 @@ pub mod parsers;
 pub mod path;
 pub mod send_utils;
 pub mod io;
+pub mod keypair;
 
 pub use parsers::*;
 pub use path::*;
 pub use send_utils::*;
 pub use io::*;
+pub use keypair::*;


### PR DESCRIPTION
I was attempting to use the `non-cli log-meta-merkle-hash` command and got a panic with no helpful message. This should fix.