### PR TITLE
fix(verifier): bind uploads to snapshot bytes

### DIFF
--- a/ncn/cli/src/lib.rs
+++ b/ncn/cli/src/lib.rs
@@ -6,25 +6,39 @@ use crate::consts::{MARINADE_OPS_VOTING_WALLET, MARINADE_WITHDRAW_AUTHORITY};
 use im::HashMap;
 pub use merkle::*;
 
+use anchor_lang::prelude::Pubkey as AnchorPubkey;
 use anyhow::Error;
 use borsh_stake::BorshDeserialize;
-use ncn_snapshot::{MetaMerkleLeaf, StakeMerkleLeaf};
 use itertools::Itertools;
 use meta_merkle_tree::{
     generated_merkle_tree::Delegation, merkle_tree::MerkleTree, utils::get_proof,
 };
-use anchor_lang::prelude::Pubkey as AnchorPubkey;
+use ncn_snapshot::{MetaMerkleLeaf, StakeMerkleLeaf};
 use solana_program::pubkey::Pubkey;
-use solana_stake_interface::stake_history::StakeHistory;
-use solana_stake_interface::sysvar::stake_history;
 use solana_runtime::{bank::Bank, stakes::StakeAccount};
 use solana_sdk::account::from_account;
 use solana_sdk::account::AccountSharedData;
 use solana_sdk::account::ReadableAccount;
+use solana_stake_interface::stake_history::StakeHistory;
+use solana_stake_interface::sysvar::stake_history;
 use spl_stake_pool::find_withdraw_authority_program_address;
 use spl_stake_pool::state::AccountType;
 use spl_stake_pool::state::StakePool;
 use std::sync::Arc;
+
+pub fn upload_signature_message(
+    slot: u64,
+    network: &str,
+    merkle_root: &str,
+    snapshot_hash: &str,
+) -> Vec<u8> {
+    let mut message = Vec::new();
+    message.extend_from_slice(&slot.to_le_bytes());
+    message.extend_from_slice(network.as_bytes());
+    message.extend_from_slice(merkle_root.as_bytes());
+    message.extend_from_slice(snapshot_hash.as_bytes());
+    message
+}
 
 fn to_anchor_pubkey(pubkey: Pubkey) -> AnchorPubkey {
     AnchorPubkey::from(pubkey.to_bytes())
@@ -50,8 +64,7 @@ fn group_delegations_by_voter_pubkey_active_stake(
     bank: &Bank,
 ) -> im::HashMap<Pubkey, Vec<Delegation>> {
     let stake_history =
-        from_account::<StakeHistory, _>(&bank.get_account(&stake_history::id()).unwrap())
-            .unwrap();
+        from_account::<StakeHistory, _>(&bank.get_account(&stake_history::id()).unwrap()).unwrap();
     let grouped = delegations
         .iter()
         .filter_map(|(stake_pubkey, stake_account)| {
@@ -105,8 +118,10 @@ fn update_stake_pool_voter_map(
     }
 
     if let Ok(stake_pool) = StakePool::deserialize(&mut &account.data()[..]) {
-        let (withdraw_authority, _) =
-            find_withdraw_authority_program_address(&spl_stake_pool::id(), &to_anchor_pubkey(*stake_pool_pubkey));
+        let (withdraw_authority, _) = find_withdraw_authority_program_address(
+            &spl_stake_pool::id(),
+            &to_anchor_pubkey(*stake_pool_pubkey),
+        );
         if stake_pool.manager == AnchorPubkey::default() {
             return;
         }

--- a/ncn/cli/src/main.rs
+++ b/ncn/cli/src/main.rs
@@ -194,17 +194,21 @@ pub enum Commands {
         )]
         save_path: PathBuf,
     },
-    /// Print the merkle root, snapshot hash, and a signature over them from a
+    /// Print the merkle root, snapshot hash, and upload signature for a
     /// MetaMerkleSnapshot file.
     ///
     /// Useful for sharing the snapshot identity with other operators before
     /// voting on-chain. `--authority-path` signs an off-chain message
-    /// containing the snapshot slot and meta merkle root; no on-chain
-    /// transaction is sent.
+    /// containing the snapshot slot, verifier network, meta merkle root, and
+    /// snapshot hash; no on-chain transaction is sent.
     LogMetaMerkleHash {
         /// Path to a MetaMerkleSnapshot file (compressed `.zip` or raw).
         #[arg(long, env, help = "Path to the MetaMerkleSnapshot file to read")]
         read_path: PathBuf,
+
+        /// Verifier-service network namespace that this upload will target.
+        #[arg(long, env, default_value = "mainnet", value_parser = parse_verifier_network)]
+        network: String,
 
         /// Whether the input file is the compressed `.zip` produced by
         /// `generate-meta-merkle`.
@@ -780,7 +784,7 @@ fn main() -> Result<()> {
         Some(format!(
             "The `{}` command requires {}. A Squads vault PDA cannot satisfy this on-chain \
              check, so no vault transaction was created. Re-run without --squads to submit this transaction with your local keypair.",
-            name, constraint, 
+            name, constraint,
         ))
     }
 
@@ -1244,6 +1248,7 @@ fn main() -> Result<()> {
         }
         Commands::LogMetaMerkleHash {
             read_path,
+            network,
             is_compressed,
         } => {
             let authority = read_signer_keypair(&cli.authority_path, "--authority-path")
@@ -1254,13 +1259,17 @@ fn main() -> Result<()> {
             let encoded_root = bs58::encode(snapshot.root).into_string();
             let encoded_hash = bs58::encode(snapshot_hash.to_bytes()).into_string();
 
-            let mut message = Vec::new();
-            message.extend_from_slice(&snapshot.slot.to_le_bytes());
-            message.extend_from_slice(&encoded_root.as_bytes());
+            let message = cli::upload_signature_message(
+                snapshot.slot,
+                &network,
+                &encoded_root,
+                &encoded_hash,
+            );
             let signature = authority.sign_message(&message);
 
             println!("Signature: {}", bs58::encode(signature).into_string());
             println!("Slot: {}", snapshot.slot);
+            println!("Network: {}", network);
             println!("Merkle Root: {}", encoded_root);
             println!("Snapshot Hash: {}", encoded_hash);
         }

--- a/ncn/cli/src/merkle.rs
+++ b/ncn/cli/src/merkle.rs
@@ -1,8 +1,8 @@
+use crate::utils::{decompress_gzip_with_limit, max_snapshot_bytes, read_all_with_limit};
 use borsh::{BorshDeserialize, BorshSerialize};
 use flate2::{write::GzEncoder, Compression};
-use ncn_snapshot::{MetaMerkleLeaf, StakeMerkleLeaf};
-use crate::utils::{decompress_gzip_with_limit, max_snapshot_bytes, read_all_with_limit};
 use meta_merkle_tree::{merkle_tree::MerkleTree, utils::get_proof};
+use ncn_snapshot::{MetaMerkleLeaf, StakeMerkleLeaf};
 use solana_sdk::hash::{hash, Hash};
 use std::fs::File;
 use std::io::{self, Write};
@@ -19,12 +19,19 @@ pub struct MetaMerkleSnapshot {
 }
 
 impl MetaMerkleSnapshot {
-    pub fn save_compressed(&self, path: PathBuf) -> io::Result<()> {
+    pub fn to_compressed_bytes(&self) -> io::Result<Vec<u8>> {
         let data = self.try_to_vec()?;
-        let file = File::create(path)?;
-        let mut enc = GzEncoder::new(file, Compression::default());
+        let mut enc = GzEncoder::new(Vec::new(), Compression::default());
         enc.write_all(&data)?;
-        enc.finish()?;
+        enc.finish()
+    }
+
+    pub fn save_compressed(&self, path: PathBuf) -> io::Result<()> {
+        let data = self.to_compressed_bytes()?;
+        let file = File::create(path)?;
+        let mut writer = io::BufWriter::new(file);
+        writer.write_all(&data)?;
+        writer.flush()?;
 
         Ok(())
     }

--- a/ncn/cli/src/utils/parsers.rs
+++ b/ncn/cli/src/utils/parsers.rs
@@ -30,6 +30,16 @@ pub fn parse_log_type(s: &str) -> Result<LogType, String> {
     }
 }
 
+pub fn parse_verifier_network(s: &str) -> Result<String, String> {
+    match s {
+        "devnet" | "testnet" | "mainnet" => Ok(s.to_string()),
+        _ => Err(format!(
+            "invalid verifier network '{}'. Must be one of: devnet, testnet, mainnet",
+            s
+        )),
+    }
+}
+
 #[derive(Clone, Debug)]
 pub enum LogType {
     ProgramConfig,

--- a/ncn/verifier-service/README.md
+++ b/ncn/verifier-service/README.md
@@ -42,7 +42,8 @@ DB_PATH=":memory:" RUST_LOG=info cargo run --bin verifier-service
 The `/upload` endpoint requires Ed25519 signature verification to prevent unauthorized snapshot uploads:
 
 - **Environment Variable**: Set `OPERATOR_PUBKEY` to the base58-encoded public key of the authorized operator
-- **Message Format**: Signatures are verified over `slot.to_le_bytes() || merkle_root_bs58_string.as_bytes()`
+- **Message Format**: Signatures are verified over `slot.to_le_bytes() || network.as_bytes() || merkle_root_bs58_string.as_bytes() || snapshot_hash_bs58_string.as_bytes()`
+- **Upload Fields**: Include `snapshot_hash` as a multipart text field before the file part. The server verifies the signature first, then recomputes the uploaded file hash and rejects mismatches.
 - **Signature Format**: Base58-encoded Ed25519 signature
 
 ### Admin Endpoint Authentication
@@ -123,11 +124,22 @@ Environment variables:
 
 To test the upload endpoint with a snapshot (replace fields with actual values):
 
+Generate the signature with the same verifier network namespace used in the upload form:
+
+```bash
+cargo run -p cli -- \
+  --authority-path ./operator-keypair.json \
+  log-meta-merkle-hash \
+  --read-path ./meta_merkle-340850340.zip \
+  --network testnet
+```
+
 ```bash
 curl -X POST http://localhost:3000/upload \
   -F "slot=340850340" \
   -F "network=testnet" \
   -F "merkle_root=34sfrZPCyuLXsq5v1ybahTVSwQQE6A3VJyr9JcgxsW21" \
+  -F "snapshot_hash=2ejpKvga5pGMyQGhmi59U6PThwKFzLy8SAjxt5yG8raH" \
   -F "signature=3nn1EGUqZ5GSXgfAs86miP4z5HtVdKYdQeDdhm1p2M5XxfK16cxwBJYonFdN4BDT7qzpx6TyEhHUrnF2Bh7wGm71" \
   -F "file=@meta_merkle-340850340.zip" \
   -w "\nHTTP Status: %{http_code}\n" \

--- a/ncn/verifier-service/src/upload.rs
+++ b/ncn/verifier-service/src/upload.rs
@@ -8,12 +8,11 @@ use axum::{
     http::StatusCode,
     response::Json,
 };
-use cli::MetaMerkleSnapshot;
+use cli::{upload_signature_message, MetaMerkleSnapshot};
 use meta_merkle_tree::{merkle_tree::MerkleTree, utils::get_proof};
 use serde_json::{json, Value};
 use solana_sdk::{pubkey::Pubkey, signature::Signature};
 use sqlx::sqlite::SqlitePool;
-use sqlx::Acquire;
 use tracing::{debug, info};
 
 use crate::database::models::{SnapshotMetaRecord, StakeAccountRecord, VoteAccountRecord};
@@ -28,7 +27,7 @@ pub async fn handle_upload(
     info!("POST /upload - Snapshot upload requested");
 
     // 1. Extract metadata fields first.
-    let (slot, network, merkle_root, signature) =
+    let (slot, network, merkle_root, provided_snapshot_hash, signature) =
         extract_metadata_only(&mut multipart).await.map_err(|e| {
             info!("Failed to extract metadata: {}", e);
             metrics::record_upload_outcome(metrics::UploadOutcome::BadRequest);
@@ -41,15 +40,23 @@ pub async fn handle_upload(
         return Err(e);
     }
 
-    // 3: Verify signature over slot || merkle_root_bs58_bytes
-    verify_signature(&slot, &merkle_root, &signature).map_err(|e| {
+    // 3. Verify signature over slot || network || merkle_root || snapshot_hash before
+    // touching the file body.
+    verify_signature(
+        &slot,
+        &network,
+        &merkle_root,
+        &provided_snapshot_hash,
+        &signature,
+    )
+    .map_err(|e| {
         info!("Signature verification failed: {}", e);
         metrics::record_upload_outcome(metrics::UploadOutcome::Unauthorized);
         StatusCode::UNAUTHORIZED
     })?;
     info!(
-        "Verified upload request: slot={}, merkle_root={}, signature={}",
-        slot, merkle_root, signature
+        "Verified upload request: slot={}, network={}, merkle_root={}, snapshot_hash={}",
+        slot, network, merkle_root, provided_snapshot_hash
     );
 
     // 4. Load the file.
@@ -58,27 +65,34 @@ pub async fn handle_upload(
         metrics::record_upload_outcome(metrics::UploadOutcome::BadRequest);
         StatusCode::BAD_REQUEST
     })?;
-    info!(
-        "Signature verified, processing file ({} bytes)",
-        file_data.len()
-    );
+    info!("Processing upload file ({} bytes)", file_data.len());
 
-    // 5. Parse snapshot file, verify merkle_root and slot from request fields.
-    let (snapshot, snapshot_hash) = MetaMerkleSnapshot::read_from_bytes_with_hash(file_data, true)
-        .map_err(|e| {
+    // 5. Parse snapshot file and verify it matches the signed request fields.
+    let (snapshot, computed_snapshot_hash) =
+        MetaMerkleSnapshot::read_from_bytes_with_hash(file_data, true).map_err(|e| {
             info!("Failed to read snapshot: {}", e);
             metrics::record_upload_outcome(metrics::UploadOutcome::BadRequest);
             StatusCode::BAD_REQUEST
         })?;
-    let encoded_hash = bs58::encode(snapshot_hash).into_string();
+    let encoded_hash = bs58::encode(computed_snapshot_hash).into_string();
 
-    if bs58::encode(snapshot.root).into_string() != merkle_root || snapshot.slot != slot {
-        info!("Merkle root or slot in snapshot mismatch");
+    if bs58::encode(snapshot.root).into_string() != merkle_root
+        || snapshot.slot != slot
+        || encoded_hash != provided_snapshot_hash
+    {
+        info!("Merkle root, slot, or snapshot hash mismatch");
         metrics::record_upload_outcome(metrics::UploadOutcome::BadRequest);
         return Err(StatusCode::BAD_REQUEST);
     }
 
-    // 6. Index data in database
+    // 6. Reject snapshots whose bundled stake leaves do not match the signed meta leaves.
+    validate_stake_merkle_roots(&snapshot).map_err(|e| {
+        info!("Invalid stake merkle root: {}", e);
+        metrics::record_upload_outcome(metrics::UploadOutcome::BadRequest);
+        StatusCode::BAD_REQUEST
+    })?;
+
+    // 7. Index data in database
     index_snapshot_data(&pool, &snapshot, &network, &merkle_root, &encoded_hash)
         .await
         .map_err(|e| {
@@ -94,6 +108,34 @@ pub async fn handle_upload(
         "slot": slot,
         "merkle_root": merkle_root,
     })))
+}
+
+fn validate_stake_merkle_roots(snapshot: &MetaMerkleSnapshot) -> Result<()> {
+    for (bundle_idx, bundle) in snapshot.leaf_bundles.iter().enumerate() {
+        let derived_root = derive_stake_merkle_root(&bundle.stake_merkle_leaves)
+            .ok_or_else(|| anyhow::anyhow!("bundle {} has no stake merkle root", bundle_idx))?;
+
+        if derived_root != bundle.meta_merkle_leaf.stake_merkle_root {
+            return Err(anyhow::anyhow!(
+                "bundle {} stake root mismatch for vote account {}",
+                bundle_idx,
+                bundle.meta_merkle_leaf.vote_account
+            ));
+        }
+    }
+
+    Ok(())
+}
+
+fn derive_stake_merkle_root(
+    stake_merkle_leaves: &[ncn_snapshot::StakeMerkleLeaf],
+) -> Option<[u8; 32]> {
+    let hashed_nodes: Vec<[u8; 32]> = stake_merkle_leaves
+        .iter()
+        .map(|n| n.hash().to_bytes())
+        .collect();
+    let stake_merkle = MerkleTree::new(&hashed_nodes[..], true);
+    stake_merkle.get_root().map(|root| root.to_bytes())
 }
 
 /// Index snapshot data in the database
@@ -196,7 +238,9 @@ async fn index_snapshot_data(
 }
 
 /// Extract metadata fields in sequence.
-async fn extract_metadata_only(multipart: &mut Multipart) -> Result<(u64, String, String, String)> {
+async fn extract_metadata_only(
+    multipart: &mut Multipart,
+) -> Result<(u64, String, String, String, String)> {
     macro_rules! extract_field {
         ($name:expr) => {
             multipart
@@ -211,8 +255,9 @@ async fn extract_metadata_only(multipart: &mut Multipart) -> Result<(u64, String
     let slot = extract_field!("slot").parse()?;
     let network = extract_field!("network");
     let merkle_root = extract_field!("merkle_root");
+    let snapshot_hash = extract_field!("snapshot_hash");
     let signature = extract_field!("signature");
-    Ok((slot, network, merkle_root, signature))
+    Ok((slot, network, merkle_root, snapshot_hash, signature))
 }
 
 /// Extract the remaining file field (after metadata extraction).
@@ -226,16 +271,20 @@ async fn extract_remaining_file(multipart: &mut Multipart) -> Result<Vec<u8>> {
         .to_vec())
 }
 
-/// Verify Ed25519 signature over slot || merkle_root_bs58_bytes
-fn verify_signature(slot: &u64, merkle_root: &str, signature: &str) -> Result<()> {
+/// Verify Ed25519 signature over slot || network || merkle_root || snapshot_hash.
+fn verify_signature(
+    slot: &u64,
+    network: &str,
+    merkle_root: &str,
+    snapshot_hash: &str,
+    signature: &str,
+) -> Result<()> {
     // Get operator pubkey from environment variable
     let operator_pubkey_str = std::env::var("OPERATOR_PUBKEY")
         .map_err(|_| anyhow::anyhow!("OPERATOR_PUBKEY env not set"))?;
     let operator_pubkey = Pubkey::from_str(&operator_pubkey_str)?;
 
-    let mut message = Vec::new();
-    message.extend_from_slice(&slot.to_le_bytes());
-    message.extend_from_slice(merkle_root.as_bytes());
+    let message = upload_signature_message(*slot, network, merkle_root, snapshot_hash);
 
     let signature = Signature::from_str(signature)?;
     if !signature.verify(&operator_pubkey.to_bytes(), &message) {
@@ -248,12 +297,17 @@ fn verify_signature(slot: &u64, merkle_root: &str, signature: &str) -> Result<()
 #[cfg(test)]
 mod tests {
     use super::*;
+    use anchor_lang::prelude::Pubkey as AnchorPubkey;
     use solana_sdk::{signature::Keypair, signer::Signer};
     use std::env;
 
     const SLOT1: u64 = 12345;
+    const NETWORK1: &str = "testnet";
+    const NETWORK2: &str = "mainnet";
     const ROOT1: &str = "test_merkle_root_hash";
     const ROOT2: &str = "different_merkle_root_hash";
+    const HASH1: &str = "test_snapshot_hash";
+    const HASH2: &str = "different_snapshot_hash";
 
     /// Helper to set up environment
     fn setup_env(pubkey: &str) {
@@ -261,13 +315,15 @@ mod tests {
     }
 
     /// Helper to create keypair and sign message
-    fn create_signed_message(slot: u64, merkle_root: &str) -> (Keypair, String) {
+    fn create_signed_message(
+        slot: u64,
+        network: &str,
+        merkle_root: &str,
+        snapshot_hash: &str,
+    ) -> (Keypair, String) {
         let keypair = Keypair::new();
 
-        let mut message = Vec::new();
-        message.extend_from_slice(&slot.to_le_bytes());
-        message.extend_from_slice(merkle_root.as_bytes());
-
+        let message = upload_signature_message(slot, network, merkle_root, snapshot_hash);
         let signature = keypair.sign_message(&message);
         (keypair, signature.to_string())
     }
@@ -275,21 +331,21 @@ mod tests {
     #[test]
     #[serial_test::serial]
     fn test_verify_signature_success() {
-        let (keypair, signature) = create_signed_message(SLOT1, ROOT1);
+        let (keypair, signature) = create_signed_message(SLOT1, NETWORK1, ROOT1, HASH1);
         setup_env(&keypair.pubkey().to_string());
 
-        let result = verify_signature(&SLOT1, ROOT1, &signature);
+        let result = verify_signature(&SLOT1, NETWORK1, ROOT1, HASH1, &signature);
         assert!(result.is_ok(), "Verification should succeed");
     }
 
     #[test]
     #[serial_test::serial]
     fn test_verify_signature_invalid_signature() {
-        let (keypair, _) = create_signed_message(SLOT1, ROOT1);
-        let (_, wrong_signature) = create_signed_message(SLOT1, ROOT1);
+        let (keypair, _) = create_signed_message(SLOT1, NETWORK1, ROOT1, HASH1);
+        let (_, wrong_signature) = create_signed_message(SLOT1, NETWORK1, ROOT1, HASH1);
         setup_env(&keypair.pubkey().to_string());
 
-        let result = verify_signature(&SLOT1, ROOT1, &wrong_signature);
+        let result = verify_signature(&SLOT1, NETWORK1, ROOT1, HASH1, &wrong_signature);
         assert!(
             result.is_err(),
             "Verification should fail with wrong signature"
@@ -301,7 +357,7 @@ mod tests {
     fn test_verify_signature_missing_env_var() {
         env::remove_var("OPERATOR_PUBKEY");
 
-        let result = verify_signature(&SLOT1, ROOT1, "dummy");
+        let result = verify_signature(&SLOT1, NETWORK1, ROOT1, HASH1, "dummy");
         assert!(result.is_err());
         assert!(result
             .unwrap_err()
@@ -312,10 +368,47 @@ mod tests {
     #[test]
     #[serial_test::serial]
     fn test_verify_signature_different_message() {
-        let (keypair, signature) = create_signed_message(SLOT1, ROOT1);
+        let (keypair, signature) = create_signed_message(SLOT1, NETWORK1, ROOT1, HASH1);
         setup_env(&keypair.pubkey().to_string());
 
-        let result = verify_signature(&SLOT1, ROOT2, &signature);
-        assert!(result.is_err(), "Should fail with different message");
+        let result = verify_signature(&SLOT1, NETWORK1, ROOT2, HASH1, &signature);
+        assert!(result.is_err(), "Should fail with different merkle root");
+
+        let result = verify_signature(&SLOT1, NETWORK2, ROOT1, HASH1, &signature);
+        assert!(result.is_err(), "Should fail with different network");
+
+        let result = verify_signature(&SLOT1, NETWORK1, ROOT1, HASH2, &signature);
+        assert!(result.is_err(), "Should fail with different snapshot hash");
+    }
+
+    #[test]
+    fn test_validate_stake_merkle_roots_rejects_incoherent_bundle() {
+        let stake_leaf = ncn_snapshot::StakeMerkleLeaf {
+            voting_wallet: AnchorPubkey::new_unique(),
+            stake_account: AnchorPubkey::new_unique(),
+            active_stake: 10,
+        };
+        let stake_merkle_root = derive_stake_merkle_root(std::slice::from_ref(&stake_leaf))
+            .expect("stake root should be derived");
+        let snapshot = MetaMerkleSnapshot {
+            root: [0; 32],
+            leaf_bundles: vec![cli::MetaMerkleLeafBundle {
+                meta_merkle_leaf: ncn_snapshot::MetaMerkleLeaf {
+                    voting_wallet: AnchorPubkey::new_unique(),
+                    vote_account: AnchorPubkey::new_unique(),
+                    stake_merkle_root,
+                    active_stake: stake_leaf.active_stake,
+                },
+                stake_merkle_leaves: vec![ncn_snapshot::StakeMerkleLeaf {
+                    active_stake: stake_leaf.active_stake + 1,
+                    ..stake_leaf
+                }],
+                proof: None,
+            }],
+            slot: SLOT1,
+        };
+
+        let result = validate_stake_merkle_roots(&snapshot);
+        assert!(result.is_err(), "incoherent stake roots must be rejected");
     }
 }

--- a/ncn/verifier-service/tests/common/mod.rs
+++ b/ncn/verifier-service/tests/common/mod.rs
@@ -88,6 +88,7 @@ pub async fn setup_server(keypair: &Keypair) -> anyhow::Result<(String, ChildGua
         .env("DB_PATH", ":memory:")
         .env("PORT", port.to_string())
         .env("RUST_LOG", "info")
+        .env("UPLOAD_RATE_BURST", "10")
         .env("UPLOAD_BODY_LIMIT", (512 * 1024 * 1024).to_string())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())

--- a/ncn/verifier-service/tests/e2e_binary.rs
+++ b/ncn/verifier-service/tests/e2e_binary.rs
@@ -7,6 +7,19 @@ use reqwest::{
 };
 use solana_sdk::{signature::Keypair, signer::Signer};
 
+const NETWORK: &str = "testnet";
+
+fn sign_upload_message(
+    keypair: &Keypair,
+    slot: u64,
+    network: &str,
+    merkle_root: &str,
+    snapshot_hash: &str,
+) -> String {
+    let message = cli::upload_signature_message(slot, network, merkle_root, snapshot_hash);
+    keypair.sign_message(&message).to_string()
+}
+
 #[tokio::test]
 #[serial_test::serial]
 async fn e2e_binary_endpoints() -> anyhow::Result<()> {
@@ -23,12 +36,8 @@ async fn e2e_binary_endpoints() -> anyhow::Result<()> {
         cli::MetaMerkleSnapshot::read_from_bytes_with_hash(bytes.clone(), true)?;
     let slot = snapshot.slot;
     let merkle_root = bs58::encode(snapshot.root).into_string();
-
-    // Build signature over slot || merkle_root
-    let mut message = Vec::new();
-    message.extend_from_slice(&slot.to_le_bytes());
-    message.extend_from_slice(merkle_root.as_bytes());
-    let signature = keypair.sign_message(&message).to_string();
+    let encoded_hash = bs58::encode(snapshot_hash.to_bytes()).into_string();
+    let signature = sign_upload_message(&keypair, slot, NETWORK, &merkle_root, &encoded_hash);
 
     // Test GET /healthz
     let client = reqwest::Client::new();
@@ -38,8 +47,9 @@ async fn e2e_binary_endpoints() -> anyhow::Result<()> {
     // Test POST /upload
     let form = Form::new()
         .text("slot", slot.to_string())
-        .text("network", "testnet")
+        .text("network", NETWORK)
         .text("merkle_root", merkle_root.clone())
+        .text("snapshot_hash", encoded_hash.clone())
         .text("signature", signature)
         .part("file", Part::bytes(bytes).file_name("meta_merkle.bin"));
 
@@ -67,7 +77,7 @@ async fn e2e_binary_endpoints() -> anyhow::Result<()> {
         "network": "testnet",
         "slot": slot,
         "merkle_root": merkle_root,
-        "snapshot_hash": bs58::encode(snapshot_hash.to_bytes()).into_string(),
+        "snapshot_hash": encoded_hash,
         "created_at": meta["created_at"],
     });
     assert_eq!(meta, expected_meta);
@@ -203,4 +213,131 @@ async fn e2e_binary_endpoints() -> anyhow::Result<()> {
     assert!(not_found.is_empty());
 
     Ok(())
+}
+
+#[tokio::test]
+#[serial_test::serial]
+async fn e2e_rejects_replayed_signature_and_incoherent_stake_root() -> anyhow::Result<()> {
+    let keypair = Keypair::new();
+    let (base_url, _guard) = setup_server(&keypair).await?;
+
+    let snapshot_path = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .unwrap()
+        .join("tests/src/fixtures/meta_merkle_340850340.zip");
+    let honest_bytes = tokio::fs::read(&snapshot_path).await?;
+    let (honest_snapshot, honest_snapshot_hash) =
+        cli::MetaMerkleSnapshot::read_from_bytes_with_hash(honest_bytes.clone(), true)?;
+    let slot = honest_snapshot.slot;
+    let merkle_root = bs58::encode(honest_snapshot.root).into_string();
+    let honest_hash = bs58::encode(honest_snapshot_hash.to_bytes()).into_string();
+    let honest_signature = sign_upload_message(&keypair, slot, NETWORK, &merkle_root, &honest_hash);
+    let client = reqwest::Client::new();
+
+    let wrong_signature =
+        sign_upload_message(&Keypair::new(), slot, NETWORK, &merkle_root, &honest_hash);
+    let unauthorized_upload = Form::new()
+        .text("slot", slot.to_string())
+        .text("network", NETWORK)
+        .text("merkle_root", merkle_root.clone())
+        .text("snapshot_hash", honest_hash.clone())
+        .text("signature", wrong_signature)
+        .part(
+            "file",
+            Part::bytes(b"not a snapshot".to_vec()).file_name("invalid_snapshot.zip"),
+        );
+    let unauthorized_response = client
+        .post(format!("{}/upload", base_url))
+        .multipart(unauthorized_upload)
+        .send()
+        .await?;
+    assert_eq!(unauthorized_response.status(), StatusCode::UNAUTHORIZED);
+
+    let honest_upload = Form::new()
+        .text("slot", slot.to_string())
+        .text("network", NETWORK)
+        .text("merkle_root", merkle_root.clone())
+        .text("snapshot_hash", honest_hash.clone())
+        .text("signature", honest_signature.clone())
+        .part(
+            "file",
+            Part::bytes(honest_bytes).file_name("honest_snapshot.zip"),
+        );
+    let honest_response = client
+        .post(format!("{}/upload", base_url))
+        .multipart(honest_upload)
+        .send()
+        .await?;
+    assert!(
+        honest_response.status().is_success(),
+        "honest upload failed with {}",
+        honest_response.status()
+    );
+
+    let honest_meta: serde_json::Value = client
+        .get(format!("{}/meta?network={}", base_url, NETWORK))
+        .send()
+        .await?
+        .error_for_status()?
+        .json()
+        .await?;
+    assert_eq!(honest_meta["snapshot_hash"], honest_hash);
+
+    let mut tampered_snapshot = honest_snapshot;
+    tampered_snapshot.leaf_bundles[0].stake_merkle_leaves[0].active_stake += 1;
+    let tampered_bytes = encode_snapshot(&tampered_snapshot)?;
+    let (_, tampered_snapshot_hash) =
+        cli::MetaMerkleSnapshot::read_from_bytes_with_hash(tampered_bytes.clone(), true)?;
+    let tampered_hash = bs58::encode(tampered_snapshot_hash.to_bytes()).into_string();
+
+    let replay_upload = Form::new()
+        .text("slot", slot.to_string())
+        .text("network", NETWORK)
+        .text("merkle_root", merkle_root.clone())
+        .text("snapshot_hash", honest_hash)
+        .text("signature", honest_signature)
+        .part(
+            "file",
+            Part::bytes(tampered_bytes.clone()).file_name("replayed_snapshot.zip"),
+        );
+    let replay_response = client
+        .post(format!("{}/upload", base_url))
+        .multipart(replay_upload)
+        .send()
+        .await?;
+    assert_eq!(replay_response.status(), StatusCode::BAD_REQUEST);
+
+    let tampered_signature =
+        sign_upload_message(&keypair, slot, NETWORK, &merkle_root, &tampered_hash);
+    let incoherent_upload = Form::new()
+        .text("slot", slot.to_string())
+        .text("network", NETWORK)
+        .text("merkle_root", merkle_root.clone())
+        .text("snapshot_hash", tampered_hash)
+        .text("signature", tampered_signature)
+        .part(
+            "file",
+            Part::bytes(tampered_bytes).file_name("incoherent_snapshot.zip"),
+        );
+    let incoherent_response = client
+        .post(format!("{}/upload", base_url))
+        .multipart(incoherent_upload)
+        .send()
+        .await?;
+    assert_eq!(incoherent_response.status(), StatusCode::BAD_REQUEST);
+
+    let final_meta: serde_json::Value = client
+        .get(format!("{}/meta?network={}", base_url, NETWORK))
+        .send()
+        .await?
+        .error_for_status()?
+        .json()
+        .await?;
+    assert_eq!(final_meta["snapshot_hash"], honest_meta["snapshot_hash"]);
+
+    Ok(())
+}
+
+fn encode_snapshot(snapshot: &cli::MetaMerkleSnapshot) -> anyhow::Result<Vec<u8>> {
+    Ok(snapshot.to_compressed_bytes()?)
 }


### PR DESCRIPTION
## Summary
- Bind upload signatures to `slot || network || merkle_root || snapshot_hash` so the operator authorizes the exact snapshot identity before file processing.
- Reject uploads before indexing when any bundle's rebuilt stake merkle root differs from its meta leaf `stake_merkle_root`.
- Update the CLI signature output, verifier docs, and e2e coverage for the tightened upload contract.

## Test Plan
- `cargo test -p verifier-service upload::tests -- --nocapture`
- `cargo test -p verifier-service --test e2e_binary -- --nocapture`
- `cargo check -p cli`

## Compatibility
- Upload clients must include `snapshot_hash` as a pre-file multipart text field and regenerate signatures with the verifier network and snapshot hash. The proof API responses are unchanged.

<!-- apex-fix-review:eyJ2IjoidjEiLCJoIjoiM2ZlYWFhMDctOTYzNS00YTQ1LWIzNDMtZTcyNjczNDg1Yzc5IiwiZiI6IjM0MjRmYWRhLTM5MWQtNDY4MC1iNTNjLTNkNjc4YjIwZTcxZiIsImUiOjE3ODI1MDIzNjh9.9ovDDnkRn6U0SE3OfXaBkhGxvIRv4dKUI9Ssk2fT2UU -->