### PR TITLE
fix(verifier): derive meta merkle proofs server-side from signed root

### DIFF
--- a/ncn/verifier-service/src/upload.rs
+++ b/ncn/verifier-service/src/upload.rs
@@ -92,14 +92,30 @@ pub async fn handle_upload(
         StatusCode::BAD_REQUEST
     })?;
 
-    // 7. Index data in database
-    index_snapshot_data(&pool, &snapshot, &network, &merkle_root, &encoded_hash)
-        .await
-        .map_err(|e| {
-            info!("Failed to index snapshot data: {}", e);
-            metrics::record_upload_outcome(metrics::UploadOutcome::Internal);
-            StatusCode::INTERNAL_SERVER_ERROR
-        })?;
+    // 7. Reconstruct the meta merkle tree from the uploaded leaves and confirm it
+    // reproduces the signed root. Every proof we later serve is derived from this
+    // tree, so the uploaded `bundle.proof` bytes are never trusted or persisted.
+    let meta_merkle_tree = reconstruct_meta_merkle_tree(&snapshot).map_err(|e| {
+        info!("Failed to reconstruct meta merkle tree: {}", e);
+        metrics::record_upload_outcome(metrics::UploadOutcome::BadRequest);
+        StatusCode::BAD_REQUEST
+    })?;
+
+    // 8. Index data in database
+    index_snapshot_data(
+        &pool,
+        &snapshot,
+        &meta_merkle_tree,
+        &network,
+        &merkle_root,
+        &encoded_hash,
+    )
+    .await
+    .map_err(|e| {
+        info!("Failed to index snapshot data: {}", e);
+        metrics::record_upload_outcome(metrics::UploadOutcome::Internal);
+        StatusCode::INTERNAL_SERVER_ERROR
+    })?;
 
     metrics::record_upload_outcome(metrics::UploadOutcome::Success);
 
@@ -138,10 +154,45 @@ fn derive_stake_merkle_root(
     stake_merkle.get_root().map(|root| root.to_bytes())
 }
 
+/// Rebuild the meta merkle tree from the uploaded meta leaves and confirm it
+/// reproduces the snapshot's signed root.
+///
+/// The bundles are stored in the same order in which the canonical tree was
+/// built, so leaf `i` corresponds to tree index `i`. Rehashing the leaves in
+/// that order yields the exact tree, which lets us (a) reject any snapshot whose
+/// leaves do not hash up to the signed root and (b) derive each vote account's
+/// proof ourselves instead of trusting the unsigned `bundle.proof` bytes. The
+/// returned tree is consumed by [`index_snapshot_data`] to compute proofs that
+/// are guaranteed to verify against the on-chain consensus root.
+fn reconstruct_meta_merkle_tree(snapshot: &MetaMerkleSnapshot) -> Result<MerkleTree> {
+    let hashed_nodes: Vec<[u8; 32]> = snapshot
+        .leaf_bundles
+        .iter()
+        .map(|bundle| bundle.meta_merkle_leaf.hash().to_bytes())
+        .collect();
+    let meta_merkle = MerkleTree::new(&hashed_nodes[..], true);
+
+    let derived_root = meta_merkle
+        .get_root()
+        .ok_or_else(|| anyhow::anyhow!("meta merkle tree has no root"))?
+        .to_bytes();
+
+    if derived_root != snapshot.root {
+        return Err(anyhow::anyhow!(
+            "derived meta merkle root {} does not match signed root {}",
+            bs58::encode(derived_root).into_string(),
+            bs58::encode(snapshot.root).into_string()
+        ));
+    }
+
+    Ok(meta_merkle)
+}
+
 /// Index snapshot data in the database
 async fn index_snapshot_data(
     pool: &SqlitePool,
     snapshot: &MetaMerkleSnapshot,
+    meta_merkle_tree: &MerkleTree,
     network: &str,
     merkle_root: &str,
     snapshot_hash: &str,
@@ -170,11 +221,11 @@ async fn index_snapshot_data(
         }
         let meta_leaf = &bundle.meta_merkle_leaf;
 
-        // Convert meta merkle proof to base58 strings
-        let meta_merkle_proof: Vec<String> = bundle
-            .proof
-            .as_ref()
-            .unwrap_or(&Vec::new())
+        // Derive the meta merkle proof from the reconstructed tree rather than
+        // trusting the unsigned `bundle.proof` bytes carried in the upload. Bundle
+        // `bundle_idx` maps to tree index `bundle_idx` by construction, so this
+        // proof is guaranteed to verify against the signed root.
+        let meta_merkle_proof: Vec<String> = get_proof(meta_merkle_tree, bundle_idx)
             .iter()
             .map(|hash| bs58::encode(hash).into_string())
             .collect();
@@ -420,5 +471,114 @@ mod tests {
 
         let result = validate_stake_merkle_roots(&snapshot);
         assert!(result.is_err(), "incoherent stake roots must be rejected");
+    }
+
+    /// Build a coherent snapshot from arbitrary meta leaves, mirroring how the CLI
+    /// generates one: hash the leaves in order, build the tree, and store each
+    /// bundle's canonical proof alongside the derived root.
+    fn build_snapshot(slot: u64, count: u8) -> MetaMerkleSnapshot {
+        let leaves: Vec<ncn_snapshot::MetaMerkleLeaf> = (0..count)
+            .map(|seed| ncn_snapshot::MetaMerkleLeaf {
+                voting_wallet: AnchorPubkey::new_unique(),
+                vote_account: AnchorPubkey::new_unique(),
+                stake_merkle_root: [seed; 32],
+                active_stake: u64::from(seed) + 1,
+            })
+            .collect();
+
+        let hashed_nodes: Vec<[u8; 32]> = leaves.iter().map(|l| l.hash().to_bytes()).collect();
+        let tree = MerkleTree::new(&hashed_nodes[..], true);
+        let root = tree.get_root().expect("root").to_bytes();
+
+        let leaf_bundles = leaves
+            .into_iter()
+            .enumerate()
+            .map(|(i, meta_merkle_leaf)| cli::MetaMerkleLeafBundle {
+                meta_merkle_leaf,
+                stake_merkle_leaves: vec![],
+                proof: Some(get_proof(&tree, i)),
+            })
+            .collect();
+
+        MetaMerkleSnapshot {
+            root,
+            leaf_bundles,
+            slot,
+        }
+    }
+
+    #[test]
+    fn test_reconstruct_meta_merkle_tree_accepts_coherent_snapshot() {
+        let snapshot = build_snapshot(SLOT1, 5);
+        let tree = reconstruct_meta_merkle_tree(&snapshot).expect("coherent snapshot reconstructs");
+
+        // Every proof derived from the reconstructed tree must verify against the
+        // signed root using the exact logic the program runs on-chain.
+        for (i, bundle) in snapshot.leaf_bundles.iter().enumerate() {
+            let proof = get_proof(&tree, i);
+            assert!(
+                ncn_snapshot::merkle_helper::verify_helper(
+                    &bundle.meta_merkle_leaf.hash().to_bytes(),
+                    &proof,
+                    snapshot.root.into(),
+                )
+                .is_ok(),
+                "derived proof for leaf {} should verify against signed root",
+                i
+            );
+        }
+    }
+
+    #[test]
+    fn test_reconstruct_meta_merkle_tree_rejects_root_mismatch() {
+        let mut snapshot = build_snapshot(SLOT1, 5);
+        // Claimed root no longer matches the leaves it is supposed to commit to.
+        snapshot.root[0] ^= 0xff;
+
+        assert!(
+            reconstruct_meta_merkle_tree(&snapshot).is_err(),
+            "snapshot whose leaves do not hash to the signed root must be rejected"
+        );
+    }
+
+    #[test]
+    fn test_reconstruct_meta_merkle_tree_rejects_tampered_leaf() {
+        let mut snapshot = build_snapshot(SLOT1, 5);
+        // Mutate a leaf while leaving the signed root untouched: the derived root
+        // now diverges from the signed root, so the upload must be rejected.
+        snapshot.leaf_bundles[0].meta_merkle_leaf.active_stake += 1;
+
+        assert!(
+            reconstruct_meta_merkle_tree(&snapshot).is_err(),
+            "tampered leaf must break root reconstruction"
+        );
+    }
+
+    #[test]
+    fn test_reconstruct_meta_merkle_tree_ignores_uploaded_proof_bytes() {
+        let mut snapshot = build_snapshot(SLOT1, 5);
+        // Poison the uploaded proof bytes for one bundle. Reconstruction works off
+        // the leaves alone, so the derived proof stays canonical and verifiable.
+        snapshot.leaf_bundles[0].proof = Some(vec![[0xaa; 32], [0xbb; 32]]);
+        snapshot.leaf_bundles[2].proof = None;
+
+        let tree = reconstruct_meta_merkle_tree(&snapshot)
+            .expect("poisoned proof bytes do not affect reconstruction");
+
+        let derived = get_proof(&tree, 0);
+        assert_ne!(
+            derived,
+            vec![[0xaa; 32], [0xbb; 32]],
+            "derived proof must not echo the poisoned upload bytes"
+        );
+        assert!(
+            ncn_snapshot::merkle_helper::verify_helper(
+                &snapshot.leaf_bundles[0].meta_merkle_leaf.hash().to_bytes(),
+                &derived,
+                snapshot.root.into(),
+            )
+            .is_ok(),
+            "derived proof must verify even when uploaded proof bytes are poisoned"
+        );
     }
 }

--- a/ncn/verifier-service/tests/e2e_binary.rs
+++ b/ncn/verifier-service/tests/e2e_binary.rs
@@ -1,7 +1,9 @@
 mod common;
 use common::setup_server;
 
+use anchor_lang::solana_program::hash::Hash;
 use meta_merkle_tree::{merkle_tree::MerkleTree, utils::get_proof};
+use ncn_snapshot::merkle_helper::verify_helper;
 use reqwest::{
     multipart::{Form, Part},
     StatusCode,
@@ -19,6 +21,19 @@ fn sign_upload_message(
 ) -> String {
     let message = cli::upload_signature_message(slot, network, merkle_root, snapshot_hash);
     keypair.sign_message(&message).to_string()
+}
+
+fn decode_proof_strings(proof: &[String]) -> Vec<[u8; 32]> {
+    proof
+        .iter()
+        .map(|node| {
+            let bytes = bs58::decode(node).into_vec().expect("base58 proof node");
+            assert_eq!(bytes.len(), 32, "proof node must decode to 32 bytes");
+            let mut hash = [0u8; 32];
+            hash.copy_from_slice(&bytes);
+            hash
+        })
+        .collect()
 }
 
 #[tokio::test]
@@ -380,7 +395,10 @@ async fn e2e_same_slot_reupload_fully_replaces_rows() -> anyhow::Result<()> {
         .text("merkle_root", merkle_root.clone())
         .text("snapshot_hash", full_hash.clone())
         .text("signature", full_signature)
-        .part("file", Part::bytes(full_bytes).file_name("full_snapshot.zip"));
+        .part(
+            "file",
+            Part::bytes(full_bytes).file_name("full_snapshot.zip"),
+        );
     let resp = client
         .post(format!("{}/upload", base_url))
         .multipart(full_upload)
@@ -442,8 +460,13 @@ async fn e2e_same_slot_reupload_fully_replaces_rows() -> anyhow::Result<()> {
         modified_hash, full_hash,
         "reupload must carry a distinct snapshot hash"
     );
-    let modified_signature =
-        sign_upload_message(&keypair, slot, NETWORK, &modified_merkle_root, &modified_hash);
+    let modified_signature = sign_upload_message(
+        &keypair,
+        slot,
+        NETWORK,
+        &modified_merkle_root,
+        &modified_hash,
+    );
 
     let modified_upload = Form::new()
         .text("slot", slot.to_string())
@@ -549,6 +572,167 @@ async fn e2e_same_slot_reupload_fully_replaces_rows() -> anyhow::Result<()> {
             stake_account
         );
     }
+
+    Ok(())
+}
+
+/// A snapshot whose `bundle.proof` bytes have been poisoned (but whose leaves and
+/// root are honest) must still be served with the canonical, on-chain-verifiable
+/// proof. This proves the verifier derives proofs from the leaves rather than
+/// echoing the unsigned upload bytes back to clients.
+#[tokio::test]
+#[serial_test::serial]
+async fn e2e_serves_derived_proof_when_upload_proof_bytes_are_poisoned() -> anyhow::Result<()> {
+    let keypair = Keypair::new();
+    let (base_url, _guard) = setup_server(&keypair).await?;
+    let client = reqwest::Client::new();
+
+    let snapshot_path = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .unwrap()
+        .join("tests/src/fixtures/meta_merkle_340850340.zip");
+    let honest_bytes = tokio::fs::read(&snapshot_path).await?;
+    let (mut snapshot, _) =
+        cli::MetaMerkleSnapshot::read_from_bytes_with_hash(honest_bytes.clone(), true)?;
+
+    let slot = snapshot.slot;
+    let merkle_root = bs58::encode(snapshot.root).into_string();
+    let root_hash: Hash = snapshot.root.into();
+
+    // The leaf and its canonical (honest) proof we expect the verifier to serve.
+    let target_leaf = snapshot.leaf_bundles[0].meta_merkle_leaf.clone();
+    let vote_account = target_leaf.vote_account.to_string();
+    let canonical_proof = snapshot.leaf_bundles[0]
+        .proof
+        .clone()
+        .expect("fixture proof must be present");
+    assert!(
+        !canonical_proof.is_empty(),
+        "fixture proof should be non-empty so poisoning is observable"
+    );
+
+    // Poison the uploaded proof bytes while leaving leaves and root intact, then
+    // sign the exact bytes so the upload is authorized.
+    snapshot.leaf_bundles[0].proof = Some(vec![[0xaa; 32], [0xbb; 32]]);
+    let poisoned_bytes = encode_snapshot(&snapshot)?;
+    let (_, poisoned_hash) =
+        cli::MetaMerkleSnapshot::read_from_bytes_with_hash(poisoned_bytes.clone(), true)?;
+    let encoded_hash = bs58::encode(poisoned_hash.to_bytes()).into_string();
+    let signature = sign_upload_message(&keypair, slot, NETWORK, &merkle_root, &encoded_hash);
+
+    let upload = Form::new()
+        .text("slot", slot.to_string())
+        .text("network", NETWORK)
+        .text("merkle_root", merkle_root.clone())
+        .text("snapshot_hash", encoded_hash)
+        .text("signature", signature)
+        .part(
+            "file",
+            Part::bytes(poisoned_bytes).file_name("poisoned_proof.zip"),
+        );
+    let response = client
+        .post(format!("{}/upload", base_url))
+        .multipart(upload)
+        .send()
+        .await?;
+    assert!(
+        response.status().is_success(),
+        "honest leaves with poisoned proof bytes should still upload, got {}",
+        response.status()
+    );
+
+    let vote_proof: serde_json::Value = client
+        .get(format!(
+            "{}/proof/vote_account/{}?network={}&slot={}",
+            base_url, vote_account, NETWORK, slot
+        ))
+        .send()
+        .await?
+        .error_for_status()?
+        .json()
+        .await?;
+
+    let served: Vec<String> = vote_proof["meta_merkle_proof"]
+        .as_array()
+        .expect("meta_merkle_proof array")
+        .iter()
+        .map(|v| v.as_str().unwrap().to_string())
+        .collect();
+    let served_bytes = decode_proof_strings(&served);
+
+    // The served proof must be the canonical one derived from the leaves, not the
+    // poisoned bytes, and it must verify with the same logic used on-chain.
+    let canonical_strings: Vec<String> = canonical_proof
+        .iter()
+        .map(|hash| bs58::encode(hash).into_string())
+        .collect();
+    assert_eq!(
+        served, canonical_strings,
+        "verifier must serve the derived canonical proof, not the uploaded bytes"
+    );
+    assert_ne!(
+        served_bytes,
+        vec![[0xaa; 32], [0xbb; 32]],
+        "verifier must not echo poisoned proof bytes"
+    );
+    assert!(
+        verify_helper(&target_leaf.hash().to_bytes(), &served_bytes, root_hash).is_ok(),
+        "served proof must verify against the signed root"
+    );
+
+    Ok(())
+}
+
+/// A snapshot whose leaves do not hash up to the signed root must be rejected,
+/// even when the request is signed over the exact uploaded bytes.
+#[tokio::test]
+#[serial_test::serial]
+async fn e2e_rejects_leaves_that_do_not_reproduce_signed_root() -> anyhow::Result<()> {
+    let keypair = Keypair::new();
+    let (base_url, _guard) = setup_server(&keypair).await?;
+    let client = reqwest::Client::new();
+
+    let snapshot_path = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .unwrap()
+        .join("tests/src/fixtures/meta_merkle_340850340.zip");
+    let honest_bytes = tokio::fs::read(&snapshot_path).await?;
+    let (mut snapshot, _) =
+        cli::MetaMerkleSnapshot::read_from_bytes_with_hash(honest_bytes.clone(), true)?;
+
+    let slot = snapshot.slot;
+    // Keep the signed root and the per-bundle stake roots unchanged, but mutate a
+    // meta leaf so its hash (and therefore the derived meta root) diverges from the
+    // signed root. This isolates the reconstruction guard from the stake-root check.
+    let merkle_root = bs58::encode(snapshot.root).into_string();
+    snapshot.leaf_bundles[0].meta_merkle_leaf.active_stake += 1;
+
+    let tampered_bytes = encode_snapshot(&snapshot)?;
+    let (_, tampered_hash) =
+        cli::MetaMerkleSnapshot::read_from_bytes_with_hash(tampered_bytes.clone(), true)?;
+    let encoded_hash = bs58::encode(tampered_hash.to_bytes()).into_string();
+    let signature = sign_upload_message(&keypair, slot, NETWORK, &merkle_root, &encoded_hash);
+
+    let upload = Form::new()
+        .text("slot", slot.to_string())
+        .text("network", NETWORK)
+        .text("merkle_root", merkle_root)
+        .text("snapshot_hash", encoded_hash)
+        .text("signature", signature)
+        .part(
+            "file",
+            Part::bytes(tampered_bytes).file_name("root_mismatch.zip"),
+        );
+    let response = client
+        .post(format!("{}/upload", base_url))
+        .multipart(upload)
+        .send()
+        .await?;
+    assert_eq!(
+        response.status(),
+        StatusCode::BAD_REQUEST,
+        "leaves that do not reproduce the signed root must be rejected"
+    );
 
     Ok(())
 }


### PR DESCRIPTION
## Summary

Fixes a finding where the verifier service trusted attacker-supplied proof bytes from an uploaded `MetaMerkleSnapshot` and never independently confirmed that the uploaded leaves hash up to the signed `merkle_root`.

`handle_upload` populated `vote_accounts.meta_merkle_proof` directly from `bundle.proof` (the unsigned, serialized proof bytes in the upload) and only checked that the snapshot's *claimed* `root` field matched the signed root. As a result, a snapshot whose `proof` bytes — or leaves — were inconsistent with the signed root could be indexed and then served from `/proof/vote_account/*`. First-party clients fetch that proof for `initMetaMerkleProof`, which then fails `verify_helper` against `ConsensusResult.ballot.meta_merkle_root` on-chain, blocking validator voting until the proof source is repaired.

The signed message already binds the full `snapshot_hash` (commit #73), closing the original signature-replay path. This PR closes the **invariant** behind the finding: the verifier must only ever serve proofs it has independently derived and that are guaranteed to verify against the signed/on-chain root.

## Change

In `ncn/verifier-service/src/upload.rs`:

1. **Reconstruct the meta merkle tree** from the uploaded meta leaves (`reconstruct_meta_merkle_tree`) and reject any snapshot whose derived root does not equal the signed `merkle_root`. The bundles are stored in the same order the canonical tree was built, so leaf `i` maps to tree index `i` and rehashing reproduces the exact tree (or fails to match the signed root).
2. **Derive each vote account's `meta_merkle_proof` server-side** from that reconstructed tree (`get_proof(tree, bundle_idx)`) instead of persisting the uploaded `bundle.proof` bytes. The upload's `proof` field is no longer read or trusted anywhere in the verifier.

This sits alongside the existing `validate_stake_merkle_roots` check and runs before any DB indexing.

## Why this satisfies the invariant (not just the exploit path)

- Any snapshot whose leaves do not hash to the signed root is rejected (`BAD_REQUEST`), regardless of how the bytes were signed.
- Reordered/poisoned proof bytes are ignored entirely — the served proof is always the one the verifier itself derived from the leaves, which verifies against the signed root using the same logic (`verify_helper`) the program runs on-chain.

## Compatibility

No change to legitimate uploads: for an honest snapshot produced by the CLI, the reconstructed tree reproduces the canonical root and the derived proofs are byte-identical to the previously-served ones (the existing `e2e_binary_endpoints` golden-proof assertions are unchanged and still pass).

## Tests

Unit (`upload.rs`):
- `test_reconstruct_meta_merkle_tree_accepts_coherent_snapshot` — derived proofs verify against the signed root via `verify_helper`
- `test_reconstruct_meta_merkle_tree_rejects_root_mismatch` — claimed root ≠ leaf hashes is rejected
- `test_reconstruct_meta_merkle_tree_rejects_tampered_leaf` — mutated leaf breaks reconstruction
- `test_reconstruct_meta_merkle_tree_ignores_uploaded_proof_bytes` — poisoned `bundle.proof` does not affect the derived proof

E2E (`tests/e2e_binary.rs`):
- `e2e_serves_derived_proof_when_upload_proof_bytes_are_poisoned` — a fully-signed upload with poisoned proof bytes still serves the canonical, on-chain-verifiable proof
- `e2e_rejects_leaves_that_do_not_reproduce_signed_root` — leaves that don't reproduce the signed root are rejected even when signed over the exact bytes

All `verifier-service` unit and e2e tests pass.