### PR TITLE
fix(frontend): prevent verifier role downgrade

### DIFF
--- a/frontend/src/components/modals/CastVoteModal.tsx
+++ b/frontend/src/components/modals/CastVoteModal.tsx
@@ -208,7 +208,7 @@ export function CastVoteModal({
               />
 
               {/* Voting Info */}
-              <div className="rounded-lg bg-white/5 p-4">
+              <div className="space-y-4 rounded-lg bg-white/5 p-4">
                 <div className="flex items-center justify-between">
                   <span className="font-mono text-xs text-foreground sm:text-sm">
                     {formatAddress(wallet?.publicKey?.toBase58() || "", 6)}
@@ -226,6 +226,12 @@ export function CastVoteModal({
                       </p>
                     )}
                   </div>
+                </div>
+                <div className="border-t border-white/10 pt-4">
+                  <p className="text-xs text-white/60">Vote path</p>
+                  <p className="text-sm font-semibold text-foreground">
+                    Validator vote
+                  </p>
                 </div>
               </div>
               <VoteDistributionControls

--- a/frontend/src/components/modals/OverrideVoteModal.tsx
+++ b/frontend/src/components/modals/OverrideVoteModal.tsx
@@ -13,6 +13,7 @@ import ErrorMessage from "./shared/ErrorMessage";
 import { VoteDistributionControls } from "./shared/VoteDistributionControls";
 import {
   useCastVoteOverride,
+  useChainVoteAccount,
   useWalletStakeAccounts,
   useVoteDistribution,
   useWalletRole,
@@ -28,6 +29,8 @@ import { PublicKey } from "@solana/web3.js";
 import { VotingProposalsDropdown } from "../VotingProposalsDropdown";
 import { StakeAccountsDropdown } from "../StakeAccountsDropdown";
 import { captureException } from "@sentry/nextjs";
+import { Checkbox } from "@/components/ui/checkbox";
+import { hasOnChainValidatorIdentity } from "@/lib/governance/role-detection";
 
 export type OverrideVoteModalDataProps =
   | {
@@ -89,6 +92,10 @@ export function OverrideVoteModal({
   >(undefined);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | undefined>();
+  const [
+    hasConfirmedValidatorOverride,
+    setHasConfirmedValidatorOverride,
+  ] = useState(false);
   const {
     distribution,
     totalPercentage,
@@ -103,6 +110,8 @@ export function OverrideVoteModal({
   const { data: stakeAccounts } = useWalletStakeAccounts(
     wallet?.publicKey?.toBase58()
   );
+  const { data: chainVoteAccount, isLoading: isLoadingChainVoteAccount } =
+    useChainVoteAccount(wallet?.publicKey?.toBase58());
   const voteOverrideFilters = buildVoteOverrideFilters(
     selectedProposal.id,
     wallet?.publicKey ?? null
@@ -116,11 +125,14 @@ export function OverrideVoteModal({
   const { mutate: castVoteOverride } = useCastVoteOverride();
 
   const isValidStakeAccount = selectedStakeAccount !== undefined;
+  const hasValidatorIdentity = hasOnChainValidatorIdentity(chainVoteAccount);
+  const requiresValidatorOverrideConfirmation = hasValidatorIdentity;
 
   useEffect(() => {
     if (isOpen) {
       setSelectedProposal({ id: initialProposalId, consensusResult });
       setSelectedStakeAccount(undefined);
+      setHasConfirmedValidatorOverride(false);
       resetDistribution();
       setError(undefined);
     }
@@ -163,6 +175,19 @@ export function OverrideVoteModal({
       setIsLoading(false);
       return;
     }
+    if (isLoadingChainVoteAccount) {
+      toast.error("Loading wallet voting identity");
+      setIsLoading(false);
+      return;
+    }
+    if (
+      requiresValidatorOverrideConfirmation &&
+      !hasConfirmedValidatorOverride
+    ) {
+      toast.error("Confirm the stake override vote path before signing");
+      setIsLoading(false);
+      return;
+    }
 
     if (
       walletRole === WalletRole.NONE ||
@@ -170,6 +195,7 @@ export function OverrideVoteModal({
       walletRole === WalletRole.BOTH
     ) {
       toast.error("You are not authorized to override vote");
+      setIsLoading(false);
     } else if (walletRole === WalletRole.STAKER) {
       if (stakeAccounts === undefined) {
         toast.error("No stake accounts found");
@@ -237,6 +263,7 @@ export function OverrideVoteModal({
   const handleClose = () => {
     setSelectedProposal({ id: undefined, consensusResult: undefined });
     setSelectedStakeAccount("");
+    setHasConfirmedValidatorOverride(false);
     resetDistribution();
     setError(undefined);
     onClose();
@@ -268,6 +295,13 @@ export function OverrideVoteModal({
                 onValueChange={handleProposalChange}
                 disabled={!!initialProposalId}
               />
+
+              <div className="rounded-lg bg-white/5 p-4">
+                <p className="text-xs text-white/60">Vote path</p>
+                <p className="text-sm font-semibold text-foreground">
+                  Stake override
+                </p>
+              </div>
 
               {/* Stake Account Selection */}
               <div className="space-y-3">
@@ -302,6 +336,34 @@ export function OverrideVoteModal({
                 className="space-y-3"
               />
 
+              {hasValidatorIdentity && (
+                <div className="rounded-lg border border-amber-400/30 bg-amber-500/10 p-4">
+                  <label
+                    htmlFor="validator-override-confirmation"
+                    className="flex items-start gap-3"
+                  >
+                    <Checkbox
+                      id="validator-override-confirmation"
+                      className="mt-0.5"
+                      checked={hasConfirmedValidatorOverride}
+                      onCheckedChange={(checked) =>
+                        setHasConfirmedValidatorOverride(checked === true)
+                      }
+                    />
+                    <span className="block space-y-1">
+                      <span className="block text-sm font-semibold text-foreground">
+                        Submit stake override instead of validator vote
+                      </span>
+                      <span className="block text-xs leading-5 text-white/70">
+                        This wallet has an on-chain validator vote account. This
+                        transaction uses only the override weight for the
+                        selected stake account.
+                      </span>
+                    </span>
+                  </label>
+                </div>
+              )}
+
               {/* Error Message */}
               {error && <ErrorMessage error={error} />}
             </form>
@@ -323,6 +385,9 @@ export function OverrideVoteModal({
               !selectedProposal.id ||
               !isValidDistribution ||
               !isValidStakeAccount ||
+              isLoadingChainVoteAccount ||
+              (requiresValidatorOverrideConfirmation &&
+                !hasConfirmedValidatorOverride) ||
               isLoading
             }
             onClick={handleSubmit}

--- a/frontend/src/components/modals/__tests__/OverrideVoteModal.test.tsx
+++ b/frontend/src/components/modals/__tests__/OverrideVoteModal.test.tsx
@@ -1,0 +1,173 @@
+import React from "react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { PublicKey } from "@solana/web3.js";
+import { OverrideVoteModal } from "../OverrideVoteModal";
+import { WalletRole } from "@/types";
+
+const mockMutate = jest.fn();
+const mockUseChainVoteAccount = jest.fn();
+const mockUseWalletRole = jest.fn();
+const mockUseWalletStakeAccounts = jest.fn();
+const mockUseVoteOverrideAccounts = jest.fn();
+const mockHandleOptionChange = jest.fn();
+const mockHandleQuickSelect = jest.fn();
+const mockResetDistribution = jest.fn();
+
+jest.mock("@solana/wallet-adapter-react", () => ({
+  useAnchorWallet: jest.fn(),
+}));
+
+jest.mock("@/hooks", () => ({
+  useCastVoteOverride: jest.fn(() => ({
+    mutate: mockMutate,
+  })),
+  useChainVoteAccount: (...args: unknown[]) => mockUseChainVoteAccount(...args),
+  useVoteDistribution: jest.fn(() => ({
+    distribution: { for: 100, against: 0, abstain: 0 },
+    totalPercentage: 100,
+    isValidDistribution: true,
+    handleOptionChange: mockHandleOptionChange,
+    handleQuickSelect: mockHandleQuickSelect,
+    resetDistribution: mockResetDistribution,
+  })),
+  useVoteOverrideAccounts: (...args: unknown[]) =>
+    mockUseVoteOverrideAccounts(...args),
+  useWalletRole: (...args: unknown[]) => mockUseWalletRole(...args),
+  useWalletStakeAccounts: (...args: unknown[]) =>
+    mockUseWalletStakeAccounts(...args),
+  VOTE_OPTIONS: ["for", "against", "abstain"],
+}));
+
+jest.mock("../../StakeAccountsDropdown", () => ({
+  StakeAccountsDropdown: ({
+    onValueChange,
+  }: {
+    onValueChange: (value: string) => void;
+  }) => {
+    React.useEffect(() => {
+      onValueChange("stake-account");
+    }, [onValueChange]);
+
+    return <div>Stake account: stake-account</div>;
+  },
+}));
+
+jest.mock("../../VotingProposalsDropdown", () => ({
+  VotingProposalsDropdown: () => <div>Proposal: proposal-id</div>,
+}));
+
+jest.mock("sonner", () => ({
+  toast: {
+    success: jest.fn(),
+    error: jest.fn(),
+  },
+}));
+
+jest.mock("@sentry/nextjs", () => ({
+  captureException: jest.fn(),
+}));
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const { useAnchorWallet } = require("@solana/wallet-adapter-react");
+
+beforeAll(() => {
+  globalThis.ResizeObserver = class ResizeObserver {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  };
+});
+
+describe("OverrideVoteModal", () => {
+  const wallet = {
+    publicKey: new PublicKey("11111111111111111111111111111111"),
+    signTransaction: jest.fn(),
+    signAllTransactions: jest.fn(),
+  };
+
+  const defaultProps = {
+    isOpen: true,
+    onClose: jest.fn(),
+    proposalId: "proposal-id",
+    consensusResult: new PublicKey("11111111111111111111111111111111"),
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    useAnchorWallet.mockReturnValue(wallet);
+    mockUseWalletRole.mockReturnValue({ walletRole: WalletRole.STAKER });
+    mockUseWalletStakeAccounts.mockReturnValue({
+      data: [
+        {
+          activeStake: 1_000,
+          stakeAccount: "stake-account",
+          voteAccount: "vote-account",
+        },
+      ],
+    });
+    mockUseVoteOverrideAccounts.mockReturnValue({ data: [] });
+    mockUseChainVoteAccount.mockReturnValue({
+      data: null,
+      isLoading: false,
+    });
+  });
+
+  it("allows normal staker override votes without validator confirmation", async () => {
+    render(<OverrideVoteModal {...defaultProps} />);
+
+    expect(screen.getByText("Stake override")).toBeInTheDocument();
+    expect(
+      screen.queryByRole("checkbox", {
+        name: /submit stake override instead of validator vote/i,
+      })
+    ).not.toBeInTheDocument();
+
+    const submitButton = screen.getByRole("button", { name: "Cast Vote" });
+    await waitFor(() => expect(submitButton).not.toBeDisabled());
+
+    fireEvent.click(submitButton);
+
+    expect(mockMutate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        stakeAccount: "stake-account",
+        voteAccount: "vote-account",
+      }),
+      expect.any(Object)
+    );
+  });
+
+  it("requires explicit confirmation before a validator-identity wallet can submit an override vote", async () => {
+    mockUseChainVoteAccount.mockReturnValue({
+      data: {
+        activeStake: 1_000,
+        nodePubkey: wallet.publicKey.toBase58(),
+        voteAccount: "validator-vote-account",
+      },
+      isLoading: false,
+    });
+
+    render(<OverrideVoteModal {...defaultProps} />);
+
+    const confirmation = screen.getByRole("checkbox", {
+      name: /submit stake override instead of validator vote/i,
+    });
+    const submitButton = screen.getByRole("button", { name: "Cast Vote" });
+
+    expect(confirmation).not.toBeChecked();
+    expect(submitButton).toBeDisabled();
+
+    fireEvent.click(confirmation);
+
+    await waitFor(() => expect(submitButton).not.toBeDisabled());
+
+    fireEvent.click(submitButton);
+
+    expect(mockMutate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        stakeAccount: "stake-account",
+        voteAccount: "vote-account",
+      }),
+      expect.any(Object)
+    );
+  });
+});

--- a/frontend/src/components/proposals/ProposalCard.tsx
+++ b/frontend/src/components/proposals/ProposalCard.tsx
@@ -7,12 +7,13 @@ import { AppButton } from "@/components/ui/AppButton";
 import LifecycleIndicator from "@/components/ui/LifecycleIndicator";
 import StatusBadge from "@/components/ui/StatusBadge";
 import { useRouter } from "next/navigation";
-import { ModalType, useModal } from "@/contexts/ModalContext";
+import { useModal } from "@/contexts/ModalContext";
 import { motion } from "framer-motion";
 import { useWallet } from "@solana/wallet-adapter-react";
-import { useWalletRole } from "@/hooks";
+import { useChainVoteAccount, useWalletRole } from "@/hooks";
 import { toast } from "sonner";
 import { getProposalDetailPagePath } from "@/helpers/proposalPage";
+import { getVoteModalNames } from "@/lib/governance/role-detection";
 
 type ProposalStatus = ProposalRecord["status"];
 interface VotingDetailItem {
@@ -168,7 +169,11 @@ export default function ProposalCard({ proposal }: ProposalCardProps) {
   const { openModal } = useModal();
 
   const { publicKey: walletPubKey, connected } = useWallet();
-  const { walletRole } = useWalletRole(walletPubKey?.toBase58());
+  const { walletRole, isLoading: isLoadingWalletRole } = useWalletRole(
+    walletPubKey?.toBase58()
+  );
+  const { data: chainVoteAccount, isLoading: isLoadingChainVoteAccount } =
+    useChainVoteAccount(walletPubKey?.toBase58());
 
   const {
     status,
@@ -190,14 +195,10 @@ export default function ProposalCard({ proposal }: ProposalCardProps) {
     { label: "Voting Ends", value: votingStatusValue },
   ];
 
-  const isStaker = walletRole === WalletRole.STAKER;
-
-  let castModalName: ModalType = "cast-vote";
-  let modifyModalName: ModalType = "modify-vote";
-  if (isStaker) {
-    castModalName = "override-vote";
-    modifyModalName = "modify-override-vote";
-  }
+  const isLoadingVoteIdentity =
+    isLoadingWalletRole || isLoadingChainVoteAccount;
+  const { castModalName, modifyModalName } =
+    getVoteModalNames(chainVoteAccount);
 
   const handleCardClick = () => {
     router.push(getProposalDetailPagePath(publicKey));
@@ -211,6 +212,10 @@ export default function ProposalCard({ proposal }: ProposalCardProps) {
       toast.error(
         "Wallet not connected, please connect your wallet to be able to perform these actions",
       );
+      return;
+    }
+    if (isLoadingVoteIdentity) {
+      toast.error("Loading wallet voting identity");
       return;
     }
 
@@ -238,16 +243,20 @@ export default function ProposalCard({ proposal }: ProposalCardProps) {
 
   const disabledActionButtons =
     !connected ||
+    isLoadingVoteIdentity ||
     (walletRole === WalletRole.STAKER && proposal.status === "supporting");
 
   let disabledErrorMessage = "";
-  if (walletRole === WalletRole.STAKER && proposal.status === "supporting") {
-    disabledErrorMessage = "Only validators are allowed to support";
-  }
-
   if (!connected) {
     disabledErrorMessage =
       "Wallet not connected, please connect your wallet to be able to perform these actions";
+  } else if (isLoadingVoteIdentity) {
+    disabledErrorMessage = "Loading wallet voting identity";
+  } else if (
+    walletRole === WalletRole.STAKER &&
+    proposal.status === "supporting"
+  ) {
+    disabledErrorMessage = "Only validators are allowed to support";
   }
 
   return (

--- a/frontend/src/components/proposals/detail/CastVote.tsx
+++ b/frontend/src/components/proposals/detail/CastVote.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { AppButton } from "@/components/ui/AppButton";
-import { ModalType, useModal } from "@/contexts/ModalContext";
+import { useModal } from "@/contexts/ModalContext";
 import { PublicKey } from "@solana/web3.js";
 import { Ban, ThumbsDown, ThumbsUp } from "lucide-react";
 
@@ -11,9 +11,10 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
-import { ProposalRecord, WalletRole } from "@/types";
-import { useHasUserVoted, useWalletRole } from "@/hooks";
+import { ProposalRecord } from "@/types";
+import { useChainVoteAccount, useHasUserVoted, useWalletRole } from "@/hooks";
 import { toast } from "sonner";
+import { getVoteModalNames } from "@/lib/governance/role-detection";
 
 interface CastVoteProps {
   proposalPublicKey: PublicKey | undefined;
@@ -50,24 +51,27 @@ function CastVote({
 }: CastVoteProps) {
   const { openModal } = useModal();
   const { publicKey } = useWallet();
-  const { walletRole } = useWalletRole(publicKey?.toBase58());
-
-  const isStaker = walletRole === WalletRole.STAKER;
-
-  let modalName: ModalType = "cast-vote";
-  if (isStaker) {
-    modalName = "override-vote";
-  }
+  const { isLoading: isLoadingWalletRole } = useWalletRole(
+    publicKey?.toBase58()
+  );
+  const { data: chainVoteAccount, isLoading: isLoadingChainVoteAccount } =
+    useChainVoteAccount(publicKey?.toBase58());
+  const { castModalName } = getVoteModalNames(chainVoteAccount);
 
   const { data: hasUserVoted = false, isLoading: isLoadingHasUserVoted } =
     useHasUserVoted(proposalPublicKey?.toBase58());
 
   const disabledButtons =
-    disabled || !proposalPublicKey || isLoadingHasUserVoted || hasUserVoted;
+    disabled ||
+    !proposalPublicKey ||
+    isLoadingWalletRole ||
+    isLoadingChainVoteAccount ||
+    isLoadingHasUserVoted ||
+    hasUserVoted;
 
   const handleVoteFor = () => {
     if (proposalPublicKey && consensusResult) {
-      openModal(modalName, {
+      openModal(castModalName, {
         consensusResult,
         proposalId: proposalPublicKey.toBase58(),
         initialVoteDist: { for: 100, abstain: 0, against: 0 },
@@ -76,7 +80,7 @@ function CastVote({
   };
   const handleVoteAgainst = () => {
     if (proposalPublicKey && consensusResult) {
-      openModal(modalName, {
+      openModal(castModalName, {
         consensusResult,
         proposalId: proposalPublicKey.toBase58(),
         initialVoteDist: { against: 100, for: 0, abstain: 0 },
@@ -85,7 +89,7 @@ function CastVote({
   };
   const handleVoteAbstain = () => {
     if (proposalPublicKey && consensusResult) {
-      openModal(modalName, {
+      openModal(castModalName, {
         consensusResult,
         proposalId: proposalPublicKey.toBase58(),
         initialVoteDist: { abstain: 100, for: 0, against: 0 },

--- a/frontend/src/components/proposals/proposals-table/ExternalProposalPanel.tsx
+++ b/frontend/src/components/proposals/proposals-table/ExternalProposalPanel.tsx
@@ -12,12 +12,13 @@ import {
 } from "@/components/ui/tooltip";
 import { useWallet } from "@solana/wallet-adapter-react";
 import { ProposalDescription } from "../ProposalDescription";
-import { ProposalRecord, ProposalStatus, WalletRole } from "@/types";
-import { useWalletRole } from "@/hooks";
+import { ProposalRecord, ProposalStatus } from "@/types";
+import { useChainVoteAccount, useWalletRole } from "@/hooks";
 import { SupportButton } from "../SupportButton";
 import { PublicKey } from "@solana/web3.js";
 import { toast } from "sonner";
 import { getProposalDetailPagePath } from "@/helpers/proposalPage";
+import { getVoteModalNames } from "@/lib/governance/role-detection";
 
 const VOTE_STATE_LABEL: Record<ProposalRecord["status"], string> = {
   supporting: "Supporting",
@@ -111,11 +112,16 @@ function VoteActions({
 }) {
   const { openModal } = useModal();
   const { publicKey } = useWallet();
-  const { walletRole } = useWalletRole(publicKey?.toBase58());
+  const { isLoading: isLoadingWalletRole } = useWalletRole(
+    publicKey?.toBase58()
+  );
+  const { data: chainVoteAccount, isLoading: isLoadingChainVoteAccount } =
+    useChainVoteAccount(publicKey?.toBase58());
 
-  const isValidator = walletRole === WalletRole.VALIDATOR;
-  const isStaker = walletRole === WalletRole.STAKER;
-  const isBoth = walletRole === WalletRole.BOTH;
+  const isLoadingVoteIdentity =
+    isLoadingWalletRole || isLoadingChainVoteAccount;
+  const { castModalName, modifyModalName } =
+    getVoteModalNames(chainVoteAccount);
 
   const isVoting = state === "voting";
 
@@ -127,19 +133,16 @@ function VoteActions({
             variant="outline"
             text="Modify Vote"
             className="w-full justify-center border-white/15 bg-white/10 text-sm font-medium text-white/75 hover:text-white"
-            disabled={disabled || consensusResult === undefined}
+            disabled={
+              disabled || consensusResult === undefined || isLoadingVoteIdentity
+            }
             onClick={() => {
               if (consensusResult && proposalId) {
-                if (isValidator || isBoth) {
-                  openModal("modify-vote", { proposalId, consensusResult });
-                } else if (isStaker) {
-                  openModal("modify-override-vote", {
-                    proposalId,
-                    consensusResult,
-                  });
-                } else {
-                  toast.error("Couldn't obtain consensus result");
-                }
+                openModal(modifyModalName, { proposalId, consensusResult });
+              } else if (isLoadingVoteIdentity) {
+                toast.error("Loading wallet voting identity");
+              } else {
+                toast.error("Couldn't obtain consensus result");
               }
             }}
           />
@@ -147,14 +150,14 @@ function VoteActions({
             variant="gradient"
             text="Cast Vote"
             className="w-full justify-center text-sm font-semibold text-foreground"
-            disabled={disabled || consensusResult === undefined}
+            disabled={
+              disabled || consensusResult === undefined || isLoadingVoteIdentity
+            }
             onClick={() => {
               if (consensusResult && proposalId) {
-                if (isValidator || isBoth) {
-                  openModal("cast-vote", { proposalId, consensusResult });
-                } else if (isStaker) {
-                  openModal("override-vote", { proposalId, consensusResult });
-                }
+                openModal(castModalName, { proposalId, consensusResult });
+              } else if (isLoadingVoteIdentity) {
+                toast.error("Loading wallet voting identity");
               } else {
                 toast.error("Couldn't obtain consensus result");
               }

--- a/frontend/src/hooks/index.ts
+++ b/frontend/src/hooks/index.ts
@@ -25,6 +25,7 @@ export * from "./useVoteAccountsWithValidators";
 export * from "./useProposalVotes";
 
 export * from "./useChainVoteAccounts";
+export * from "./useChainVoteAccount";
 export * from "./useRawVoteAccounts";
 
 export * from "./useHasUserVoted";

--- a/frontend/src/hooks/useChainVoteAccount.ts
+++ b/frontend/src/hooks/useChainVoteAccount.ts
@@ -6,11 +6,16 @@ import { useChainVoteAccounts } from "./useChainVoteAccounts";
 export const useChainVoteAccount = (userPubKey: string | undefined) => {
   const { endpointUrl: endpoint } = useEndpoint();
 
-  const { data: chainVoteAccounts = [] } = useChainVoteAccounts();
+  const {
+    data: chainVoteAccounts = [],
+    isLoading: isLoadingChainVoteAccounts,
+    isPending: isPendingChainVoteAccounts,
+  } = useChainVoteAccounts();
 
-  const enabled = !!userPubKey && chainVoteAccounts.length > 0;
+  const enabled =
+    !!userPubKey && !isLoadingChainVoteAccounts && !isPendingChainVoteAccounts;
 
-  return useQuery({
+  const query = useQuery({
     staleTime: 1000 * 120, // 2 minutes
     enabled,
     queryKey: [
@@ -27,4 +32,13 @@ export const useChainVoteAccount = (userPubKey: string | undefined) => {
       return chainVoteAccount || null;
     },
   });
+
+  const isWaitingForChainVoteAccounts =
+    !!userPubKey && (isLoadingChainVoteAccounts || isPendingChainVoteAccounts);
+
+  return {
+    ...query,
+    isLoading: isWaitingForChainVoteAccounts || query.isLoading,
+    isPending: isWaitingForChainVoteAccounts || query.isPending,
+  };
 };

--- a/frontend/src/hooks/useWalletRole.ts
+++ b/frontend/src/hooks/useWalletRole.ts
@@ -22,9 +22,13 @@ export function useWalletRole(
     "staker"
   );
 
-  const { data, isLoading } = useVoterWalletSummary(userPubKey);
+  const { data, isLoading: isLoadingWalletSummary } =
+    useVoterWalletSummary(userPubKey);
 
-  const { data: chainVoteAccount } = useChainVoteAccount(userPubKey);
+  const { data: chainVoteAccount, isLoading: isLoadingChainVoteAccount } =
+    useChainVoteAccount(userPubKey);
+
+  const isLoading = isLoadingWalletSummary || isLoadingChainVoteAccount;
 
   useEffect(() => {
     if (isLoading || data === undefined) return;
@@ -32,7 +36,7 @@ export function useWalletRole(
     const role = determineWalletRole(
       data.stake_accounts,
       data.vote_accounts,
-      chainVoteAccount || undefined
+      chainVoteAccount
     );
 
     setWalletRole(role);

--- a/frontend/src/lib/governance/__tests__/role-detection.test.ts
+++ b/frontend/src/lib/governance/__tests__/role-detection.test.ts
@@ -1,0 +1,63 @@
+import type { ChainVoteAccountData } from "@/chain";
+import {
+  determineWalletRole,
+  getVoteModalNames,
+  hasOnChainValidatorIdentity,
+  WalletRole,
+} from "../role-detection";
+
+const chainVoteAccount: ChainVoteAccountData = {
+  activeStake: 1_000,
+  nodePubkey: "validator-wallet",
+  voteAccount: "validator-vote-account",
+};
+
+describe("determineWalletRole", () => {
+  it("keeps on-chain validator identity authoritative when verifier vote accounts are suppressed", () => {
+    const role = determineWalletRole(
+      [{ stakeAccount: "stake-account" }],
+      [],
+      chainVoteAccount
+    );
+
+    expect(role).toBe(WalletRole.BOTH);
+  });
+
+  it("detects validator-only wallets from on-chain identity", () => {
+    const role = determineWalletRole(undefined, [], chainVoteAccount);
+
+    expect(role).toBe(WalletRole.VALIDATOR);
+  });
+
+  it("does not treat verifier-only vote account summaries as validator identity", () => {
+    const role = determineWalletRole(
+      [{ stakeAccount: "stake-account" }],
+      [{ voteAccount: "verifier-vote-account" }],
+      null
+    );
+
+    expect(role).toBe(WalletRole.STAKER);
+  });
+});
+
+describe("vote path modal selection", () => {
+  it("routes on-chain validators through validator vote modals", () => {
+    expect(getVoteModalNames(chainVoteAccount)).toEqual({
+      castModalName: "cast-vote",
+      modifyModalName: "modify-vote",
+    });
+  });
+
+  it("routes wallets without validator identity through stake override modals", () => {
+    expect(getVoteModalNames(null)).toEqual({
+      castModalName: "override-vote",
+      modifyModalName: "modify-override-vote",
+    });
+  });
+
+  it("reports validator identity only from positive chain data", () => {
+    expect(hasOnChainValidatorIdentity(chainVoteAccount)).toBe(true);
+    expect(hasOnChainValidatorIdentity(null)).toBe(false);
+    expect(hasOnChainValidatorIdentity(undefined)).toBe(false);
+  });
+});

--- a/frontend/src/lib/governance/role-detection.ts
+++ b/frontend/src/lib/governance/role-detection.ts
@@ -10,18 +10,45 @@ export enum WalletRole {
 
 export function determineWalletRole(
   stakeAccounts: unknown[] | undefined,
-  voteAccounts: unknown[] | undefined,
-  chainVoteAccount: ChainVoteAccountData | undefined
+  _voteAccounts: unknown[] | undefined,
+  chainVoteAccount: ChainVoteAccountData | null | undefined
 ): WalletRole {
   const hasStake = !!stakeAccounts?.length;
-  const hasVoteAccounts = !!voteAccounts?.length && !!chainVoteAccount;
+  const hasValidatorIdentity = hasOnChainValidatorIdentity(chainVoteAccount);
 
-  if (hasStake && hasVoteAccounts) return WalletRole.BOTH;
+  if (hasStake && hasValidatorIdentity) return WalletRole.BOTH;
+  else if (hasValidatorIdentity) return WalletRole.VALIDATOR;
   else if (hasStake) return WalletRole.STAKER;
-  else if (hasVoteAccounts) return WalletRole.VALIDATOR;
 
   // default to staker even if there are no stake accounts
   return WalletRole.STAKER;
+}
+
+export function hasOnChainValidatorIdentity(
+  chainVoteAccount: ChainVoteAccountData | null | undefined
+): boolean {
+  return chainVoteAccount != null;
+}
+
+export type VoteModalNames = {
+  castModalName: "cast-vote" | "override-vote";
+  modifyModalName: "modify-vote" | "modify-override-vote";
+};
+
+export function getVoteModalNames(
+  chainVoteAccount: ChainVoteAccountData | null | undefined
+): VoteModalNames {
+  if (hasOnChainValidatorIdentity(chainVoteAccount)) {
+    return {
+      castModalName: "cast-vote",
+      modifyModalName: "modify-vote",
+    };
+  }
+
+  return {
+    castModalName: "override-vote",
+    modifyModalName: "modify-override-vote",
+  };
 }
 
 export function getDefaultView(role: WalletRole): ViewType | undefined {


### PR DESCRIPTION
## Summary

This PR fixes a vote-routing issue where the UI could treat a validator wallet as a staker if verifier-provided `/voter` data omitted the wallet’s vote accounts.

The UI now treats the on-chain validator vote account as the source of truth. If a wallet has an on-chain validator identity, the normal `Cast Vote` and `Modify Vote` actions open the validator vote flow, even if verifier summary data is missing or incomplete.

This prevents a compromised or incorrect verifier from steering validators into the lower-weight stake override flow.

## What Changed

- Make on-chain `chainVoteAccount` authoritative for validator identity.
- Route vote modals from on-chain identity instead of verifier `/voter` summaries.
- Keep vote actions disabled while wallet voting identity is still loading.
- Show the vote path before signing: `Validator vote` or `Stake override`.
- Add an explicit confirmation before submitting a stake override from a wallet that also has validator identity.
- Add tests covering verifier-suppressed vote accounts and the override confirmation flow.

## Why

A validator should not be downgraded to a staker because verifier data is missing or maliciously suppressed. The user’s vote path should be based on verifiable on-chain identity so the UI does not accidentally submit a lower-weight override vote when the user expects a full validator vote.

## Test Plan
- `pnpm run lint`
- `pnpm exec tsc --noEmit`
- `pnpm test -- --runInBand`


<!-- apex-fix-review:eyJ2IjoidjEiLCJoIjoiM2RjOTgwNDQtYTllYy00ZGJkLWFiNzUtYTY3MTBjYWYxYjlhIiwiZiI6ImY5MzFkMjQyLTlkNzgtNGM5ZS05MDk4LTc5ZTk5MjZkZWUzZSIsImUiOjE3ODI3NTE3Mjh9.6-4iyG7-IHDIpUXCzW10v33-7D9mXU7GxnBqjC-Kpeo -->