### PR TITLE
chore: fixes to prep for 0.2.0 release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ node_modules/
 admin.json
 
 jito-tip-router
+.surfpool

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -144,7 +144,7 @@ Later phases are driven by two CLIs: **`svmgov`** (governance — `init-global-c
       svmgov program if it was set wrong or svmgov is redeployed (no ncn redeploy needed).
 - [ ] `update-operator-whitelist --add <op1,op2,…>` — add the production operator set
       (max 64).
-- [ ] `log --ty program-config` — verify authority, threshold, vote_duration,
+- [ ] `ncn-cli get-program-config` & `ncn-cli get-operator-whitelist` — verify authority, threshold, vote_duration,
       tie_breaker_admin, svmgov program, whitelist.
 
 ## Phase 5 — Admin values to decide (fill these in before Phase 4)

--- a/frontend/src/chain/idl/gov-v1.json
+++ b/frontend/src/chain/idl/gov-v1.json
@@ -1,5 +1,5 @@
 {
-  "address": "HsiPGfvF441TrU8eCLLerQDcEMtyzYszBfKxqoSuaD9R",
+  "address": "ncnwF8AgynRcdEnGLcprSQNaKvgSMTgk3yPRc8cf9Zf",
   "metadata": {
     "name": "gov_v1",
     "version": "0.1.0-40000",

--- a/frontend/src/chain/idl/svmgov_program.json
+++ b/frontend/src/chain/idl/svmgov_program.json
@@ -1,5 +1,5 @@
 {
-  "address": "4HarXuo8QjE5GSGzuUxHA1cnNM9mFt2th2JQAC5DSNqU",
+  "address": "govYkyQ3ePtGULAtY6V75qjWE8UH4vCUVQ1W4HdCAZU",
   "metadata": {
     "name": "svmgov_program",
     "version": "0.1.0-40000",

--- a/frontend/src/chain/types/gov-v1.ts
+++ b/frontend/src/chain/types/gov-v1.ts
@@ -5,7 +5,7 @@
  * IDL can be found at `target/idl/gov_v1.json`.
  */
 export type GovV1 = {
-  address: "HsiPGfvF441TrU8eCLLerQDcEMtyzYszBfKxqoSuaD9R";
+  address: "ncnwF8AgynRcdEnGLcprSQNaKvgSMTgk3yPRc8cf9Zf";
   metadata: {
     name: "govV1";
     version: "0.1.0";

--- a/frontend/src/chain/types/svmgov_program.ts
+++ b/frontend/src/chain/types/svmgov_program.ts
@@ -5,7 +5,7 @@
  * IDL can be found at `target/idl/svmgov_program.json`.
  */
 export type SvmgovProgram = {
-  "address": "4HarXuo8QjE5GSGzuUxHA1cnNM9mFt2th2JQAC5DSNqU",
+  "address": "govYkyQ3ePtGULAtY6V75qjWE8UH4vCUVQ1W4HdCAZU",
   "metadata": {
     "name": "svmgovProgram",
     "version": "0.1.0",

--- a/ncn/Anchor.toml
+++ b/ncn/Anchor.toml
@@ -6,7 +6,7 @@ resolution = true
 skip-lint = false
 
 [programs.localnet]
-ncn_snapshot = "HsiPGfvF441TrU8eCLLerQDcEMtyzYszBfKxqoSuaD9R"
+ncn_snapshot = "ncnwF8AgynRcdEnGLcprSQNaKvgSMTgk3yPRc8cf9Zf"
 
 [registry]
 url = "https://api.apr.dev"

--- a/ncn/cli/src/utils/send_utils.rs
+++ b/ncn/cli/src/utils/send_utils.rs
@@ -99,12 +99,19 @@ pub fn send_init_program_config(
     tx_sender: &TxSender,
     svmgov_program_pubkey: Pubkey,
 ) -> Result<RoutedOutcome> {
+    // InitProgramConfig has two signer slots: `payer` (funds the ProgramConfig PDA rent)
+    // and `authority` (becomes program_config.authority). When routed through Squads, the
+    // wrapped instruction is signed solely by the vault PDA at execution time, so BOTH
+    // slots must resolve to the vault PDA — otherwise the proposal would also require the
+    // local payer's signature, which Squads cannot supply, leaving it unexecutable. In
+    // direct mode they stay the local payer/authority keypairs.
+    let payer = effective_signer(tx_sender.squads.as_ref(), tx_sender.program.payer());
     let authority = effective_signer(tx_sender.squads.as_ref(), tx_sender.authority.pubkey());
     let ixs = tx_sender
         .program
         .request()
         .accounts(accounts::InitProgramConfig {
-            payer: tx_sender.program.payer(),
+            payer,
             authority,
             program_config: ProgramConfig::pda().0,
             system_program: system_program::ID,

--- a/ncn/programs/ncn-snapshot/src/lib.rs
+++ b/ncn/programs/ncn-snapshot/src/lib.rs
@@ -11,7 +11,7 @@ use anchor_lang::prelude::*;
 pub use instructions::*;
 pub use state::*;
 
-declare_id!("HsiPGfvF441TrU8eCLLerQDcEMtyzYszBfKxqoSuaD9R");
+declare_id!("ncnwF8AgynRcdEnGLcprSQNaKvgSMTgk3yPRc8cf9Zf");
 
 #[program]
 pub mod ncn_snapshot {

--- a/networks.toml
+++ b/networks.toml
@@ -6,30 +6,30 @@ release_version = "0.1.0-40000"
 
 [networks.mainnet]
 rpc_url = "https://api.mainnet-beta.solana.com"
-svmgov_program_id       = "4HarXuo8QjE5GSGzuUxHA1cnNM9mFt2th2JQAC5DSNqU"
-ncn_snapshot_program_id = "HsiPGfvF441TrU8eCLLerQDcEMtyzYszBfKxqoSuaD9R"
+svmgov_program_id       = "govYkyQ3ePtGULAtY6V75qjWE8UH4vCUVQ1W4HdCAZU"
+ncn_snapshot_program_id = "ncnwF8AgynRcdEnGLcprSQNaKvgSMTgk3yPRc8cf9Zf"
 jito_tip_router_commit  = "d60e3eb75917f8f183c6cbc1a176796f0d095708"
 
 [networks.mainnet-staging]
 rpc_url = "https://api.mainnet-beta.solana.com"
-svmgov_program_id       = "4HarXuo8QjE5GSGzuUxHA1cnNM9mFt2th2JQAC5DSNqU"
-ncn_snapshot_program_id = "HsiPGfvF441TrU8eCLLerQDcEMtyzYszBfKxqoSuaD9R"
+svmgov_program_id       = "govYkyQ3ePtGULAtY6V75qjWE8UH4vCUVQ1W4HdCAZU"
+ncn_snapshot_program_id = "ncnwF8AgynRcdEnGLcprSQNaKvgSMTgk3yPRc8cf9Zf"
 jito_tip_router_commit  = "d60e3eb75917f8f183c6cbc1a176796f0d095708"
 
 [networks.testnet]
 rpc_url = "https://api.testnet.solana.com"
-svmgov_program_id       = "4HarXuo8QjE5GSGzuUxHA1cnNM9mFt2th2JQAC5DSNqU"
-ncn_snapshot_program_id = "HsiPGfvF441TrU8eCLLerQDcEMtyzYszBfKxqoSuaD9R"
+svmgov_program_id       = "govYkyQ3ePtGULAtY6V75qjWE8UH4vCUVQ1W4HdCAZU"
+ncn_snapshot_program_id = "ncnwF8AgynRcdEnGLcprSQNaKvgSMTgk3yPRc8cf9Zf"
 jito_tip_router_commit  = "d60e3eb75917f8f183c6cbc1a176796f0d095708"
 
 [networks.testnet-staging]
 rpc_url = "https://api.testnet.solana.com"
-svmgov_program_id       = "4HarXuo8QjE5GSGzuUxHA1cnNM9mFt2th2JQAC5DSNqU"
-ncn_snapshot_program_id = "HsiPGfvF441TrU8eCLLerQDcEMtyzYszBfKxqoSuaD9R"
+svmgov_program_id       = "govYkyQ3ePtGULAtY6V75qjWE8UH4vCUVQ1W4HdCAZU"
+ncn_snapshot_program_id = "ncnwF8AgynRcdEnGLcprSQNaKvgSMTgk3yPRc8cf9Zf"
 jito_tip_router_commit  = "d60e3eb75917f8f183c6cbc1a176796f0d095708"
 
 [networks.localnet]
 rpc_url = "http://localhost:8899"
-svmgov_program_id       = "4HarXuo8QjE5GSGzuUxHA1cnNM9mFt2th2JQAC5DSNqU"
-ncn_snapshot_program_id = "HsiPGfvF441TrU8eCLLerQDcEMtyzYszBfKxqoSuaD9R"
+svmgov_program_id       = "govYkyQ3ePtGULAtY6V75qjWE8UH4vCUVQ1W4HdCAZU"
+ncn_snapshot_program_id = "ncnwF8AgynRcdEnGLcprSQNaKvgSMTgk3yPRc8cf9Zf"
 jito_tip_router_commit  = "d60e3eb75917f8f183c6cbc1a176796f0d095708"

--- a/runbooks/README.md
+++ b/runbooks/README.md
@@ -1,0 +1,77 @@
+# program Runbooks
+
+[![Surfpool](https://img.shields.io/badge/Operated%20with-Surfpool-gree?labelColor=gray)](https://surfpool.run)
+
+## Available Runbooks
+
+### deployment
+Deploy programs
+
+## Getting Started
+
+This repository is using [Surfpool](https://surfpool.run) as a part of its development workflow.
+
+Surfpool provides three major upgrades to the Solana development experience:
+- **Surfnet**: A local validator that runs on your machine, allowing you fork mainnet on the fly so that you always use the latest chain data when testing your programs.
+- **Runbooks**: Bringing the devops best practice of `infrastructure as code` to Solana, Runbooks allow you to have secure, reproducible, and composable scripts for managing on-chain operations & deployments.
+- **Surfpool Studio**: An all-local Web UI that gives new levels of introspection into your transactions.
+
+### Installation
+
+Surfpool installer:
+
+```console
+curl -sL https://run.surfpool.run/ | bash
+```
+
+Install from source:
+
+```console
+# Clone repo
+git clone https://github.com/solana-foundation/surfpool.git
+
+# Set repo as current directory
+cd surfpool
+
+# Build
+cargo surfpool-install
+```
+
+### Start a Surfnet
+
+```console
+$ surfpool start
+```
+
+## Resources
+
+Access tutorials and documentation at [docs.surfpool.run](https://docs.surfpool.run) to understand Surfnets and the Runbook syntax, and to discover the powerful features of surfpool.
+
+Additionally, the [Visual Studio Code extension](https://marketplace.visualstudio.com/items?itemName=txtx.txtx) will make writing runbooks easier.
+
+Our [Surfpool 101 Series](https://www.youtube.com/playlist?list=PL0FMgRjJMRzO1FdunpMS-aUS4GNkgyr3T) is also a great place to start learning about Surfpool and its features:
+<a href="https://www.youtube.com/playlist?list=PL0FMgRjJMRzO1FdunpMS-aUS4GNkgyr3T">
+  <picture>
+    <source srcset="https://raw.githubusercontent.com/solana-foundation/surfpool/main/doc/assets/youtube.png">
+    <img alt="Surfpool 101 series" style="max-width: 100%;">
+  </picture>
+</a>
+
+## Quickstart
+
+### List runbooks available in this repository
+```console
+$ surfpool ls
+Name                                    Description
+deployment                              Deploy programs
+```
+
+### Start a Surfnet, automatically executing the `deployment` runbook on program recompile:
+```console
+$ surfpool start --watch
+```
+
+### Execute an existing runbook
+```console
+$ surfpool run deployment
+```

--- a/runbooks/deployment/main.tx
+++ b/runbooks/deployment/main.tx
@@ -1,0 +1,33 @@
+################################################################
+# Manage program deployment through Crypto Infrastructure as Code
+################################################################
+
+addon "svm" {
+    rpc_api_url = input.rpc_api_url
+    network_id = input.network_id
+}
+
+action "deploy_ncn_program" "svm::deploy_program" {
+    description = "Deploy ncn_snapshot program"
+    program = svm::get_program_from_anchor_project(
+        "ncn_snapshot", 
+        "ncn/target/deploy/ncn_snapshot-keypair.json",
+        "ncn/target/idl/ncn_snapshot.json",
+        "ncn/target/deploy/ncn_snapshot.so"
+    ) 
+    authority = signer.squads
+    payer = signer.proposer
+}
+
+
+action "deploy_svmgov_program" "svm::deploy_program" {
+    description = "Deploy svmgov_program program"
+    program = svm::get_program_from_anchor_project(
+        "svmgov_program", 
+        "svmgov/program/target/deploy/svmgov_program-keypair.json",
+        "svmgov/program/target/idl/svmgov_program.json",
+        "svmgov/program/target/deploy/svmgov_program.so"
+    ) 
+    authority = signer.squads
+    payer = signer.proposer
+}

--- a/runbooks/deployment/signers.localnet.tx
+++ b/runbooks/deployment/signers.localnet.tx
@@ -1,0 +1,10 @@
+signer "proposer" "svm::secret_key" {
+    description = "Keypair with proposer rights on squads multisig"
+    keypair_json = input.proposer_keypair_json
+}
+
+signer "squads" "svm::squads" {
+    description = "Squad signer for managing multisig proposals"
+    multisig_account_public_key = input.squad_multisig_public_key
+    initiator = signer.proposer
+}

--- a/runbooks/deployment/signers.mainnet.tx
+++ b/runbooks/deployment/signers.mainnet.tx
@@ -1,0 +1,10 @@
+signer "proposer" "svm::secret_key" {
+    description = "Keypair with proposer rights on squads multisig"
+    keypair_json = input.proposer_keypair_json
+}
+
+signer "squads" "svm::squads" {
+    description = "Squad signer for managing multisig proposals"
+    multisig_account_public_key = input.squad_multisig_public_key
+    initiator = signer.proposer
+}

--- a/svmgov/cli/idls/svmgov_program.json
+++ b/svmgov/cli/idls/svmgov_program.json
@@ -1,5 +1,5 @@
 {
-  "address": "4HarXuo8QjE5GSGzuUxHA1cnNM9mFt2th2JQAC5DSNqU",
+  "address": "govYkyQ3ePtGULAtY6V75qjWE8UH4vCUVQ1W4HdCAZU",
   "metadata": {
     "name": "svmgov_program",
     "version": "0.1.0-40000",

--- a/svmgov/cli/src/instructions/global_config.rs
+++ b/svmgov/cli/src/instructions/global_config.rs
@@ -236,11 +236,13 @@ pub async fn nominate_admin(
     keypair: Option<String>,
     new_admin: String,
     rpc_url: Option<String>,
+    squads: Option<SquadsCliOpts>,
 ) -> Result<()> {
     let proposed_admin = Pubkey::from_str(&new_admin)
         .map_err(|e| anyhow!("Invalid new admin pubkey '{}': {}", new_admin, e))?;
 
     let (payer, program) = setup_admin(keypair, rpc_url)?;
+    let admin = effective_signer(squads.as_ref(), payer.pubkey());
 
     let global_config_pda = derive_global_config_pda(&program.id());
 
@@ -250,32 +252,41 @@ pub async fn nominate_admin(
         .request()
         .args(args::NominateAdmin { proposed_admin })
         .accounts(accounts::NominateAdmin {
-            admin: payer.pubkey(),
+            admin,
             global_config: global_config_pda,
         })
         .instructions()?;
 
-    let blockhash = program.rpc().get_latest_blockhash().await?;
-    let transaction =
-        Transaction::new_signed_with_payer(&ixs, Some(&payer.pubkey()), &[&payer], blockhash);
+    let rpc = program.rpc();
+    let squads_config = squads.as_ref().map(|opts| opts.to_config(payer.pubkey()));
+    let outcome = crate::utils::squads::route(
+        &rpc,
+        ixs,
+        Vec::new(),
+        &[payer.as_ref()],
+        squads_config.as_ref(),
+    )
+    .await?;
+    spinner.finish_and_clear();
+    println!("{}", outcome.format_structured());
 
-    let sig = program
-        .rpc()
-        .send_and_confirm_transaction(&transaction)
-        .await?;
-
-    spinner.finish_with_message(format!(
-        "Nominated {} as admin. They must run `accept-admin` to complete the transfer. https://explorer.solana.com/tx/{}",
-        proposed_admin, sig
-    ));
+    println!(
+        "Nominating {} as admin. They must run `accept-admin` to complete the transfer.",
+        proposed_admin
+    );
 
     Ok(())
 }
 
 /// Step 2 of the two-step admin transfer. The nominated admin accepts the role and
 /// becomes the active admin. Signed by the nominee (the pending admin).
-pub async fn accept_admin(keypair: Option<String>, rpc_url: Option<String>) -> Result<()> {
+pub async fn accept_admin(
+    keypair: Option<String>,
+    rpc_url: Option<String>,
+    squads: Option<SquadsCliOpts>,
+) -> Result<()> {
     let (payer, program) = setup_admin(keypair, rpc_url)?;
+    let new_admin = effective_signer(squads.as_ref(), payer.pubkey());
 
     let global_config_pda = derive_global_config_pda(&program.id());
 
@@ -285,25 +296,23 @@ pub async fn accept_admin(keypair: Option<String>, rpc_url: Option<String>) -> R
         .request()
         .args(args::AcceptAdmin {})
         .accounts(accounts::AcceptAdmin {
-            new_admin: payer.pubkey(),
+            new_admin: new_admin,
             global_config: global_config_pda,
         })
         .instructions()?;
 
-    let blockhash = program.rpc().get_latest_blockhash().await?;
-    let transaction =
-        Transaction::new_signed_with_payer(&ixs, Some(&payer.pubkey()), &[&payer], blockhash);
-
-    let sig = program
-        .rpc()
-        .send_and_confirm_transaction(&transaction)
-        .await?;
-
-    spinner.finish_with_message(format!(
-        "Admin role accepted. {} is now the config admin. https://explorer.solana.com/tx/{}",
-        payer.pubkey(),
-        sig
-    ));
+    let rpc = program.rpc();
+    let squads_config = squads.as_ref().map(|opts| opts.to_config(payer.pubkey()));
+    let outcome = crate::utils::squads::route(
+        &rpc,
+        ixs,
+        Vec::new(),
+        &[payer.as_ref()],
+        squads_config.as_ref(),
+    )
+    .await?;
+    spinner.finish_and_clear();
+    println!("{}", outcome.format_structured());
 
     Ok(())
 }

--- a/svmgov/cli/src/instructions/init_index.rs
+++ b/svmgov/cli/src/instructions/init_index.rs
@@ -3,15 +3,17 @@ use anyhow::Result;
 
 use crate::{
     svmgov_program::client::{accounts, args},
-    utils::utils::{create_spinner, derive_proposal_index_pda, setup_all},
+    utils::utils::{create_spinner, derive_proposal_index_pda, setup_admin},
 };
 
 pub async fn initialize_index(
     identity_keypair: Option<String>,
     rpc_url: Option<String>,
 ) -> Result<()> {
-    let (payer, _vote_account, program, _merkle_proof_program) =
-        setup_all(identity_keypair, rpc_url).await?;
+    // init-index is permissionless on-chain: the signer only pays rent for the
+    // ProposalIndex PDA. Use setup_admin (no vote-account lookup) rather than
+    // setup_all, which requires the signer to be a validator identity.
+    let (payer, program) = setup_admin(identity_keypair, rpc_url)?;
 
     let proposal_index = derive_proposal_index_pda(&program.id());
 

--- a/svmgov/cli/src/main.rs
+++ b/svmgov/cli/src/main.rs
@@ -832,10 +832,19 @@ async fn handle_command(cli: Cli) -> Result<()> {
             instructions::show_global_config(cli.rpc_url).await?;
         }
         Commands::NominateAdmin { new_admin } => {
-            instructions::nominate_admin(cli.keypair, new_admin.clone(), cli.rpc_url).await?;
+            instructions::nominate_admin(
+                cli.keypair, 
+                new_admin.clone(), 
+                cli.rpc_url, 
+                squads_opts.clone()
+            ).await?;
         }
         Commands::AcceptAdmin => {
-            instructions::accept_admin(cli.keypair, cli.rpc_url).await?;
+            instructions::accept_admin(
+                cli.keypair, 
+                cli.rpc_url, 
+                squads_opts.clone()
+            ).await?;
         }
         Commands::Init => {
             init::run_init().await?;

--- a/svmgov/program/Anchor.toml
+++ b/svmgov/program/Anchor.toml
@@ -6,16 +6,16 @@ resolution = true
 skip-lint = false
 
 [programs.localnet]
-svmgov_program = "4HarXuo8QjE5GSGzuUxHA1cnNM9mFt2th2JQAC5DSNqU"
+svmgov_program = "govYkyQ3ePtGULAtY6V75qjWE8UH4vCUVQ1W4HdCAZU"
 
 [programs.devnet]
-svmgov_program = "4HarXuo8QjE5GSGzuUxHA1cnNM9mFt2th2JQAC5DSNqU"
+svmgov_program = "govYkyQ3ePtGULAtY6V75qjWE8UH4vCUVQ1W4HdCAZU"
 
 [programs.testnet]
-svmgov_program = "4HarXuo8QjE5GSGzuUxHA1cnNM9mFt2th2JQAC5DSNqU"
+svmgov_program = "govYkyQ3ePtGULAtY6V75qjWE8UH4vCUVQ1W4HdCAZU"
 
 [programs.mainnet]
-svmgov_program = "4HarXuo8QjE5GSGzuUxHA1cnNM9mFt2th2JQAC5DSNqU"
+svmgov_program = "govYkyQ3ePtGULAtY6V75qjWE8UH4vCUVQ1W4HdCAZU"
 
 [registry]
 url = "https://api.apr.dev"

--- a/svmgov/program/programs/svmgov_program/src/lib.rs
+++ b/svmgov/program/programs/svmgov_program/src/lib.rs
@@ -11,7 +11,7 @@ use instructions::*;
 
 use ncn_snapshot::StakeMerkleLeaf;
 
-declare_id!("4HarXuo8QjE5GSGzuUxHA1cnNM9mFt2th2JQAC5DSNqU");
+declare_id!("govYkyQ3ePtGULAtY6V75qjWE8UH4vCUVQ1W4HdCAZU");
 
 #[program]
 pub mod svmgov_program {

--- a/txtx.yml
+++ b/txtx.yml
@@ -1,0 +1,19 @@
+---
+name: program
+id: program
+runbooks:
+  - name: deployment
+    description: Deploy programs
+    location: runbooks/deployment
+environments:
+  localnet:
+      network_id: localnet
+      rpc_api_url: http://127.0.0.1:8899
+      squad_multisig_public_key: AYqpqhQxY5m3JT5J214jmvvpAuGSn5K7XeyXzpcGHDDh
+      proposer_keypair_json: ./proposer.json
+  mainnet:
+      network_id: mainnet
+      rpc_api_url: <RPC_URL>
+      squad_multisig_public_key: <>
+      payer_keypair_json: <>
+      proposer_keypair_json: <>


### PR DESCRIPTION
I went through a full admin dry run using squads multisigs for both programs:
 - deploy ncn + svmgov programs with txtx runbook
 - svmgov
   - `init-global-config`
   - `init-index`
   -  `show-global-config` and validate
   - `nominate-admin`
   - `accept-admin`
   - `update-global-config`
 - ncn
   - `init-program-config`
   - `update-program-config`
   - `update-operator-whitelist`
   - `update-program-config` to change admin
   - `finalize-proposed-authority`

That led to a few fixes in this PR.

I also took this opportunity to generate new program pubkeys for the final deployment.