### PR TITLE
fix(ncn-router): dedupe whitelist by canonical origin (slash-variant follow-up to #82)

### DIFF
--- a/ncn-router/src/cron_job.rs
+++ b/ncn-router/src/cron_job.rs
@@ -371,24 +371,41 @@ fn compare_with_chain(
     Ok(())
 }
 
-/// Keep one canonical whitelist record per verifier origin (`domain`).
+/// Canonical routing identity for a verifier origin. `ncn-router` redirects to
+/// `domain` after ensuring a trailing slash, so `http://x` and `http://x/`
+/// resolve to the same upstream. De-duplicating on this canonical form (rather
+/// than the raw string) prevents slash variants from surviving as separate
+/// whitelist rows that the router would later collapse to one upstream — i.e.
+/// extra routing tickets for a single origin. Matches `canonical_domain` in
+/// `ncn-router`'s `router.rs`.
+fn canonical_domain(domain: &str) -> String {
+    if domain.ends_with('/') {
+        domain.to_string()
+    } else {
+        format!("{}/", domain)
+    }
+}
+
+/// Keep one canonical whitelist record per verifier origin (canonical `domain`).
 ///
-/// When a domain appears more than once (e.g. it is listed twice in the config),
-/// an `ok` record is preferred over a non-`ok` one so a transient failure on one
-/// poll cannot shadow a successful poll for the same origin. Among records of the
-/// same rank the first occurrence wins, which keeps the output deterministic in
-/// config order. This still collapses each origin to a single row, so a verifier
-/// can never hold extra routing tickets — it just avoids demoting an origin that
-/// did verify successfully. Mirrors the `status == "ok"`-first selection in
-/// `ncn-router`'s `select_routable_verifiers`.
+/// When a domain appears more than once (e.g. it is listed twice in the config,
+/// possibly with trailing-slash variants), an `ok` record is preferred over a
+/// non-`ok` one so a transient failure on one poll cannot shadow a successful
+/// poll for the same origin. Among records of the same rank the first occurrence
+/// wins, which keeps the output deterministic in config order. This still
+/// collapses each origin to a single row, so a verifier can never hold extra
+/// routing tickets — it just avoids demoting an origin that did verify
+/// successfully. Mirrors the `status == "ok"`-first selection in `ncn-router`'s
+/// `select_routable_verifiers`.
 fn dedupe_verifiers_by_domain(verifiers: Vec<WhitelistVerifier>) -> Vec<WhitelistVerifier> {
     let mut index_by_domain: std::collections::HashMap<String, usize> =
         std::collections::HashMap::new();
     let mut deduped: Vec<WhitelistVerifier> = Vec::new();
     for verifier in verifiers {
-        match index_by_domain.get(&verifier.domain) {
+        let key = canonical_domain(&verifier.domain);
+        match index_by_domain.get(&key) {
             None => {
-                index_by_domain.insert(verifier.domain.clone(), deduped.len());
+                index_by_domain.insert(key, deduped.len());
                 deduped.push(verifier);
             }
             Some(&idx) => {
@@ -686,5 +703,26 @@ mod tests {
         assert_eq!(dup.status, "ok");
         assert_eq!(dup.name, "succeeded");
         assert_eq!(deduped[0].domain, "http://dup");
+    }
+
+    #[test]
+    fn dedupe_collapses_trailing_slash_domain_variants() {
+        // `http://evil` and `http://evil/` resolve to the same upstream in the
+        // router, so they must collapse to a single whitelist row even though the
+        // raw strings differ.
+        let verifiers = vec![
+            verifier("evil", "http://evil", "ok"),
+            verifier("evil-slash", "http://evil/", "ok"),
+            verifier("other", "http://other", "ok"),
+        ];
+        let deduped = dedupe_verifiers_by_domain(verifiers);
+        assert_eq!(deduped.len(), 2);
+        assert_eq!(
+            deduped
+                .iter()
+                .filter(|v| canonical_domain(&v.domain) == "http://evil/")
+                .count(),
+            1
+        );
     }
 }

--- a/ncn-router/src/router.rs
+++ b/ncn-router/src/router.rs
@@ -206,10 +206,9 @@ fn handle_request(state: Arc<RouterState>, request: tiny_http::Request) {
 
     let chosen = ok_verifiers.choose(&mut rng).unwrap();
 
-    let mut target = chosen.domain.clone();
-    if !target.ends_with('/') {
-        target.push('/');
-    }
+    // Build the upstream base from the same canonical form used for de-duplication,
+    // so the routing identity is consistent end to end.
+    let mut target = canonical_domain(&chosen.domain);
 
     let relative_path = path.trim_start_matches('/');
     target.push_str(relative_path);
@@ -315,17 +314,31 @@ fn split_path_and_query(url: &str) -> (&str, Vec<(String, String)>) {
     (path, pairs)
 }
 
+/// Canonical routing identity for a verifier origin. The router redirects to
+/// `domain` after ensuring a trailing slash, so `http://x` and `http://x/`
+/// resolve to the same upstream. Using this as the de-dup key (and to build the
+/// redirect target) keeps the routing identity consistent and prevents slash
+/// variants from surviving as separate tickets that collapse to one upstream.
+fn canonical_domain(domain: &str) -> String {
+    if domain.ends_with('/') {
+        domain.to_string()
+    } else {
+        format!("{}/", domain)
+    }
+}
+
 /// Select the verifiers eligible for routing: `status == "ok"`, de-duplicated by
-/// `domain`. The whitelist is sampled uniformly, so a single origin appearing in
-/// multiple rows would otherwise be sampled as extra routing tickets. Keeping one
-/// row per domain enforces "one ticket per origin" at the sampling site,
-/// independent of how the whitelist file was produced.
+/// canonical domain. The whitelist is sampled uniformly, so a single origin
+/// appearing in multiple rows would otherwise be sampled as extra routing
+/// tickets. Keeping one row per canonical origin enforces "one ticket per
+/// origin" at the sampling site, independent of how the whitelist file was
+/// produced and regardless of trailing-slash variants.
 fn select_routable_verifiers(verifiers: &[WhitelistVerifier]) -> Vec<&WhitelistVerifier> {
-    let mut seen: std::collections::HashSet<&str> = std::collections::HashSet::new();
+    let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
     verifiers
         .iter()
         .filter(|v| v.status == "ok")
-        .filter(|v| seen.insert(v.domain.as_str()))
+        .filter(|v| seen.insert(canonical_domain(&v.domain)))
         .collect()
 }
 
@@ -576,5 +589,25 @@ mod tests {
         let routable = select_routable_verifiers(&verifiers);
         assert_eq!(routable.len(), 1);
         assert_eq!(routable[0].domain, "http://a");
+    }
+
+    #[test]
+    fn routable_verifiers_dedupe_trailing_slash_variants() {
+        // `http://evil` and `http://evil/` redirect to the same upstream, so they
+        // must not survive as two separate routing tickets.
+        let verifiers = vec![
+            verifier("evil", "http://evil", "ok"),
+            verifier("evil-slash", "http://evil/", "ok"),
+            verifier("honest", "http://good/", "ok"),
+        ];
+        let routable = select_routable_verifiers(&verifiers);
+        assert_eq!(routable.len(), 2);
+        assert_eq!(
+            routable
+                .iter()
+                .filter(|v| canonical_domain(&v.domain) == "http://evil/")
+                .count(),
+            1
+        );
     }
 }


### PR DESCRIPTION
## Summary

Follow-up to the merged fix for the duplicate-routing-ticket finding (#82). A rescan found the remediation was incomplete: both the cron-side whitelist dedup and the router-side `select_routable_verifiers` keyed on the **raw `domain` string**, while `ncn-router` redirects to a verifier base only **after ensuring a trailing slash**. So `http://evil` and `http://evil/` survived as two separate `ok` rows (two routing tickets) yet collapsed to the same upstream after selection — restoring extra routing weight for a single origin.

## Fix

Introduce a shared `canonical_domain(domain)` helper that mirrors the router's redirect identity (ensure a single trailing slash, no other normalization) and key the de-duplication on it at both layers:

- **cron** (`cron_job.rs`): `dedupe_verifiers_by_domain` now collapses entries by canonical domain before writing the snapshot.
- **router** (`router.rs`): `select_routable_verifiers` de-duplicates the `ok` set by canonical domain before sampling, and the redirect `target` is built from the same canonical form so the routing identity is consistent end to end.

This collapses **exactly** the variants the router would collapse (trailing-slash) and no more, so genuinely-distinct origins (different host/port/path) are unaffected — no over-merging, no rejected-input compatibility impact.

## Why match the router exactly (no trimming, etc.)

The router does not trim whitespace; a whitespace variant like `http://evil ` produces a *different* (broken) upstream target, so it cannot grant extra weight to the same working upstream. Canonicalizing on trailing-slash only — the precise set the router collapses — closes the exploitable gap without merging entries that resolve to distinct upstreams.

## Testing

- `cargo test --bins`: 18 tests pass (5 cron + 13 router), including new `dedupe_collapses_trailing_slash_domain_variants` (cron) and `routable_verifiers_dedupe_trailing_slash_variants` (router).
- Existing network-binding, ok-preference, and percent-encoding tests remain green.

<!-- apex-fix-review:eyJ2IjoidjEiLCJoIjoiMzkzMWI3N2EtMDlkZi00ZjYzLWEwNTgtYmU0NDg4ZjY5YTZjIiwiZiI6IjVjN2NhYmMzLWUzMWEtNDFkZS1hMGIyLTUyZDNiZGRkOTEwYSIsImUiOjE3ODI3ODMyNDd9.fGFPfoREWFXo2mS1tCc0YfQ7uOtcfFKT6WhLU3LcK7k -->
