### PR TITLE
docs: snapshot-slot recovery + generate-meta-merkle path clarification

### DIFF
--- a/docs/src/content/ncn/cli/index.mdx
+++ b/docs/src/content/ncn/cli/index.mdx
@@ -65,12 +65,13 @@ These options are available on all commands. Each can also be set via the matchi
 
 ### `snapshot-slot`
 
-Generates a Solana ledger snapshot for a specific target slot. Replays the validator bank up to `--slot` and writes a full snapshot into `--backup-snapshots-dir`. Requires `--ledger-path` and `--full-snapshots-path` (or defaults derived from `--ledger-path`).
+Generates a Solana ledger snapshot for a specific target slot. Replays the validator bank up to `--slot` and writes a full snapshot into `--backup-snapshots-dir`. Requires `--ledger-path` and `--full-snapshots-path` (or defaults derived from `--ledger-path`). Unlike `generate-meta-merkle` — which requires an exact-slot snapshot to already exist — `snapshot-slot` creates one, making it the recovery path when `await-snapshot` cannot find snapshot coverage for the target slot (see below).
 
 ```bash
 ncn-cli \
   --ledger-path /mnt/ledger \
   --full-snapshots-path /mnt/ledger/full-snapshots \
+  --account-paths /mnt/accounts \
   --backup-snapshots-dir /mnt/ledger/backup-snapshots \
   snapshot-slot --slot <SLOT>
 ```
@@ -83,6 +84,20 @@ ncn-cli \
 >
 > - `--full-snapshots-path`: Where the CLI reads *full* snapshots from.
 > - `--backup-snapshots-dir`: Where snapshot artifacts are copied/saved for backup.
+
+> **Recovery: `await-snapshot` is waiting forever**
+>
+> `await-snapshot` does not wait for the slot itself — it waits for an *incremental snapshot whose range covers the target slot* to appear. If snapshot retention is too narrow, the target can fall into a coverage gap where no retained incremental ends at or before it, and the poll never completes.
+>
+> Recovery: stop the validator (bank load is memory-heavy), then run `snapshot-slot` to replay-build the exact-slot snapshot, and point `generate-meta-merkle` at the same `--backup-snapshots-dir`. Run inside `tmux`/`screen` — a large replay can take hours. The target slot's blocks must still be in the blockstore (not evicted by `--limit-ledger-size`); the tool logs whether the desired slot is present.
+
+> **Determinism**
+>
+> Solana bank state at a given slot is path-independent: replaying forward from an older full snapshot reaches the same state as capturing near the target, so the recovered snapshot produces the same MetaMerkle root and snapshot hash as the rest of the cohort. Confirm with `log-meta-merkle-hash` before uploading or voting.
+
+> **Prevention**
+>
+> Retain enough incrementals that any target slot has one terminating at or before it. A working baseline: full retention `2` / full interval `100000` / incremental retention `30` / incremental interval `2500` — roughly 75,000 slots of incremental coverage, which keeps `await-snapshot` on its happy path.
 
 ---
 
@@ -104,6 +119,10 @@ ncn-cli \
 |---|---|---|---|
 | `--slot <u64>` | Yes | — | Target slot. A full snapshot for this exact slot must already exist in `--backup-snapshots-dir`. |
 | `--save-path <PATH>` | No | `./` | Directory to write the compressed `MetaMerkleSnapshot` (`meta_merkle-<slot>.zip`) to. |
+
+> **Full-snapshot lookup**
+>
+> The full-snapshot tarball (`snapshot-<slot>-*.tar.zst`) is located via `--backup-snapshots-dir`, **not** `--full-snapshots-path` (which is not consumed by this subcommand). If it isn't found there, generation fails with `Missing snapshot at slot <X>` — point `--backup-snapshots-dir` at the directory holding your `snapshot-<slot>-*.tar.zst`, or produce one with `snapshot-slot` first.
 
 ---
 

--- a/docs/src/content/ncn/cli/index.mdx
+++ b/docs/src/content/ncn/cli/index.mdx
@@ -85,27 +85,27 @@ ncn-cli \
 > - `--full-snapshots-path`: Where the CLI reads *full* snapshots from.
 > - `--backup-snapshots-dir`: Where snapshot artifacts are copied/saved for backup.
 
-> **Recovery: `await-snapshot` is waiting forever**
->
-> `await-snapshot` does not wait for the slot itself — it waits for an *incremental snapshot whose range covers the target slot* to appear. If snapshot retention is too narrow, the target can fall into a coverage gap where no retained incremental ends at or before it, and the poll never completes.
->
-> Recovery: stop the validator (bank load is memory-heavy), then run `snapshot-slot` to replay-build the exact-slot snapshot, and point `generate-meta-merkle` at the same `--backup-snapshots-dir`. Run inside `tmux`/`screen` — a large replay can take hours. The target slot's blocks must still be in the blockstore (not evicted by `--limit-ledger-size`); the tool logs whether the desired slot is present.
+#### Recovery: `await-snapshot` is waiting forever
 
-> **Determinism**
->
-> Solana bank state at a given slot is path-independent: replaying forward from an older full snapshot reaches the same state as capturing near the target, so the recovered snapshot produces the same MetaMerkle root and snapshot hash as the rest of the cohort. Confirm with `log-meta-merkle-hash` before uploading or voting.
+`await-snapshot` does not wait for the slot itself — it waits for an *incremental snapshot whose range covers the target slot* to appear. If snapshot retention is too narrow, the target can fall into a coverage gap where no retained incremental ends at or before it, and the poll never completes.
 
-> **Prevention**
->
-> Retain enough incrementals that any target slot has one terminating at or before it. A working baseline: full retention `2` / full interval `100000` / incremental retention `30` / incremental interval `2500` — roughly 75,000 slots of incremental coverage, which keeps `await-snapshot` on its happy path.
+Recovery: stop the validator (bank load is memory-heavy), then run `snapshot-slot` to replay-build the exact-slot snapshot, and point `generate-meta-merkle` at the same `--backup-snapshots-dir`. Run inside `tmux`/`screen` — a large replay can take hours. The target slot's blocks must still be in the blockstore (not evicted by `--limit-ledger-size`); the tool logs whether the desired slot is present.
 
-> **`await-snapshot`: stage genesis into the backup ledger dir first**
->
-> The internal `agave-ledger-tool ... copy` step populates rocksdb into `--backup-ledger-dir` but does **not** copy the genesis files. The subsequent snapshot-creation step then fails with a misleading `Missing snapshot at slot <X>`, preceded by a `Failed to load genesis config` line. Before running `await-snapshot`, copy `genesis.tar.bz2` and `genesis.bin` from the live ledger directory into `--backup-ledger-dir`.
+#### Determinism
 
-> **Disk budget**
->
-> Budget roughly **350GB free** for a mainnet run: a ~118GB full-snapshot copy, ~90GB of copied ledger range (rocksdb), the accounts unpack during bank load, and the newly created target-slot snapshot. 150GB is not enough — runs fail mid-flight.
+Solana bank state at a given slot is path-independent: replaying forward from an older full snapshot reaches the same state as capturing near the target, so the recovered snapshot produces the same MetaMerkle root and snapshot hash as the rest of the cohort. Confirm with `log-meta-merkle-hash` before uploading or voting.
+
+#### Prevention
+
+Retain enough incrementals that any target slot has one terminating at or before it. A working baseline: full retention `2` / full interval `100000` / incremental retention `30` / incremental interval `2500` — roughly 75,000 slots of incremental coverage, which keeps `await-snapshot` on its happy path.
+
+#### `await-snapshot`: stage genesis into the backup ledger dir first
+
+The internal `agave-ledger-tool ... copy` step populates rocksdb into `--backup-ledger-dir` but does **not** copy the genesis files. The subsequent snapshot-creation step then fails with a misleading `Missing snapshot at slot <X>`, preceded by a `Failed to load genesis config` line. Before running `await-snapshot`, copy `genesis.tar.bz2` and `genesis.bin` from the live ledger directory into `--backup-ledger-dir`.
+
+#### Disk budget
+
+Budget roughly **350GB free** for a mainnet run: a ~118GB full-snapshot copy, ~90GB of copied ledger range (rocksdb), the accounts unpack during bank load, and the newly created target-slot snapshot. 150GB is not enough — runs fail mid-flight.
 
 #### Failure quick-reference
 
@@ -139,9 +139,9 @@ ncn-cli \
 | `--slot <u64>` | Yes | — | Target slot. A full snapshot for this exact slot must already exist in `--backup-snapshots-dir`. |
 | `--save-path <PATH>` | No | `./` | Directory to write the compressed `MetaMerkleSnapshot` (`meta_merkle-<slot>.zip`) to. |
 
-> **Full-snapshot lookup**
->
-> The full-snapshot tarball (`snapshot-<slot>-*.tar.zst`) is located via `--backup-snapshots-dir`, **not** `--full-snapshots-path` (which is not consumed by this subcommand). If it isn't found there, generation fails with `Missing snapshot at slot <X>` — point `--backup-snapshots-dir` at the directory holding your `snapshot-<slot>-*.tar.zst`, or produce one with `snapshot-slot` first.
+#### Full-snapshot lookup
+
+The full-snapshot tarball (`snapshot-<slot>-*.tar.zst`) is located via `--backup-snapshots-dir`, **not** `--full-snapshots-path` (which is not consumed by this subcommand). If it isn't found there, generation fails with `Missing snapshot at slot <X>` — point `--backup-snapshots-dir` at the directory holding your `snapshot-<slot>-*.tar.zst`, or produce one with `snapshot-slot` first.
 
 ---
 

--- a/docs/src/content/ncn/cli/index.mdx
+++ b/docs/src/content/ncn/cli/index.mdx
@@ -99,6 +99,25 @@ ncn-cli \
 >
 > Retain enough incrementals that any target slot has one terminating at or before it. A working baseline: full retention `2` / full interval `100000` / incremental retention `30` / incremental interval `2500` — roughly 75,000 slots of incremental coverage, which keeps `await-snapshot` on its happy path.
 
+> **`await-snapshot`: stage genesis into the backup ledger dir first**
+>
+> The internal `agave-ledger-tool ... copy` step populates rocksdb into `--backup-ledger-dir` but does **not** copy the genesis files. The subsequent snapshot-creation step then fails with a misleading `Missing snapshot at slot <X>`, preceded by a `Failed to load genesis config` line. Before running `await-snapshot`, copy `genesis.tar.bz2` and `genesis.bin` from the live ledger directory into `--backup-ledger-dir`.
+
+> **Disk budget**
+>
+> Budget roughly **350GB free** for a mainnet run: a ~118GB full-snapshot copy, ~90GB of copied ledger range (rocksdb), the accounts unpack during bank load, and the newly created target-slot snapshot. 150GB is not enough — runs fail mid-flight.
+
+#### Failure quick-reference
+
+| Symptom | Actual cause | Fix |
+|---|---|---|
+| `unexpected argument '--allow-dead-slots'` | `agave-ledger-tool` is older than the validator | Rebuild the ledger-tool from the validator's own source tree (`--manifest-path dev-bins/Cargo.toml`) and pass it via `--agave-ledger-tool-path` |
+| `Missing snapshot at slot <X>` right after `Extracting genesis.tar.bz2` | genesis files missing from `--backup-ledger-dir` | Copy `genesis.tar.bz2` + `genesis.bin` from the live ledger dir and re-run |
+| `Missing snapshot at slot <X>` with `Blockstore missing data to replay` above it | blockstore no longer covers the slot range | Pick a target inside the retained window, or recover via `snapshot-slot` while the blocks are still present |
+| `generate-meta-merkle` fails instantly with `Missing snapshot at slot <X>` | no exact-slot snapshot in `--backup-snapshots-dir` | See **Full-snapshot lookup** below — produce one with `snapshot-slot`, or run the full `await-snapshot` flow |
+| `await-snapshot` polls forever | no retained incremental covers the target | See **Recovery** above |
+| The final error line looks unrelated | the causal error is usually 2-4 lines earlier in the log | Read upward — error propagation was improved by #125 |
+
 ---
 
 ### `generate-meta-merkle`


### PR DESCRIPTION
Documents the snapshot-slot command and how to recover when await-snapshot can't find an incremental snapshot covering the target slot — it replays to build the exact-slot snapshot that generate-meta-merkle requires.
Complements #52, which clarifies the await message; this covers the recovery procedure the message points toward. Field-tested on a live mainnet round: a single-pass ~84k-slot replay produced a MetaMerkle root and snapshot hash matching cohort consensus exactly. Also notes the retention config that prevents the gap.
Also clarifies that generate-meta-merkle reads the full snapshot from --backup-snapshots-dir, not --full-snapshots-path — prevents the common "Missing snapshot at slot X" confusion.