### PR TITLE
fix(frontend): set MetaMerkleProof close_timestamp to vote expiry

### DIFF
--- a/frontend/src/chain/instructions/__tests__/helpers.test.ts
+++ b/frontend/src/chain/instructions/__tests__/helpers.test.ts
@@ -44,8 +44,9 @@ describe("computeProofCloseTimestamp", () => {
     const ts = await computeProofCloseTimestamp(connection, 102);
 
     // epochStartSlot = 400_000; targetSlot = 400_000 + 2 * 432_000 = 1_264_000
-    // slotDelta = 1_264_000 - 500_000 = 764_000; 764_000 * 400 / 1000 = 305_600
-    expect(ts).toBe(1_700_305_600);
+    // slotDelta = 1_264_000 - 500_000 = 764_000; projected = 764_000 * 400 / 1000 = 305_600
+    // buffer = max(305_600 * 20 / 100, 3600) = 61_120; result = 305_600 + 61_120 = 366_720
+    expect(ts).toBe(1_700_366_720);
 
     // Security regression guard: the shipped frontend used to hard-code 1, which made the proof
     // permissionlessly closable immediately. The fix must produce the real vote-expiry instant.
@@ -69,7 +70,8 @@ describe("computeProofCloseTimestamp", () => {
     expect(getBlockTime).toHaveBeenNthCalledWith(1, 500_000);
     expect(getBlockTime).toHaveBeenNthCalledWith(2, 499_999);
     // refSlot = 499_999; slotDelta = 1_264_000 - 499_999 = 764_001; *400/1000 = 305_600.4 -> 305_600
-    expect(ts).toBe(1_700_305_600);
+    // buffer = max(305_600 * 20 / 100, 3600) = 61_120; result = 305_600 + 61_120 = 366_720
+    expect(ts).toBe(1_700_366_720);
   });
 
   it("returns a past timestamp once voting has already ended (allows immediate permissionless close)", async () => {
@@ -87,6 +89,7 @@ describe("computeProofCloseTimestamp", () => {
 
     // epochStartSlot = 950_000; targetSlot = 950_000 - 432_000 = 518_000
     // slotDelta = 518_000 - 1_000_000 = -482_000; -482_000 * 400 / 1000 = -192_800
+    // projected <= 0, so no buffer is added and the result stays in the past (immediately closable)
     expect(ts).toBe(1_699_807_200);
     expect(ts).toBeLessThan(1_700_000_000);
   });

--- a/frontend/src/chain/instructions/__tests__/helpers.test.ts
+++ b/frontend/src/chain/instructions/__tests__/helpers.test.ts
@@ -102,10 +102,11 @@ describe("computeProofCloseTimestamp", () => {
       async () => null
     );
 
+    // Walks back from absoluteSlot (500_000) over MAX_ATTEMPTS = 8 slots, so the
+    // lowest slot actually tried — and thus the reported "ending at" — is 499_993.
     await expect(computeProofCloseTimestamp(connection, 102)).rejects.toThrow(
-      /Failed to fetch a recent block time/
+      /Failed to fetch a recent block time \(tried 8 slots ending at 499993\)/
     );
-    // MAX_ATTEMPTS = 8
     expect(getBlockTime).toHaveBeenCalledTimes(8);
   });
 });

--- a/frontend/src/chain/instructions/__tests__/helpers.test.ts
+++ b/frontend/src/chain/instructions/__tests__/helpers.test.ts
@@ -1,0 +1,111 @@
+import type { Connection } from "@solana/web3.js";
+
+// helpers.ts transitively imports EndpointContext -> env.ts (an ESM-only package Jest does not
+// transform). computeProofCloseTimestamp does not use it, so stub it out to keep the unit isolated.
+jest.mock("@/contexts/EndpointContext", () => ({
+  RPC_URLS: { testnet: "http://localhost:8899" },
+}));
+
+import { computeProofCloseTimestamp } from "../helpers";
+
+/**
+ * Builds a minimal Connection stand-in exposing only the two methods
+ * computeProofCloseTimestamp uses.
+ */
+function mockConnection(
+  epochInfo: {
+    absoluteSlot: number;
+    slotIndex: number;
+    epoch: number;
+    slotsInEpoch: number;
+  },
+  getBlockTime: (slot: number) => Promise<number | null>
+): { connection: Connection; getBlockTime: jest.Mock } {
+  const getBlockTimeMock = jest.fn(getBlockTime);
+  const connection = {
+    getEpochInfo: jest.fn(async () => epochInfo),
+    getBlockTime: getBlockTimeMock,
+  } as unknown as Connection;
+  return { connection, getBlockTime: getBlockTimeMock };
+}
+
+describe("computeProofCloseTimestamp", () => {
+  it("projects a future end_epoch forward to a real future timestamp (never the vulnerable 1)", async () => {
+    const { connection } = mockConnection(
+      {
+        absoluteSlot: 500_000,
+        slotIndex: 100_000,
+        epoch: 100,
+        slotsInEpoch: 432_000,
+      },
+      async () => 1_700_000_000
+    );
+
+    const ts = await computeProofCloseTimestamp(connection, 102);
+
+    // epochStartSlot = 400_000; targetSlot = 400_000 + 2 * 432_000 = 1_264_000
+    // slotDelta = 1_264_000 - 500_000 = 764_000; 764_000 * 400 / 1000 = 305_600
+    expect(ts).toBe(1_700_305_600);
+
+    // Security regression guard: the shipped frontend used to hard-code 1, which made the proof
+    // permissionlessly closable immediately. The fix must produce the real vote-expiry instant.
+    expect(ts).toBeGreaterThan(1);
+    expect(ts).toBeGreaterThan(1_700_000_000);
+  });
+
+  it("walks backwards over a skipped reference slot until a block time resolves", async () => {
+    const { connection, getBlockTime } = mockConnection(
+      {
+        absoluteSlot: 500_000,
+        slotIndex: 100_000,
+        epoch: 100,
+        slotsInEpoch: 432_000,
+      },
+      async (slot: number) => (slot === 500_000 ? null : 1_700_000_000)
+    );
+
+    const ts = await computeProofCloseTimestamp(connection, 102);
+
+    expect(getBlockTime).toHaveBeenNthCalledWith(1, 500_000);
+    expect(getBlockTime).toHaveBeenNthCalledWith(2, 499_999);
+    // refSlot = 499_999; slotDelta = 1_264_000 - 499_999 = 764_001; *400/1000 = 305_600.4 -> 305_600
+    expect(ts).toBe(1_700_305_600);
+  });
+
+  it("returns a past timestamp once voting has already ended (allows immediate permissionless close)", async () => {
+    const { connection } = mockConnection(
+      {
+        absoluteSlot: 1_000_000,
+        slotIndex: 50_000,
+        epoch: 200,
+        slotsInEpoch: 432_000,
+      },
+      async () => 1_700_000_000
+    );
+
+    const ts = await computeProofCloseTimestamp(connection, 199);
+
+    // epochStartSlot = 950_000; targetSlot = 950_000 - 432_000 = 518_000
+    // slotDelta = 518_000 - 1_000_000 = -482_000; -482_000 * 400 / 1000 = -192_800
+    expect(ts).toBe(1_699_807_200);
+    expect(ts).toBeLessThan(1_700_000_000);
+  });
+
+  it("throws if no block time resolves within the attempt budget", async () => {
+    const { connection, getBlockTime } = mockConnection(
+      {
+        absoluteSlot: 500_000,
+        slotIndex: 100_000,
+        epoch: 100,
+        slotsInEpoch: 432_000,
+      },
+      async () => null
+    );
+
+    await expect(computeProofCloseTimestamp(connection, 102)).rejects.toThrow(
+      /Failed to fetch a recent block time/
+    );
+    // MAX_ATTEMPTS = 8
+    expect(getBlockTime).toHaveBeenCalledTimes(8);
+  });
+});

--- a/frontend/src/chain/instructions/castVote.ts
+++ b/frontend/src/chain/instructions/castVote.ts
@@ -19,6 +19,7 @@ import {
   createGovV1ProgramWithWallet,
   getVoteAccountProof,
   getMetaMerkleProofPda,
+  computeProofCloseTimestamp,
 } from "./helpers";
 
 /**
@@ -106,6 +107,15 @@ export async function castVote(
   const instructions: TransactionInstruction[] = [];
 
   if (!merkleAccountInfo) {
+    // Set close_timestamp to the proposal's vote expiry so the proof cannot be closed
+    // permissionlessly while voting is open. See computeProofCloseTimestamp.
+    const proposalAccount =
+      await program.account.proposal.fetch(proposalPubkey);
+    const closeTimestamp = await computeProofCloseTimestamp(
+      program.provider.connection,
+      proposalAccount.endEpoch.toNumber()
+    );
+
     const initMerkleInstruction = await govV1Program.methods
       .initMetaMerkleProof(
         {
@@ -125,7 +135,7 @@ export async function castVote(
         voteAccountProof.meta_merkle_proof.map((proof) =>
           Array.from(new PublicKey(proof).toBytes())
         ),
-        new BN(1)
+        new BN(closeTimestamp)
       )
       .accountsStrict({
         consensusResult,

--- a/frontend/src/chain/instructions/castVoteOverride.ts
+++ b/frontend/src/chain/instructions/castVoteOverride.ts
@@ -1,4 +1,9 @@
-import { PublicKey, SystemProgram, Transaction } from "@solana/web3.js";
+import {
+  PublicKey,
+  SystemProgram,
+  Transaction,
+  TransactionInstruction,
+} from "@solana/web3.js";
 import {
   CastVoteOverrideParams,
   TransactionResult,
@@ -17,6 +22,7 @@ import {
   deriveVoteOverridePda,
   deriveVoteOverrideCachePda,
   getMetaMerkleProofPda,
+  computeProofCloseTimestamp,
 } from "./helpers";
 import { BN } from "@coral-xyz/anchor";
 
@@ -79,6 +85,10 @@ export async function castVoteOverride(
     "confirmed"
   );
 
+  // Instructions are sent in a single atomic transaction so the proof cannot be deleted by an
+  // attacker between creating it and consuming it in the override vote.
+  const instructions: TransactionInstruction[] = [];
+
   if (!merkleAccountInfo) {
     const govV1Program = createGovV1ProgramWithWallet(
       wallet,
@@ -93,6 +103,15 @@ export async function castVoteOverride(
 
     const metaMerkleProofData = metaMerkleProof.meta_merkle_proof.map((proof) =>
       Array.from(new PublicKey(proof).toBytes())
+    );
+
+    // Set close_timestamp to the proposal's vote expiry so the proof cannot be closed
+    // permissionlessly while voting is open. See computeProofCloseTimestamp.
+    const proposalAccount =
+      await program.account.proposal.fetch(proposalPubkey);
+    const closeTimestamp = await computeProofCloseTimestamp(
+      program.provider.connection,
+      proposalAccount.endEpoch.toNumber()
     );
 
     const initMerkleInstruction = await govV1Program.methods
@@ -110,7 +129,7 @@ export async function castVoteOverride(
           ),
         },
         metaMerkleProofData,
-        new BN(1)
+        new BN(closeTimestamp)
       )
       .accountsStrict({
         consensusResult,
@@ -120,21 +139,7 @@ export async function castVoteOverride(
       })
       .instruction();
 
-    const recentBlockhash =
-      await program.provider.connection.getLatestBlockhash("confirmed");
-
-    const transaction = new Transaction();
-    transaction.add(initMerkleInstruction);
-    transaction.feePayer = wallet.publicKey;
-    transaction.recentBlockhash = recentBlockhash.blockhash;
-
-    const tx = await wallet.signTransaction(transaction);
-
-    const signature = await program.provider.connection.sendRawTransaction(
-      tx.serialize(),
-      { preflightCommitment: "confirmed" }
-    );
-    console.log("signature initMerkleInstruction", signature);
+    instructions.push(initMerkleInstruction);
   }
 
   // Convert merkle proof data
@@ -192,8 +197,10 @@ export async function castVoteOverride(
     })
     .instruction();
 
+  instructions.push(castVoteOverrideInstruction);
+
   const transaction = new Transaction();
-  transaction.add(castVoteOverrideInstruction);
+  transaction.add(...instructions);
   transaction.feePayer = wallet.publicKey;
   transaction.recentBlockhash = (
     await program.provider.connection.getLatestBlockhash("confirmed")

--- a/frontend/src/chain/instructions/helpers.ts
+++ b/frontend/src/chain/instructions/helpers.ts
@@ -216,6 +216,81 @@ export function getMetaMerkleProofPda(
   return metaMerkleProofPda;
 }
 
+// Milliseconds per slot (matches solana_sdk::clock::DEFAULT_MS_PER_SLOT and the svmgov CLI's
+// compute_vote_expiry_timestamp).
+const MS_PER_SLOT = 400;
+
+/**
+ * Estimate the Unix timestamp (in seconds) at which voting expires for a proposal — i.e. the
+ * start of `endEpoch`, after which voting is no longer valid. This is the value a newly created
+ * `MetaMerkleProof` should use for its `close_timestamp`: until this time the proof cannot be
+ * closed permissionlessly, so it survives for the whole voting window and an attacker cannot
+ * delete the shared proof state between the init and vote steps. Mirrors the svmgov CLI's
+ * `compute_vote_expiry_timestamp`.
+ *
+ * There is no on-chain expiry timestamp (the proposal only stores `end_epoch`), so this estimates
+ * it: anchor to a recent confirmed block time and project forward to the start of `endEpoch` at
+ * ~400ms/slot. If voting has already ended the result is in the past, which correctly allows
+ * immediate permissionless close.
+ */
+export async function computeProofCloseTimestamp(
+  connection: Connection,
+  endEpoch: number
+): Promise<number> {
+  const info = await connection.getEpochInfo("confirmed");
+
+  // Absolute slot at the start of `endEpoch` — the point at which voting expires.
+  const epochStartSlot = info.absoluteSlot - info.slotIndex;
+  const targetSlot =
+    epochStartSlot + (endEpoch - info.epoch) * info.slotsInEpoch;
+
+  // Anchor the estimate to a real block time and project forward. Whichever slot resolves is
+  // used as the reference, so the slot delta (and thus the estimate) stays consistent.
+  const [refSlot, refTime] = await blockTimeAtOrBefore(
+    connection,
+    info.absoluteSlot
+  );
+  const slotDelta = targetSlot - refSlot;
+
+  // Math.trunc (toward zero) matches Rust's i64 integer division in the CLI helper, so an
+  // already-expired proposal yields the same past timestamp in both code paths.
+  return refTime + Math.trunc((slotDelta * MS_PER_SLOT) / 1000);
+}
+
+/**
+ * Fetch a block time at or before `slot`, walking backwards over skipped slots (which have no
+ * block and therefore no block time) until one resolves. Returns the `[slot, unixTimestamp]`
+ * pair that succeeded. Mirrors the svmgov CLI helper of the same purpose.
+ */
+async function blockTimeAtOrBefore(
+  connection: Connection,
+  slot: number
+): Promise<[number, number]> {
+  const MAX_ATTEMPTS = 8;
+
+  let candidate = slot;
+  let lastErr: unknown;
+  for (let attempt = 0; attempt < MAX_ATTEMPTS; attempt++) {
+    try {
+      const blockTime = await connection.getBlockTime(candidate);
+      if (blockTime !== null) {
+        return [candidate, blockTime];
+      }
+      lastErr = new Error(`no block time available for slot ${candidate}`);
+    } catch (e) {
+      lastErr = e;
+    }
+    if (candidate === 0) break;
+    candidate = Math.max(0, candidate - 1);
+  }
+
+  throw new Error(
+    `Failed to fetch a recent block time (tried ${MAX_ATTEMPTS} slots ending at ${candidate}): ${String(
+      lastErr
+    )}`
+  );
+}
+
 // Convert merkle proof strings to the format expected by the program
 export function convertMerkleProofStrings(proofStrings: string[]): number[][] {
   return proofStrings.map((proof) =>

--- a/frontend/src/chain/instructions/helpers.ts
+++ b/frontend/src/chain/instructions/helpers.ts
@@ -269,8 +269,12 @@ async function blockTimeAtOrBefore(
   const MAX_ATTEMPTS = 8;
 
   let candidate = slot;
+  let lastTried = slot;
+  let attempts = 0;
   let lastErr: unknown;
   for (let attempt = 0; attempt < MAX_ATTEMPTS; attempt++) {
+    lastTried = candidate;
+    attempts = attempt + 1;
     try {
       const blockTime = await connection.getBlockTime(candidate);
       if (blockTime !== null) {
@@ -285,7 +289,7 @@ async function blockTimeAtOrBefore(
   }
 
   throw new Error(
-    `Failed to fetch a recent block time (tried ${MAX_ATTEMPTS} slots ending at ${candidate}): ${String(
+    `Failed to fetch a recent block time (tried ${attempts} slots ending at ${lastTried}): ${String(
       lastErr
     )}`
   );

--- a/frontend/src/chain/instructions/helpers.ts
+++ b/frontend/src/chain/instructions/helpers.ts
@@ -219,6 +219,10 @@ export function getMetaMerkleProofPda(
 // Milliseconds per slot (matches solana_sdk::clock::DEFAULT_MS_PER_SLOT and the svmgov CLI's
 // compute_vote_expiry_timestamp).
 const MS_PER_SLOT = 400;
+// Buffer added to forward-looking estimates so a slower-than-400ms network can't make the proof
+// closable before voting truly ends. Matches the svmgov CLI's compute_vote_expiry_timestamp.
+const BUFFER_PCT = 20; // tolerate an average of ~480ms/slot over the projection
+const MIN_BUFFER_SECONDS = 3600; // floor for proposals ending near an epoch boundary
 
 /**
  * Estimate the Unix timestamp (in seconds) at which voting expires for a proposal — i.e. the
@@ -232,6 +236,13 @@ const MS_PER_SLOT = 400;
  * it: anchor to a recent confirmed block time and project forward to the start of `endEpoch` at
  * ~400ms/slot. If voting has already ended the result is in the past, which correctly allows
  * immediate permissionless close.
+ *
+ * The 400ms/slot projection assumes default slot times. When slots run slower the chain reaches
+ * `endEpoch` later than estimated, so a bare estimate can land before voting ends and let the
+ * proof be closed too soon. To stay safe we add a buffer to forward-looking estimates — a
+ * percentage of the projected window (the error grows with distance to `endEpoch`) with a fixed
+ * floor — but never to already-expired proposals, which keep a past timestamp and stay
+ * immediately closable.
  */
 export async function computeProofCloseTimestamp(
   connection: Connection,
@@ -254,7 +265,16 @@ export async function computeProofCloseTimestamp(
 
   // Math.trunc (toward zero) matches Rust's i64 integer division in the CLI helper, so an
   // already-expired proposal yields the same past timestamp in both code paths.
-  return refTime + Math.trunc((slotDelta * MS_PER_SLOT) / 1000);
+  const projectedSecs = Math.trunc((slotDelta * MS_PER_SLOT) / 1000);
+  const buffer =
+    projectedSecs > 0
+      ? Math.max(
+          Math.trunc((projectedSecs * BUFFER_PCT) / 100),
+          MIN_BUFFER_SECONDS
+        )
+      : 0;
+
+  return refTime + projectedSecs + buffer;
 }
 
 /**

--- a/frontend/src/chain/instructions/modifyVote.ts
+++ b/frontend/src/chain/instructions/modifyVote.ts
@@ -18,6 +18,7 @@ import {
   createGovV1ProgramWithWallet,
   getVoteAccountProof,
   getMetaMerkleProofPda,
+  computeProofCloseTimestamp,
 } from "./helpers";
 
 /**
@@ -101,6 +102,15 @@ export async function modifyVote(
   const instructions: TransactionInstruction[] = [];
 
   if (!merkleAccountInfo) {
+    // Set close_timestamp to the proposal's vote expiry so the proof cannot be closed
+    // permissionlessly while voting is open. See computeProofCloseTimestamp.
+    const proposalAccount =
+      await program.account.proposal.fetch(proposalPubkey);
+    const closeTimestamp = await computeProofCloseTimestamp(
+      program.provider.connection,
+      proposalAccount.endEpoch.toNumber()
+    );
+
     const initMerkleInstruction = await govV1Program.methods
       .initMetaMerkleProof(
         {
@@ -120,7 +130,7 @@ export async function modifyVote(
         voteAccountProof.meta_merkle_proof.map((proof) =>
           Array.from(new PublicKey(proof).toBytes())
         ),
-        new BN(1)
+        new BN(closeTimestamp)
       )
       .accountsStrict({
         consensusResult,

--- a/frontend/src/chain/instructions/modifyVoteOverride.ts
+++ b/frontend/src/chain/instructions/modifyVoteOverride.ts
@@ -1,4 +1,9 @@
-import { PublicKey, SystemProgram, Transaction } from "@solana/web3.js";
+import {
+  PublicKey,
+  SystemProgram,
+  Transaction,
+  TransactionInstruction,
+} from "@solana/web3.js";
 import {
   ModifyVoteOverrideParams,
   TransactionResult,
@@ -17,6 +22,7 @@ import {
   deriveVoteOverrideCachePda,
   deriveVotePda,
   getMetaMerkleProofPda,
+  computeProofCloseTimestamp,
 } from "./helpers";
 import { BN } from "@coral-xyz/anchor";
 
@@ -79,6 +85,10 @@ export async function modifyVoteOverride(
     "confirmed"
   );
 
+  // Instructions are sent in a single atomic transaction so the proof cannot be deleted by an
+  // attacker between creating it and consuming it in the override vote.
+  const instructions: TransactionInstruction[] = [];
+
   if (!merkleAccountInfo) {
     console.log("merkle proof does not exist, initializing");
     const govV1Program = createGovV1ProgramWithWallet(
@@ -96,6 +106,15 @@ export async function modifyVoteOverride(
       Array.from(new PublicKey(proof).toBytes())
     );
 
+    // Set close_timestamp to the proposal's vote expiry so the proof cannot be closed
+    // permissionlessly while voting is open. See computeProofCloseTimestamp.
+    const proposalAccount =
+      await program.account.proposal.fetch(proposalPubkey);
+    const closeTimestamp = await computeProofCloseTimestamp(
+      program.provider.connection,
+      proposalAccount.endEpoch.toNumber()
+    );
+
     const initMerkleInstruction = await govV1Program.methods
       .initMetaMerkleProof(
         {
@@ -111,7 +130,7 @@ export async function modifyVoteOverride(
           ),
         },
         metaMerkleProofData,
-        new BN(1)
+        new BN(closeTimestamp)
       )
       .accountsStrict({
         consensusResult,
@@ -121,21 +140,7 @@ export async function modifyVoteOverride(
       })
       .instruction();
 
-    const recentBlockhash =
-      await program.provider.connection.getLatestBlockhash("confirmed");
-
-    const transaction = new Transaction();
-    transaction.add(initMerkleInstruction);
-    transaction.feePayer = wallet.publicKey;
-    transaction.recentBlockhash = recentBlockhash.blockhash;
-
-    const tx = await wallet.signTransaction(transaction);
-
-    const signature = await program.provider.connection.sendRawTransaction(
-      tx.serialize(),
-      { preflightCommitment: "confirmed" }
-    );
-    console.log("signature initMerkleInstruction", signature);
+    instructions.push(initMerkleInstruction);
   }
 
   // Convert merkle proof data
@@ -193,8 +198,10 @@ export async function modifyVoteOverride(
     })
     .instruction();
 
+  instructions.push(modifyVoteOverrideInstruction);
+
   const transaction = new Transaction();
-  transaction.add(modifyVoteOverrideInstruction);
+  transaction.add(...instructions);
   transaction.feePayer = wallet.publicKey;
   transaction.recentBlockhash = (
     await program.provider.connection.getLatestBlockhash("confirmed")

--- a/svmgov/cli/src/utils/utils.rs
+++ b/svmgov/cli/src/utils/utils.rs
@@ -448,11 +448,22 @@ pub async fn fetch_global_config(program: &Program<Arc<Keypair>>) -> Result<Glob
 /// estimates it: anchor to a recent confirmed block time and project forward to the start of
 /// `end_epoch` at ~400ms/slot. If voting has already ended the result is in the past, which
 /// correctly allows immediate permissionless close.
+///
+/// The 400ms/slot projection assumes the network runs at the default slot time. When slots are
+/// slower the chain reaches `end_epoch` later in wall-clock time than estimated, so a bare
+/// estimate can land before voting truly ends and let the proof be closed too soon. To stay on
+/// the safe side we add a buffer to forward-looking estimates: a percentage of the projected
+/// window (the error grows with distance to `end_epoch`) with a fixed floor (so proposals
+/// ending near an epoch boundary still get a meaningful grace window). The buffer is only added
+/// when projecting into the future — already-expired proposals keep a past timestamp and stay
+/// immediately closable.
 pub async fn compute_vote_expiry_timestamp(
     program: &Program<Arc<Keypair>>,
     end_epoch: u64,
 ) -> Result<i64> {
     const MS_PER_SLOT: i64 = 400; // solana_sdk::clock::DEFAULT_MS_PER_SLOT
+    const BUFFER_PCT: i64 = 20; // tolerate an average of ~480ms/slot over the projection
+    const MIN_BUFFER_SECONDS: i64 = 3600; // floor for proposals ending near an epoch boundary
 
     let rpc = program.rpc();
 
@@ -473,7 +484,14 @@ pub async fn compute_vote_expiry_timestamp(
     let (ref_slot, ref_time) = block_time_at_or_before(&rpc, info.absolute_slot).await?;
     let slot_delta = target_slot - ref_slot as i64;
 
-    Ok(ref_time + slot_delta * MS_PER_SLOT / 1000)
+    let projected_secs = slot_delta * MS_PER_SLOT / 1000;
+    let buffer = if projected_secs > 0 {
+        std::cmp::max(projected_secs * BUFFER_PCT / 100, MIN_BUFFER_SECONDS)
+    } else {
+        0
+    };
+
+    Ok(ref_time + projected_secs + buffer)
 }
 
 /// Fetch a block time at or before `slot`, walking backwards over skipped slots (which have no

--- a/svmgov/cli/src/utils/utils.rs
+++ b/svmgov/cli/src/utils/utils.rs
@@ -483,8 +483,10 @@ async fn block_time_at_or_before(rpc: &RpcClient, slot: u64) -> Result<(u64, i64
     const MAX_ATTEMPTS: u32 = 8;
 
     let mut slot = slot;
+    let mut last_tried = slot;
     let mut last_err = None;
     for _ in 0..MAX_ATTEMPTS {
+        last_tried = slot;
         match rpc.get_block_time(slot).await {
             Ok(time) => return Ok((slot, time)),
             Err(e) => {
@@ -497,7 +499,7 @@ async fn block_time_at_or_before(rpc: &RpcClient, slot: u64) -> Result<(u64, i64
     Err(anyhow!(
         "Failed to fetch a recent block time (tried {} slots ending at {}): {}",
         MAX_ATTEMPTS,
-        slot,
+        last_tried,
         last_err.unwrap_or_else(|| "unknown error".to_string())
     ))
 }


### PR DESCRIPTION
The shipped frontend initialized MetaMerkleProof with close_timestamp = 1, which makes the proof permissionlessly closable immediately (the on-chain close gate only requires now >= close_timestamp). Because the override flows sent proof creation and the vote in two separate transactions, an attacker could close the proof between them and force the vote to fail, suppressing delegator override voting through the web app. The same hard-coded value affected the cast/modify vote flows.

Compute close_timestamp as the proposal's vote-expiry instant, mirroring the svmgov CLI's compute_vote_expiry_timestamp, so the proof cannot be closed while voting is open. Also bundle proof creation and the override vote into a single atomic transaction (the cast/modify vote flows already did this), as defense-in-depth so no inter-transaction window remains.

Add unit tests for the new close-timestamp computation.