### PR TITLE
fix(verifier): fully replace slot rows on reupload to prevent hybrid snapshots

### DIFF
--- a/ncn/verifier-service/src/database/operations.rs
+++ b/ncn/verifier-service/src/database/operations.rs
@@ -37,6 +37,24 @@ impl VoteAccountRecord {
         Ok(())
     }
 
+    /// Delete every vote account row for a given `(network, slot)`.
+    ///
+    /// Used to fully replace a slot's rows when it is reindexed, so accounts
+    /// that are omitted from a same-slot reupload cannot survive and produce a
+    /// hybrid snapshot.
+    pub async fn delete_by_slot<'e, E>(exec: E, network: &str, snapshot_slot: u64) -> Result<()>
+    where
+        E: Executor<'e, Database = Sqlite>,
+    {
+        sqlx::query("DELETE FROM vote_accounts WHERE network = ? AND snapshot_slot = ?")
+            .bind(network)
+            .bind(i64::try_from(snapshot_slot)?)
+            .execute(exec)
+            .await?;
+
+        Ok(())
+    }
+
     /// Get vote account summaries filtered by voting wallet
     pub async fn get_summary_by_voting_wallet(
         pool: &SqlitePool,
@@ -126,6 +144,24 @@ impl StakeAccountRecord {
         .bind(serde_json::to_string(&self.stake_merkle_proof)?)
         .execute(exec)
         .await?;
+
+        Ok(())
+    }
+
+    /// Delete every stake account row for a given `(network, slot)`.
+    ///
+    /// Used to fully replace a slot's rows when it is reindexed, so accounts
+    /// that are omitted from a same-slot reupload cannot survive and produce a
+    /// hybrid snapshot.
+    pub async fn delete_by_slot<'e, E>(exec: E, network: &str, snapshot_slot: u64) -> Result<()>
+    where
+        E: Executor<'e, Database = Sqlite>,
+    {
+        sqlx::query("DELETE FROM stake_accounts WHERE network = ? AND snapshot_slot = ?")
+            .bind(network)
+            .bind(i64::try_from(snapshot_slot)?)
+            .execute(exec)
+            .await?;
 
         Ok(())
     }

--- a/ncn/verifier-service/src/upload.rs
+++ b/ncn/verifier-service/src/upload.rs
@@ -149,6 +149,16 @@ async fn index_snapshot_data(
     // Begin transaction for atomic indexing
     let mut tx = pool.begin().await?;
 
+    // Treat a same-slot reupload as a full replacement, not a merge. Clear any
+    // rows left by a previous upload of this `(network, slot)` before
+    // repopulating, so accounts that are omitted from the new snapshot cannot
+    // survive. Without this, an upsert-only path leaves stale rows behind while
+    // `snapshot_meta` advertises the new `snapshot_hash`, yielding a hybrid
+    // snapshot where `/meta` and `/proof`/`/voter` disagree. The deletes and
+    // inserts share one transaction, so readers never observe a partial state.
+    VoteAccountRecord::delete_by_slot(&mut *tx, network, snapshot.slot).await?;
+    StakeAccountRecord::delete_by_slot(&mut *tx, network, snapshot.slot).await?;
+
     // Index vote accounts and stake accounts
     for (bundle_idx, bundle) in snapshot.leaf_bundles.iter().enumerate() {
         if bundle_idx % 100 == 0 {

--- a/ncn/verifier-service/tests/e2e_binary.rs
+++ b/ncn/verifier-service/tests/e2e_binary.rs
@@ -341,3 +341,188 @@ async fn e2e_rejects_replayed_signature_and_incoherent_stake_root() -> anyhow::R
 fn encode_snapshot(snapshot: &cli::MetaMerkleSnapshot) -> anyhow::Result<Vec<u8>> {
     Ok(snapshot.to_compressed_bytes()?)
 }
+
+/// Reuploading the same `(network, slot)` with a different (subset) snapshot
+/// body must fully replace the slot's rows, not merge into a hybrid snapshot.
+/// Rows for accounts omitted from the reupload must be cleared so that `/meta`,
+/// `/proof/*`, and `/voter/*` all describe the single snapshot identified by the
+/// advertised `snapshot_hash`.
+#[tokio::test]
+#[serial_test::serial]
+async fn e2e_same_slot_reupload_fully_replaces_rows() -> anyhow::Result<()> {
+    let keypair = Keypair::new();
+    let (base_url, _guard) = setup_server(&keypair).await?;
+    let client = reqwest::Client::new();
+
+    let snapshot_path = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .unwrap()
+        .join("tests/src/fixtures/meta_merkle_340850340.zip");
+    let full_bytes = tokio::fs::read(&snapshot_path).await?;
+    let (full_snapshot, full_hash) =
+        cli::MetaMerkleSnapshot::read_from_bytes_with_hash(full_bytes.clone(), true)?;
+
+    assert!(
+        full_snapshot.leaf_bundles.len() >= 2,
+        "fixture must contain at least two bundles"
+    );
+
+    let slot = full_snapshot.slot;
+    let merkle_root = bs58::encode(full_snapshot.root).into_string();
+    let full_hash = bs58::encode(full_hash.to_bytes()).into_string();
+    let full_signature = sign_upload_message(&keypair, slot, NETWORK, &merkle_root, &full_hash);
+
+    // First upload: the complete fixture snapshot.
+    let full_upload = Form::new()
+        .text("slot", slot.to_string())
+        .text("network", NETWORK)
+        .text("merkle_root", merkle_root.clone())
+        .text("snapshot_hash", full_hash.clone())
+        .text("signature", full_signature)
+        .part("file", Part::bytes(full_bytes).file_name("full_snapshot.zip"));
+    let resp = client
+        .post(format!("{}/upload", base_url))
+        .multipart(full_upload)
+        .send()
+        .await?;
+    assert!(
+        resp.status().is_success(),
+        "full upload failed status={}",
+        resp.status()
+    );
+
+    // Keep (and modify) the first bundle; omit the second on the reupload.
+    let mut modified_bundle = full_snapshot.leaf_bundles[0].clone();
+    let omitted_bundle = full_snapshot.leaf_bundles[1].clone();
+    modified_bundle.meta_merkle_leaf.active_stake = modified_bundle
+        .meta_merkle_leaf
+        .active_stake
+        .saturating_add(1);
+
+    // The omitted account is queryable after the full upload.
+    let omitted_vote_account = omitted_bundle.meta_merkle_leaf.vote_account.to_string();
+    let omitted_before = client
+        .get(format!(
+            "{}/proof/vote_account/{}?network={}&slot={}",
+            base_url, omitted_vote_account, NETWORK, slot
+        ))
+        .send()
+        .await?;
+    assert!(
+        omitted_before.status().is_success(),
+        "omitted account should be present after the full upload, got status={}",
+        omitted_before.status()
+    );
+
+    // Second upload: same (network, slot), only the modified bundle. Signed with
+    // its own snapshot hash so it passes the byte-binding check.
+    let modified_snapshot = cli::MetaMerkleSnapshot {
+        root: full_snapshot.root,
+        leaf_bundles: vec![modified_bundle.clone()],
+        slot,
+    };
+    let modified_bytes = modified_snapshot.to_compressed_bytes()?;
+    let (_, modified_hash) =
+        cli::MetaMerkleSnapshot::read_from_bytes_with_hash(modified_bytes.clone(), true)?;
+    let modified_hash = bs58::encode(modified_hash.to_bytes()).into_string();
+    assert_ne!(
+        modified_hash, full_hash,
+        "reupload must carry a distinct snapshot hash"
+    );
+    let modified_signature =
+        sign_upload_message(&keypair, slot, NETWORK, &merkle_root, &modified_hash);
+
+    let modified_upload = Form::new()
+        .text("slot", slot.to_string())
+        .text("network", NETWORK)
+        .text("merkle_root", merkle_root.clone())
+        .text("snapshot_hash", modified_hash.clone())
+        .text("signature", modified_signature)
+        .part(
+            "file",
+            Part::bytes(modified_bytes).file_name("modified_snapshot.zip"),
+        );
+    let resp = client
+        .post(format!("{}/upload", base_url))
+        .multipart(modified_upload)
+        .send()
+        .await?;
+    assert!(
+        resp.status().is_success(),
+        "modified upload failed status={}",
+        resp.status()
+    );
+
+    // /meta now advertises the new snapshot hash.
+    let meta: serde_json::Value = client
+        .get(format!("{}/meta?network={}", base_url, NETWORK))
+        .send()
+        .await?
+        .error_for_status()?
+        .json()
+        .await?;
+    assert_eq!(meta["snapshot_hash"], modified_hash);
+
+    // The modified account reflects the reuploaded data.
+    let modified_vote_account = modified_bundle.meta_merkle_leaf.vote_account.to_string();
+    let modified_proof: serde_json::Value = client
+        .get(format!(
+            "{}/proof/vote_account/{}?network={}&slot={}",
+            base_url, modified_vote_account, NETWORK, slot
+        ))
+        .send()
+        .await?
+        .error_for_status()?
+        .json()
+        .await?;
+    assert_eq!(
+        modified_proof["meta_merkle_leaf"]["active_stake"].as_u64(),
+        Some(modified_bundle.meta_merkle_leaf.active_stake)
+    );
+
+    // The omitted account is no longer queryable for this slot: the reupload
+    // fully replaced the slot instead of leaving a hybrid snapshot behind.
+    let omitted_after = client
+        .get(format!(
+            "{}/proof/vote_account/{}?network={}&slot={}",
+            base_url, omitted_vote_account, NETWORK, slot
+        ))
+        .send()
+        .await?;
+    assert_eq!(
+        omitted_after.status(),
+        StatusCode::NOT_FOUND,
+        "omitted vote account must be cleared on reupload"
+    );
+
+    // A stake row under the omitted bundle must be cleared too. Check a single
+    // representative account (one not also present in the retained bundle) to
+    // stay within the request rate limit.
+    let retained_stake_accounts: std::collections::HashSet<String> = modified_bundle
+        .stake_merkle_leaves
+        .iter()
+        .map(|leaf| leaf.stake_account.to_string())
+        .collect();
+    if let Some(stake_account) = omitted_bundle
+        .stake_merkle_leaves
+        .iter()
+        .map(|leaf| leaf.stake_account.to_string())
+        .find(|account| !retained_stake_accounts.contains(account))
+    {
+        let stake_after = client
+            .get(format!(
+                "{}/proof/stake_account/{}?network={}&slot={}",
+                base_url, stake_account, NETWORK, slot
+            ))
+            .send()
+            .await?;
+        assert_eq!(
+            stake_after.status(),
+            StatusCode::NOT_FOUND,
+            "omitted stake account {} must be cleared on reupload",
+            stake_account
+        );
+    }
+
+    Ok(())
+}

--- a/ncn/verifier-service/tests/e2e_binary.rs
+++ b/ncn/verifier-service/tests/e2e_binary.rs
@@ -1,6 +1,7 @@
 mod common;
 use common::setup_server;
 
+use meta_merkle_tree::{merkle_tree::MerkleTree, utils::get_proof};
 use reqwest::{
     multipart::{Form, Part},
     StatusCode,
@@ -399,6 +400,17 @@ async fn e2e_same_slot_reupload_fully_replaces_rows() -> anyhow::Result<()> {
         .active_stake
         .saturating_add(1);
 
+    // Re-derive the meta-merkle root and proof over the replacement leaf set
+    // (a single bundle here), mirroring how the CLI builds a snapshot. A real
+    // operator computes a fresh root for the bundles they actually upload;
+    // reusing the original full-tree root would leave merkle_root and the
+    // stored meta_merkle_proof cryptographically stale for the new data.
+    let meta_hashed_nodes = vec![modified_bundle.meta_merkle_leaf.hash().to_bytes()];
+    let meta_merkle = MerkleTree::new(&meta_hashed_nodes[..], true);
+    let modified_root = meta_merkle.get_root().expect("meta merkle root").to_bytes();
+    modified_bundle.proof = Some(get_proof(&meta_merkle, 0));
+    let modified_merkle_root = bs58::encode(modified_root).into_string();
+
     // The omitted account is queryable after the full upload.
     let omitted_vote_account = omitted_bundle.meta_merkle_leaf.vote_account.to_string();
     let omitted_before = client
@@ -414,10 +426,11 @@ async fn e2e_same_slot_reupload_fully_replaces_rows() -> anyhow::Result<()> {
         omitted_before.status()
     );
 
-    // Second upload: same (network, slot), only the modified bundle. Signed with
-    // its own snapshot hash so it passes the byte-binding check.
+    // Second upload: same (network, slot), only the modified bundle, committed
+    // to by its own freshly-derived root. Signed with its own snapshot hash so
+    // it passes the byte-binding check.
     let modified_snapshot = cli::MetaMerkleSnapshot {
-        root: full_snapshot.root,
+        root: modified_root,
         leaf_bundles: vec![modified_bundle.clone()],
         slot,
     };
@@ -430,12 +443,12 @@ async fn e2e_same_slot_reupload_fully_replaces_rows() -> anyhow::Result<()> {
         "reupload must carry a distinct snapshot hash"
     );
     let modified_signature =
-        sign_upload_message(&keypair, slot, NETWORK, &merkle_root, &modified_hash);
+        sign_upload_message(&keypair, slot, NETWORK, &modified_merkle_root, &modified_hash);
 
     let modified_upload = Form::new()
         .text("slot", slot.to_string())
         .text("network", NETWORK)
-        .text("merkle_root", merkle_root.clone())
+        .text("merkle_root", modified_merkle_root.clone())
         .text("snapshot_hash", modified_hash.clone())
         .text("signature", modified_signature)
         .part(
@@ -453,7 +466,7 @@ async fn e2e_same_slot_reupload_fully_replaces_rows() -> anyhow::Result<()> {
         resp.status()
     );
 
-    // /meta now advertises the new snapshot hash.
+    // /meta now advertises the new snapshot hash and the new (consistent) root.
     let meta: serde_json::Value = client
         .get(format!("{}/meta?network={}", base_url, NETWORK))
         .send()
@@ -462,8 +475,10 @@ async fn e2e_same_slot_reupload_fully_replaces_rows() -> anyhow::Result<()> {
         .json()
         .await?;
     assert_eq!(meta["snapshot_hash"], modified_hash);
+    assert_eq!(meta["merkle_root"], modified_merkle_root);
 
-    // The modified account reflects the reuploaded data.
+    // The modified account reflects the reuploaded data, and its served proof
+    // is the one derived from the replacement tree (empty for a single leaf).
     let modified_vote_account = modified_bundle.meta_merkle_leaf.vote_account.to_string();
     let modified_proof: serde_json::Value = client
         .get(format!(
@@ -478,6 +493,17 @@ async fn e2e_same_slot_reupload_fully_replaces_rows() -> anyhow::Result<()> {
     assert_eq!(
         modified_proof["meta_merkle_leaf"]["active_stake"].as_u64(),
         Some(modified_bundle.meta_merkle_leaf.active_stake)
+    );
+    let expected_proof: Vec<String> = modified_bundle
+        .proof
+        .clone()
+        .unwrap_or_default()
+        .into_iter()
+        .map(|hash| bs58::encode(hash).into_string())
+        .collect();
+    assert_eq!(
+        modified_proof["meta_merkle_proof"],
+        serde_json::json!(expected_proof)
     );
 
     // The omitted account is no longer queryable for this slot: the reupload


### PR DESCRIPTION
## Summary

Same-slot reuploads were **merged**, not **replaced**. `index_snapshot_data` upserts only the rows present in the new upload (`ON CONFLICT … DO UPDATE`) and overwrites `snapshot_meta`, so `vote_accounts` / `stake_accounts` that are omitted from a same-slot reupload survive under the same `(network, slot)`.

That let `/meta` advertise one `snapshot_hash` while `/proof/*` and `/voter/*` served a **hybrid** of two different snapshots for the same slot — an attacker controlling a valid signed upload for an already-indexed slot could selectively suppress accounts while the published metadata looked clean.

## Fix

Treat a same-slot reindex as a **full replacement**. Inside the existing indexing transaction, delete all `vote_accounts` and `stake_accounts` for `(network, slot)` **before** repopulating from the validated snapshot, with `snapshot_meta` written last. The deletes and inserts share a single transaction, so readers never observe a partial/hybrid state.

- `database/operations.rs`: add `VoteAccountRecord::delete_by_slot` and `StakeAccountRecord::delete_by_slot`, both taking a transaction executor so they run in the same atomic unit.
- `upload.rs`: clear the slot's rows at the start of the indexing transaction, before the bundle loop.

This satisfies the invariant — rows served for a given `(network, slot)` always correspond exactly to the snapshot identified by that slot's `snapshot_meta.snapshot_hash` — not merely the original exploit path.

## Tests

- New e2e regression test `e2e_same_slot_reupload_fully_replaces_rows`: uploads the full fixture snapshot, then reuploads a same-`(network, slot)` subset containing a single modified bundle. Asserts `/meta` switches to the new `snapshot_hash`, the retained account reflects the new data, and the omitted vote/stake accounts are no longer queryable (`404`).
- Verified the test **fails** without the fix (omitted account returns `200` instead of `404`) and **passes** with it.
- Full `verifier-service` suite green (unit + all e2e tests). No previously accepted input is rejected; idempotent re-uploads of identical bytes still succeed.

<!-- apex-fix-review:eyJ2IjoidjEiLCJoIjoiMzAxZmUzN2QtNTUyMS00MGE5LWE4OGQtMTdjZTRjNGI1ZTFlIiwiZiI6IjRmNDg0ZjllLTk1NDctNDM2OS04ZmUxLWRhZGZhNWI3NTkxZSIsImUiOjE3ODI3NTE3NDV9.U50qBKCT1l0sVkhyiWQv-rOik_8iSueGV3ol4CW1-Vw -->
