### PR TITLE
fix(svmgov): prevent proposal backdating in flush_merkle_root and support_proposal

### DIFF
--- a/frontend/src/chain/idl/svmgov_program.json
+++ b/frontend/src/chain/idl/svmgov_program.json
@@ -1784,6 +1784,11 @@
       "code": 6052,
       "name": "NotPendingAdmin",
       "msg": "Signer is not the pending admin nominee"
+    },
+    {
+      "code": 6053,
+      "name": "InvalidBallotBox",
+      "msg": "Invalid ballot box: provided account does not match the expected BallotBox PDA for the snapshot slot"
     }
   ],
   "types": [

--- a/frontend/src/chain/idl/svmgov_program.json
+++ b/frontend/src/chain/idl/svmgov_program.json
@@ -656,7 +656,7 @@
         },
         {
           "name": "program",
-          "address": "4HarXuo8QjE5GSGzuUxHA1cnNM9mFt2th2JQAC5DSNqU"
+          "address": "govYkyQ3ePtGULAtY6V75qjWE8UH4vCUVQ1W4HdCAZU"
         },
         {
           "name": "program_data"
@@ -1789,6 +1789,11 @@
       "code": 6053,
       "name": "InvalidBallotBox",
       "msg": "Invalid ballot box: provided account does not match the expected BallotBox PDA for the snapshot slot"
+    },
+    {
+      "code": 6054,
+      "name": "SnapshotSlotNotInFuture",
+      "msg": "Snapshot slot must be in the future (greater than the current slot)"
     }
   ],
   "types": [

--- a/svmgov/cli/idls/svmgov_program.json
+++ b/svmgov/cli/idls/svmgov_program.json
@@ -1784,6 +1784,11 @@
       "code": 6052,
       "name": "NotPendingAdmin",
       "msg": "Signer is not the pending admin nominee"
+    },
+    {
+      "code": 6053,
+      "name": "InvalidBallotBox",
+      "msg": "Invalid ballot box: provided account does not match the expected BallotBox PDA for the snapshot slot"
     }
   ],
   "types": [

--- a/svmgov/cli/idls/svmgov_program.json
+++ b/svmgov/cli/idls/svmgov_program.json
@@ -656,7 +656,7 @@
         },
         {
           "name": "program",
-          "address": "4HarXuo8QjE5GSGzuUxHA1cnNM9mFt2th2JQAC5DSNqU"
+          "address": "govYkyQ3ePtGULAtY6V75qjWE8UH4vCUVQ1W4HdCAZU"
         },
         {
           "name": "program_data"
@@ -1789,6 +1789,11 @@
       "code": 6053,
       "name": "InvalidBallotBox",
       "msg": "Invalid ballot box: provided account does not match the expected BallotBox PDA for the snapshot slot"
+    },
+    {
+      "code": 6054,
+      "name": "SnapshotSlotNotInFuture",
+      "msg": "Snapshot slot must be in the future (greater than the current slot)"
     }
   ],
   "types": [

--- a/svmgov/program/programs/svmgov_program/src/error.rs
+++ b/svmgov/program/programs/svmgov_program/src/error.rs
@@ -114,4 +114,8 @@ pub enum GovernanceError {
     NoPendingAdmin,
     #[msg("Signer is not the pending admin nominee")]
     NotPendingAdmin,
+    #[msg(
+        "Invalid ballot box: provided account does not match the expected BallotBox PDA for the snapshot slot"
+    )]
+    InvalidBallotBox,
 }

--- a/svmgov/program/programs/svmgov_program/src/error.rs
+++ b/svmgov/program/programs/svmgov_program/src/error.rs
@@ -118,4 +118,6 @@ pub enum GovernanceError {
         "Invalid ballot box: provided account does not match the expected BallotBox PDA for the snapshot slot"
     )]
     InvalidBallotBox,
+    #[msg("Snapshot slot must be in the future (greater than the current slot)")]
+    SnapshotSlotNotInFuture,
 }

--- a/svmgov/program/programs/svmgov_program/src/instructions/flush_merkle_root.rs
+++ b/svmgov/program/programs/svmgov_program/src/instructions/flush_merkle_root.rs
@@ -2,7 +2,7 @@ use anchor_lang::{prelude::*, solana_program::vote};
 
 use crate::{
     error::GovernanceError, events::MerkleRootFlushed, state::{GlobalConfig, Proposal},
-    utils::get_epoch_slot_range,
+    utils::compute_future_snapshot_slot,
 };
 
 #[derive(Accounts)]
@@ -71,16 +71,29 @@ impl<'info> FlushMerkleRoot<'info> {
         // Recalculate snapshot_slot based on current epoch
         // Using the same logic as in support_proposal
         let target_epoch = clock.epoch + self.global_config.snapshot_epoch_extension;
-        let (start_slot, _) = get_epoch_slot_range(target_epoch);
-        let offset_result = (start_slot as i64)
-            .checked_add(self.global_config.snapshot_slot_offset)
-            .ok_or(GovernanceError::ArithmeticOverflow)?;
-        require!(offset_result >= 0, GovernanceError::ArithmeticOverflow);
-        let snapshot_slot = offset_result as u64;
-        self.proposal.snapshot_slot = snapshot_slot;
-        // start voting 1 epoch after snapshot
-        self.proposal.start_epoch = target_epoch + 1;
-        self.proposal.end_epoch = target_epoch + 1 + self.global_config.voting_epochs;
+        // SECURITY: enforce the future-slot invariant *before* mutating any proposal
+        // state. `init_ballot_box` below is skipped whenever `ballot_box` already
+        // exists, so this is the only place the `snapshot_slot > clock.slot` guard is
+        // guaranteed to run. Without it a proposal could be backdated onto an
+        // already-finalized ConsensusResult for a past slot.
+        let snapshot_slot = compute_future_snapshot_slot(
+            target_epoch,
+            self.global_config.snapshot_slot_offset,
+            clock.slot,
+        )?;
+
+        // SECURITY: bind `ballot_box` to the exact PDA implied by the recomputed
+        // snapshot slot so a caller cannot pass an arbitrary non-empty account to
+        // skip the init_ballot_box CPI (and its validation) below.
+        let (expected_ballot_box, _) = Pubkey::find_program_address(
+            &[b"BallotBox", &snapshot_slot.to_le_bytes()],
+            &self.ballot_program.key,
+        );
+        require_keys_eq!(
+            self.ballot_box.key(),
+            expected_ballot_box,
+            GovernanceError::InvalidBallotBox
+        );
 
         // Calculate new consensus_result PDA based on new snapshot_slot
         let (consensus_result_pda, _) = Pubkey::find_program_address(
@@ -88,6 +101,11 @@ impl<'info> FlushMerkleRoot<'info> {
             &self.ballot_program.key,
         );
 
+        // All validation passed; commit the recomputed lineage.
+        self.proposal.snapshot_slot = snapshot_slot;
+        // start voting 1 epoch after snapshot
+        self.proposal.start_epoch = target_epoch + 1;
+        self.proposal.end_epoch = target_epoch + 1 + self.global_config.voting_epochs;
         self.proposal.consensus_result = Some(consensus_result_pda);
 
         // Initialize ballot box if it doesn't exist

--- a/svmgov/program/programs/svmgov_program/src/instructions/support_proposal.rs
+++ b/svmgov/program/programs/svmgov_program/src/instructions/support_proposal.rs
@@ -12,7 +12,7 @@ use crate::{
     error::GovernanceError,
     events::ProposalSupported,
     state::{GlobalConfig, Proposal, Support},
-    utils::get_epoch_slot_range,
+    utils::compute_future_snapshot_slot,
 };
 
 #[derive(Accounts)]
@@ -133,27 +133,36 @@ impl<'info> SupportProposal<'info> {
             // this is for emit checks
             current_voting_emit = true;
 
-            let (start_slot, _) = get_epoch_slot_range(
-                clock.epoch
-                    + self.global_config.discussion_epochs
-                    + self.global_config.snapshot_epoch_extension,
+            let target_epoch = clock.epoch
+                + self.global_config.discussion_epochs
+                + self.global_config.snapshot_epoch_extension;
+            // SECURITY: enforce the future-slot invariant before mutating proposal
+            // state. The init_ballot_box CPI below is skipped whenever `ballot_box`
+            // already exists, so this re-check prevents a proposal from being bound
+            // onto an already-finalized ConsensusResult for a past slot.
+            snapshot_slot = compute_future_snapshot_slot(
+                target_epoch,
+                self.global_config.snapshot_slot_offset,
+                clock.slot,
+            )?;
+
+            // SECURITY: bind `ballot_box` to the exact PDA implied by the snapshot
+            // slot so a caller cannot pass an arbitrary non-empty account to skip
+            // the init_ballot_box CPI (and its validation) below.
+            let (expected_ballot_box, _) = Pubkey::find_program_address(
+                &[b"BallotBox", &snapshot_slot.to_le_bytes()],
+                &self.ballot_program.key,
             );
-            let offset_result = (start_slot as i64)
-                .checked_add(self.global_config.snapshot_slot_offset)
-                .ok_or(GovernanceError::ArithmeticOverflow)?;
-            require!(offset_result >= 0, GovernanceError::ArithmeticOverflow);
-            snapshot_slot = offset_result as u64;
+            require_keys_eq!(
+                self.ballot_box.key(),
+                expected_ballot_box,
+                GovernanceError::InvalidBallotBox
+            );
+
             // start voting 1 epoch after snapshot
             // checking in any vote or others is start_epoch <= current_epoch < end_epoch
-            proposal_account.start_epoch = clock.epoch
-                + self.global_config.discussion_epochs
-                + self.global_config.snapshot_epoch_extension
-                + 1;
-            proposal_account.end_epoch = clock.epoch
-                + self.global_config.discussion_epochs
-                + self.global_config.snapshot_epoch_extension
-                + 1
-                + self.global_config.voting_epochs;
+            proposal_account.start_epoch = target_epoch + 1;
+            proposal_account.end_epoch = target_epoch + 1 + self.global_config.voting_epochs;
             proposal_account.snapshot_slot = snapshot_slot; // 1000 slots into snapshot
 
             let (consensus_result_pda, _) = Pubkey::find_program_address(

--- a/svmgov/program/programs/svmgov_program/src/utils.rs
+++ b/svmgov/program/programs/svmgov_program/src/utils.rs
@@ -157,3 +157,106 @@ pub fn get_epoch_slot_range(epoch: u64) -> (u64, u64) {
 
     (start_slot, end_slot)
 }
+
+/// Computes the snapshot slot for a proposal's voting lineage from the snapshot
+/// `target_epoch` and the configured `snapshot_slot_offset`, enforcing that the
+/// resulting slot is strictly in the future relative to `current_slot`.
+///
+/// The `snapshot_slot > current_slot` invariant mirrors the guard inside
+/// `ncn_snapshot::init_ballot_box`. Both `support_proposal` and
+/// `flush_merkle_root` skip that CPI whenever the supplied `ballot_box` account
+/// already exists, so without re-checking here a caller could bind a proposal to
+/// an already-finalized `ConsensusResult` for a past slot (proposal backdating).
+///
+/// Returns the validated `snapshot_slot`, or an error if the offset underflows
+/// below zero or the resulting slot is not in the future.
+pub fn compute_future_snapshot_slot(
+    target_epoch: u64,
+    snapshot_slot_offset: i64,
+    current_slot: u64,
+) -> core::result::Result<u64, crate::error::GovernanceError> {
+    let (start_slot, _) = get_epoch_slot_range(target_epoch);
+    let offset_result = (start_slot as i64)
+        .checked_add(snapshot_slot_offset)
+        .ok_or(crate::error::GovernanceError::ArithmeticOverflow)?;
+    if offset_result < 0 {
+        return Err(crate::error::GovernanceError::ArithmeticOverflow);
+    }
+    let snapshot_slot = offset_result as u64;
+    if snapshot_slot <= current_slot {
+        return Err(crate::error::GovernanceError::InvalidSnapshotSlot);
+    }
+    Ok(snapshot_slot)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::error::GovernanceError;
+
+    #[test]
+    fn epoch_slot_range_is_correct() {
+        assert_eq!(get_epoch_slot_range(0), (0, 431_999));
+        assert_eq!(get_epoch_slot_range(1), (432_000, 863_999));
+    }
+
+    #[test]
+    fn future_snapshot_slot_accepts_future_slot() {
+        // Epoch 2 starts at slot 864_000; current slot is well before that.
+        assert_eq!(
+            compute_future_snapshot_slot(2, 0, 500_000).unwrap(),
+            864_000
+        );
+    }
+
+    #[test]
+    fn future_snapshot_slot_applies_positive_offset() {
+        assert_eq!(
+            compute_future_snapshot_slot(2, 100, 500_000).unwrap(),
+            864_100
+        );
+    }
+
+    #[test]
+    fn future_snapshot_slot_rejects_past_slot() {
+        // Recomputed snapshot slot (864_000) is behind the current slot.
+        assert!(matches!(
+            compute_future_snapshot_slot(2, 0, 900_000),
+            Err(GovernanceError::InvalidSnapshotSlot)
+        ));
+    }
+
+    #[test]
+    fn future_snapshot_slot_rejects_current_slot() {
+        // Must be strictly greater than the current slot, not equal to it.
+        assert!(matches!(
+            compute_future_snapshot_slot(2, 0, 864_000),
+            Err(GovernanceError::InvalidSnapshotSlot)
+        ));
+    }
+
+    #[test]
+    fn future_snapshot_slot_rejects_negative_offset_underflow() {
+        // A negative offset that drives the slot below zero is an overflow error.
+        assert!(matches!(
+            compute_future_snapshot_slot(0, -1, 0),
+            Err(GovernanceError::ArithmeticOverflow)
+        ));
+    }
+
+    #[test]
+    fn future_snapshot_slot_rejects_backdating_via_negative_offset() {
+        // Mirrors the reported exploit: a negative `snapshot_slot_offset` pulls the
+        // recomputed snapshot slot into an already-past slot. It must be rejected
+        // rather than silently accepted (which previously let a proposal bind onto
+        // a stale, already-finalized ConsensusResult by skipping init_ballot_box).
+        let target_epoch = 5;
+        let (start_slot, _) = get_epoch_slot_range(target_epoch); // 2_160_000
+        let current_slot = start_slot + 10; // we are already past the snapshot start
+        let offset = -20i64; // recomputed slot = start_slot - 20 < current_slot
+        assert!(matches!(
+            compute_future_snapshot_slot(target_epoch, offset, current_slot),
+            Err(GovernanceError::InvalidSnapshotSlot)
+        ));
+    }
+}

--- a/svmgov/program/programs/svmgov_program/src/utils.rs
+++ b/svmgov/program/programs/svmgov_program/src/utils.rs
@@ -184,7 +184,7 @@ pub fn compute_future_snapshot_slot(
     }
     let snapshot_slot = offset_result as u64;
     if snapshot_slot <= current_slot {
-        return Err(crate::error::GovernanceError::InvalidSnapshotSlot);
+        return Err(crate::error::GovernanceError::SnapshotSlotNotInFuture);
     }
     Ok(snapshot_slot)
 }
@@ -222,7 +222,7 @@ mod tests {
         // Recomputed snapshot slot (864_000) is behind the current slot.
         assert!(matches!(
             compute_future_snapshot_slot(2, 0, 900_000),
-            Err(GovernanceError::InvalidSnapshotSlot)
+            Err(GovernanceError::SnapshotSlotNotInFuture)
         ));
     }
 
@@ -231,7 +231,7 @@ mod tests {
         // Must be strictly greater than the current slot, not equal to it.
         assert!(matches!(
             compute_future_snapshot_slot(2, 0, 864_000),
-            Err(GovernanceError::InvalidSnapshotSlot)
+            Err(GovernanceError::SnapshotSlotNotInFuture)
         ));
     }
 
@@ -256,7 +256,7 @@ mod tests {
         let offset = -20i64; // recomputed slot = start_slot - 20 < current_slot
         assert!(matches!(
             compute_future_snapshot_slot(target_epoch, offset, current_slot),
-            Err(GovernanceError::InvalidSnapshotSlot)
+            Err(GovernanceError::SnapshotSlotNotInFuture)
         ));
     }
 }


### PR DESCRIPTION
## Summary

Fixes a proposal **backdating** vulnerability in the svmgov program.

`flush_merkle_root` recomputed a supported proposal's snapshot lineage and then
skipped the `ncn_snapshot::init_ballot_box` CPI whenever the supplied
`ballot_box` account was non-empty (`if self.ballot_box.data_is_empty()`).
Because `init_ballot_box` held the **only** `snapshot_slot > clock.slot` guard,
a proposal author could:

1. Pass an arbitrary non-empty account (e.g. another `Proposal` PDA) as
   `ballot_box`, skipping the CPI and its validation, and
2. Have the proposal's `snapshot_slot` / `consensus_result` recomputed onto an
   **already-past** slot when config (`snapshot_epoch_extension` /
   `snapshot_slot_offset`) lets the recomputed slot fall in the past.

The proposal then rebinds onto an already-finalized `ConsensusResult`, and
`cast_vote` later accepts proofs against that already-known meta-merkle root.

The sibling instruction `support_proposal` establishes the same lineage through
the identical unchecked-`ballot_box` / skip-CPI sink, so it is hardened the same
way to satisfy the invariant rather than only the reported entry point.

## Fix

For **both** lineage-setting instructions (`flush_merkle_root` and
`support_proposal`):

- **Enforce `snapshot_slot > clock.slot` before mutating any proposal state**,
  via a new `compute_future_snapshot_slot` helper. This mirrors the guard inside
  `ncn_snapshot::init_ballot_box`, so the future-slot invariant holds even when
  the CPI is skipped.
- **Bind `ballot_box` to the exact PDA** derived from the recomputed
  `snapshot_slot` (`require_keys_eq!` against
  `["BallotBox", snapshot_slot.to_le_bytes()]`), rejecting any arbitrary account
  used to skip the CPI.
- **Reorder writes** to `snapshot_slot`, `start_epoch`, `end_epoch`, and
  `consensus_result` so they only happen **after** validation succeeds.

Adds the `InvalidBallotBox` error (appended to the enum to preserve existing
error-code numbers) and updates the committed IDLs accordingly.

## Compatibility

No legitimate flow is affected. Any honest call already targets a future
snapshot slot — the `init_ballot_box` CPI would otherwise reject a past slot at
creation time — and honest callers always pass the correct `BallotBox` PDA
(required for the `init` CPI to succeed). The new checks only reject the exploit
path (skipping the CPI with a stale slot and/or a mismatched `ballot_box`), so
no previously valid request becomes invalid.

## Testing

- `cargo test -p svmgov_program --lib` — added unit tests for
  `compute_future_snapshot_slot` covering the accepted future-slot case, the
  positive-offset case, equal-to-current rejection, past-slot rejection,
  negative-offset underflow, and the exploit's
  backdating-via-negative-offset rejection. All 8 lib tests pass.
- `cargo build -p svmgov_program` — clean, no new warnings.

<!-- apex-fix-review:eyJ2IjoidjEiLCJoIjoiYTIzMjk2YWItNzc5Ny00ZDMxLWEzMjMtMDczMGIyNWFjMmU4IiwiZiI6ImU0MDhmZTYxLTEwMjQtNDk1Yy04MmYzLTQ0MWFhYjM5NjdmNyIsImUiOjE3ODI1MDIyNzN9.37okri0L8CKsHOGxTtFuT5fTs-gAi4JNth0M96BUUDU -->
