### PR TITLE
fix(frontend): pair override votes with the snapshot validator, not live delegation

### DIFF
--- a/frontend/src/chain/instructions/__tests__/castVoteOverride.test.ts
+++ b/frontend/src/chain/instructions/__tests__/castVoteOverride.test.ts
@@ -1,0 +1,225 @@
+import { PublicKey, TransactionInstruction } from "@solana/web3.js";
+
+// helpers.ts transitively imports EndpointContext -> env.ts (an ESM-only package Jest does not
+// transform). Stub it so the real helpers (PDA derivations, converters, assertOverrideProofLineage)
+// can be required without pulling in the untransformed module.
+jest.mock("@/contexts/EndpointContext", () => ({
+  RPC_URLS: { testnet: "http://localhost:8899" },
+}));
+
+// Mock the network / program-creating helpers and the PDA-derivation helpers; keep the real
+// converters and assertOverrideProofLineage. (PublicKey.findProgramAddressSync is unreliable under
+// next/jest's web3.js build, so the PDA helpers are stubbed — we assert on the inputs they receive,
+// which is what the fix is about: every derivation must be driven by the snapshot vote account.)
+const mockGetStakeAccountProof = jest.fn();
+const mockGetVoteAccountProof = jest.fn();
+const mockCreateProgramWithWallet = jest.fn();
+const mockGetMetaMerkleProofPda = jest.fn();
+const mockDeriveVotePda = jest.fn();
+const mockDeriveVoteOverridePda = jest.fn();
+const mockDeriveVoteOverrideCachePda = jest.fn();
+
+jest.mock("../helpers", () => {
+  const actual = jest.requireActual("../helpers");
+  return {
+    ...actual,
+    getStakeAccountProof: (...args: unknown[]) =>
+      mockGetStakeAccountProof(...args),
+    getVoteAccountProof: (...args: unknown[]) =>
+      mockGetVoteAccountProof(...args),
+    createProgramWithWallet: (...args: unknown[]) =>
+      mockCreateProgramWithWallet(...args),
+    getMetaMerkleProofPda: (...args: unknown[]) =>
+      mockGetMetaMerkleProofPda(...args),
+    deriveVotePda: (...args: unknown[]) => mockDeriveVotePda(...args),
+    deriveVoteOverridePda: (...args: unknown[]) =>
+      mockDeriveVoteOverridePda(...args),
+    deriveVoteOverrideCachePda: (...args: unknown[]) =>
+      mockDeriveVoteOverrideCachePda(...args),
+  };
+});
+
+import type { AnchorWallet } from "@solana/wallet-adapter-react";
+
+import { castVoteOverride } from "../castVoteOverride";
+import { SVMGOV_PROGRAM_ID } from "../types";
+import type { RPCEndpoint } from "@/types";
+
+// Distinct, valid 32-byte public keys used as stand-ins (byte-filled so PDA derivation always
+// resolves a viable nonce).
+const keyFromByte = (b: number): string =>
+  new PublicKey(new Uint8Array(32).fill(b)).toBase58();
+const SNAPSHOT_VOTE_ACCOUNT = keyFromByte(1); // validator A at snapshot
+const LIVE_VOTE_ACCOUNT = keyFromByte(2); // validator B (post-snapshot redelegation)
+const STAKE_ACCOUNT = keyFromByte(3);
+const VOTING_WALLET = keyFromByte(4);
+const STAKE_MERKLE_ROOT = keyFromByte(5);
+const CONSENSUS_RESULT = keyFromByte(6);
+const PROPOSAL = keyFromByte(7);
+const SIGNER = keyFromByte(8);
+const BLOCKHASH = keyFromByte(9);
+
+// Stand-in return values for the mocked PDA-derivation helpers.
+const META_MERKLE_PROOF_PDA = new PublicKey(keyFromByte(20));
+const VALIDATOR_VOTE_PDA = new PublicKey(keyFromByte(21));
+const VOTE_OVERRIDE_PDA = new PublicKey(keyFromByte(22));
+const VOTE_OVERRIDE_CACHE_PDA = new PublicKey(keyFromByte(23));
+
+describe("castVoteOverride", () => {
+  let recordedAccounts: Record<string, PublicKey>;
+
+  function buildFakeProgram() {
+    recordedAccounts = {};
+    const fakeIx = new TransactionInstruction({
+      keys: [],
+      programId: SVMGOV_PROGRAM_ID,
+      data: Buffer.alloc(0),
+    });
+    const instruction = jest.fn(async () => fakeIx);
+    const accountsStrict = jest.fn((accts: Record<string, PublicKey>) => {
+      recordedAccounts = accts;
+      return { instruction };
+    });
+    const castVoteOverrideMethod = jest.fn(() => ({ accountsStrict }));
+
+    return {
+      programId: SVMGOV_PROGRAM_ID,
+      provider: {
+        connection: {
+          // Truthy account info => the MetaMerkleProof already exists, so the init branch (which
+          // needs the gov-v1 program / proposal fetch / block time) is skipped.
+          getAccountInfo: jest.fn(async () => ({ data: Buffer.alloc(0) })),
+          getLatestBlockhash: jest.fn(async () => ({ blockhash: BLOCKHASH })),
+          sendRawTransaction: jest.fn(async () => "test-signature"),
+        },
+      },
+      methods: { castVoteOverride: castVoteOverrideMethod },
+    };
+  }
+
+  const wallet = {
+    publicKey: new PublicKey(SIGNER),
+    signTransaction: jest.fn(async () => ({ serialize: () => Buffer.alloc(0) })),
+    signAllTransactions: jest.fn(),
+  } as unknown as AnchorWallet;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockCreateProgramWithWallet.mockReturnValue(buildFakeProgram());
+    mockGetMetaMerkleProofPda.mockReturnValue(META_MERKLE_PROOF_PDA);
+    mockDeriveVotePda.mockReturnValue(VALIDATOR_VOTE_PDA);
+    mockDeriveVoteOverridePda.mockReturnValue(VOTE_OVERRIDE_PDA);
+    mockDeriveVoteOverrideCachePda.mockReturnValue(VOTE_OVERRIDE_CACHE_PDA);
+
+    // The verifier returns the validator the stake was delegated to AT SNAPSHOT TIME (A),
+    // regardless of any later redelegation to B.
+    mockGetStakeAccountProof.mockResolvedValue({
+      network: "testnet",
+      snapshot_slot: 340_850_340,
+      stake_merkle_leaf: {
+        active_stake: 500,
+        stake_account: STAKE_ACCOUNT,
+        voting_wallet: VOTING_WALLET,
+      },
+      stake_merkle_proof: [],
+      vote_account: SNAPSHOT_VOTE_ACCOUNT,
+    });
+    mockGetVoteAccountProof.mockResolvedValue({
+      network: "testnet",
+      snapshot_slot: 340_850_340,
+      meta_merkle_leaf: {
+        active_stake: 500,
+        stake_merkle_root: STAKE_MERKLE_ROOT,
+        vote_account: SNAPSHOT_VOTE_ACCOUNT,
+        voting_wallet: VOTING_WALLET,
+      },
+      meta_merkle_proof: [],
+    });
+  });
+
+  const params = {
+    proposalId: PROPOSAL,
+    forVotesBp: 10_000,
+    againstVotesBp: 0,
+    abstainVotesBp: 0,
+    stakeAccount: STAKE_ACCOUNT,
+    wallet,
+    consensusResult: new PublicKey(CONSENSUS_RESULT),
+  };
+  const blockchainParams = {
+    network: "testnet" as RPCEndpoint,
+    endpoint: "http://localhost:8899",
+  };
+  const slot = 340_850_340;
+
+  it("resolves the meta proof and PDAs from the stake proof's SNAPSHOT vote account, not the live delegation", async () => {
+    const result = await castVoteOverride(params, blockchainParams, slot);
+
+    expect(result).toEqual({ signature: "test-signature", success: true });
+
+    // The stake proof is fetched by stake account.
+    expect(mockGetStakeAccountProof).toHaveBeenCalledWith(
+      STAKE_ACCOUNT,
+      "testnet",
+      slot
+    );
+
+    // The meta proof is fetched for the SNAPSHOT validator (A) carried by the stake proof —
+    // never the live/redelegated validator (B). This is the core of the fix.
+    expect(mockGetVoteAccountProof).toHaveBeenCalledWith(
+      SNAPSHOT_VOTE_ACCOUNT,
+      "testnet",
+      slot
+    );
+    expect(mockGetVoteAccountProof).not.toHaveBeenCalledWith(
+      LIVE_VOTE_ACCOUNT,
+      expect.anything(),
+      expect.anything()
+    );
+
+    const snapshotVote = new PublicKey(SNAPSHOT_VOTE_ACCOUNT);
+
+    // The meta-proof PDA is derived from the meta proof whose leaf carries the snapshot validator.
+    const metaProofArg = mockGetMetaMerkleProofPda.mock.calls[0][0] as {
+      meta_merkle_leaf: { vote_account: string };
+    };
+    expect(metaProofArg.meta_merkle_leaf.vote_account).toBe(
+      SNAPSHOT_VOTE_ACCOUNT
+    );
+
+    // The validator_vote PDA is derived from the snapshot vote account (2nd positional arg),
+    // which in turn binds the vote_override PDA — so a redelegated stake can no longer be paired
+    // with the live validator.
+    expect(mockDeriveVotePda).toHaveBeenCalledTimes(1);
+    const votePdaVoteArg = mockDeriveVotePda.mock.calls[0][1] as PublicKey;
+    expect(votePdaVoteArg.equals(snapshotVote)).toBe(true);
+
+    // The instruction accounts use the snapshot validator and the snapshot-derived PDAs.
+    expect(recordedAccounts.splVoteAccount.equals(snapshotVote)).toBe(true);
+    expect(recordedAccounts.validatorVote.equals(VALIDATOR_VOTE_PDA)).toBe(true);
+    expect(recordedAccounts.metaMerkleProof.equals(META_MERKLE_PROOF_PDA)).toBe(
+      true
+    );
+    expect(recordedAccounts.voteOverride.equals(VOTE_OVERRIDE_PDA)).toBe(true);
+  });
+
+  it("throws when the verifier returns a meta proof whose vote account disagrees with the stake proof", async () => {
+    // Defense-in-depth: if the verifier ever returns a meta proof for a different validator than
+    // the stake proof's snapshot vote account, the override must be rejected client-side.
+    mockGetVoteAccountProof.mockResolvedValue({
+      network: "testnet",
+      snapshot_slot: 340_850_340,
+      meta_merkle_leaf: {
+        active_stake: 500,
+        stake_merkle_root: STAKE_MERKLE_ROOT,
+        vote_account: LIVE_VOTE_ACCOUNT,
+        voting_wallet: VOTING_WALLET,
+      },
+      meta_merkle_proof: [],
+    });
+
+    await expect(
+      castVoteOverride(params, blockchainParams, slot)
+    ).rejects.toThrow(/does not match meta proof vote account/);
+  });
+});

--- a/frontend/src/chain/instructions/__tests__/helpers.test.ts
+++ b/frontend/src/chain/instructions/__tests__/helpers.test.ts
@@ -6,7 +6,14 @@ jest.mock("@/contexts/EndpointContext", () => ({
   RPC_URLS: { testnet: "http://localhost:8899" },
 }));
 
-import { computeProofCloseTimestamp } from "../helpers";
+import {
+  assertOverrideProofLineage,
+  computeProofCloseTimestamp,
+} from "../helpers";
+import type {
+  StakeAccountProofResponse,
+  VoteAccountProofResponse,
+} from "../types";
 
 /**
  * Builds a minimal Connection stand-in exposing only the two methods
@@ -111,5 +118,73 @@ describe("computeProofCloseTimestamp", () => {
       /Failed to fetch a recent block time \(tried 8 slots ending at 499993\)/
     );
     expect(getBlockTime).toHaveBeenCalledTimes(8);
+  });
+});
+
+describe("assertOverrideProofLineage", () => {
+  // Snapshot validator the stake was delegated to at snapshot time.
+  const SNAPSHOT_VOTE_ACCOUNT = "SnapshotVoteAccount11111111111111111111111";
+  // A different validator the stake was redelegated to after the snapshot.
+  const LIVE_VOTE_ACCOUNT = "LiveVoteAccount2222222222222222222222222222";
+  const VOTING_WALLET = "VotingWallet333333333333333333333333333333";
+
+  function stakeProof(
+    overrides: Partial<StakeAccountProofResponse> = {}
+  ): StakeAccountProofResponse {
+    return {
+      network: "testnet",
+      snapshot_slot: 340_850_340,
+      stake_merkle_leaf: {
+        active_stake: 500,
+        stake_account: "StakeAccount4444444444444444444444444444444",
+        voting_wallet: VOTING_WALLET,
+      },
+      stake_merkle_proof: [],
+      vote_account: SNAPSHOT_VOTE_ACCOUNT,
+      ...overrides,
+    };
+  }
+
+  function metaProof(
+    overrides: Partial<VoteAccountProofResponse["meta_merkle_leaf"]> = {}
+  ): VoteAccountProofResponse {
+    return {
+      network: "testnet",
+      snapshot_slot: 340_850_340,
+      meta_merkle_leaf: {
+        active_stake: 500,
+        stake_merkle_root: "StakeMerkleRoot55555555555555555555555555555",
+        vote_account: SNAPSHOT_VOTE_ACCOUNT,
+        voting_wallet: VOTING_WALLET,
+        ...overrides,
+      },
+      meta_merkle_proof: [],
+    };
+  }
+
+  it("passes when the stake proof and meta proof share the snapshot vote account and voting wallet", () => {
+    expect(() =>
+      assertOverrideProofLineage(stakeProof(), metaProof())
+    ).not.toThrow();
+  });
+
+  it("throws when the meta proof is for a different (live) validator than the stake snapshot", () => {
+    // This is the redelegation case: pairing the live validator's meta proof with the snapshot
+    // stake proof must be rejected client-side rather than failing opaquely on-chain.
+    expect(() =>
+      assertOverrideProofLineage(
+        stakeProof(),
+        metaProof({ vote_account: LIVE_VOTE_ACCOUNT })
+      )
+    ).toThrow(/does not match meta proof vote account/);
+  });
+
+  it("throws when the voting wallets disagree", () => {
+    expect(() =>
+      assertOverrideProofLineage(
+        stakeProof(),
+        metaProof({ voting_wallet: "OtherWallet66666666666666666666666666666666" })
+      )
+    ).toThrow(/voting wallet/);
   });
 });

--- a/frontend/src/chain/instructions/__tests__/helpers.test.ts
+++ b/frontend/src/chain/instructions/__tests__/helpers.test.ts
@@ -6,9 +6,12 @@ jest.mock("@/contexts/EndpointContext", () => ({
   RPC_URLS: { testnet: "http://localhost:8899" },
 }));
 
+import { PublicKey } from "@solana/web3.js";
+
 import {
   assertOverrideProofLineage,
   computeProofCloseTimestamp,
+  resolveSnapshotVoteAccount,
 } from "../helpers";
 import type {
   StakeAccountProofResponse,
@@ -186,5 +189,43 @@ describe("assertOverrideProofLineage", () => {
         metaProof({ voting_wallet: "OtherWallet66666666666666666666666666666666" })
       )
     ).toThrow(/voting wallet/);
+  });
+});
+
+describe("resolveSnapshotVoteAccount", () => {
+  const VOTE_ACCOUNT = new PublicKey(new Uint8Array(32).fill(1)).toBase58();
+
+  function stakeProof(
+    overrides: Partial<StakeAccountProofResponse> = {}
+  ): StakeAccountProofResponse {
+    return {
+      network: "testnet",
+      snapshot_slot: 340_850_340,
+      stake_merkle_leaf: {
+        active_stake: 500,
+        stake_account: new PublicKey(new Uint8Array(32).fill(3)).toBase58(),
+        voting_wallet: new PublicKey(new Uint8Array(32).fill(4)).toBase58(),
+      },
+      stake_merkle_proof: [],
+      vote_account: VOTE_ACCOUNT,
+      ...overrides,
+    };
+  }
+
+  it("returns the snapshot vote account as a PublicKey", () => {
+    const resolved = resolveSnapshotVoteAccount(stakeProof());
+    expect(resolved.toBase58()).toBe(VOTE_ACCOUNT);
+  });
+
+  it("throws a clear error when the verifier omits vote_account", () => {
+    // An older verifier build that predates surfacing vote_account on the stake-proof endpoint
+    // leaves the field undefined at runtime; surface that explicitly rather than letting
+    // `new PublicKey(undefined)` throw an opaque "Invalid public key input".
+    const proof = stakeProof({
+      vote_account: undefined as unknown as string,
+    });
+    expect(() => resolveSnapshotVoteAccount(proof)).toThrow(
+      /missing the snapshot vote_account/
+    );
   });
 });

--- a/frontend/src/chain/instructions/castVoteOverride.ts
+++ b/frontend/src/chain/instructions/castVoteOverride.ts
@@ -15,6 +15,7 @@ import {
   createGovV1ProgramWithWallet,
   getVoteAccountProof,
   getStakeAccountProof,
+  resolveSnapshotVoteAccount,
   assertOverrideProofLineage,
   convertMerkleProofStrings,
   convertStakeMerkleLeafDataToIdlType,
@@ -77,7 +78,7 @@ export async function castVoteOverride(
     network,
     slot
   );
-  const splVoteAccount = new PublicKey(stakeMerkleProof.vote_account);
+  const splVoteAccount = resolveSnapshotVoteAccount(stakeMerkleProof);
   const metaMerkleProof = await getVoteAccountProof(
     splVoteAccount.toBase58(),
     network,

--- a/frontend/src/chain/instructions/castVoteOverride.ts
+++ b/frontend/src/chain/instructions/castVoteOverride.ts
@@ -15,6 +15,7 @@ import {
   createGovV1ProgramWithWallet,
   getVoteAccountProof,
   getStakeAccountProof,
+  assertOverrideProofLineage,
   convertMerkleProofStrings,
   convertStakeMerkleLeafDataToIdlType,
   validateVoteBasisPoints,
@@ -41,7 +42,6 @@ export async function castVoteOverride(
     abstainVotesBp,
     stakeAccount,
     wallet,
-    voteAccount,
     consensusResult,
   } = params;
 
@@ -61,17 +61,29 @@ export async function castVoteOverride(
   validateVoteBasisPoints(forVotesBp, againstVotesBp, abstainVotesBp);
 
   const proposalPubkey = new PublicKey(proposalId);
-  const splVoteAccount = new PublicKey(voteAccount);
   const program = createProgramWithWallet(wallet, blockchainParams.endpoint);
 
   const stakeAccountPubkey = new PublicKey(stakeAccount);
 
-  // Get proofs
+  // Get proofs. Fetch the stake proof first: its `vote_account` is the validator the stake was
+  // delegated to AT SNAPSHOT TIME. We must derive everything (the meta proof, the spl_vote_account
+  // and the validator_vote / vote_override PDAs) from this snapshot validator, not the live
+  // on-chain delegation. If the delegator redelegated after the snapshot, the live vote account
+  // would pair this stake proof with the wrong validator's meta proof and the override would fail
+  // on-chain even though the delegator was eligible at snapshot time.
   const network = blockchainParams.network;
-  const [metaMerkleProof, stakeMerkleProof] = await Promise.all([
-    getVoteAccountProof(splVoteAccount.toBase58(), network, slot),
-    getStakeAccountProof(stakeAccount, network, slot),
-  ]);
+  const stakeMerkleProof = await getStakeAccountProof(
+    stakeAccount,
+    network,
+    slot
+  );
+  const splVoteAccount = new PublicKey(stakeMerkleProof.vote_account);
+  const metaMerkleProof = await getVoteAccountProof(
+    splVoteAccount.toBase58(),
+    network,
+    slot
+  );
+  assertOverrideProofLineage(stakeMerkleProof, metaMerkleProof);
 
   const metaMerkleProofPda = getMetaMerkleProofPda(
     metaMerkleProof,

--- a/frontend/src/chain/instructions/helpers.ts
+++ b/frontend/src/chain/instructions/helpers.ts
@@ -217,6 +217,25 @@ export function getMetaMerkleProofPda(
 }
 
 /**
+ * Resolve the snapshot validator vote account from a stake proof, guarding against a verifier
+ * response that omits the field. `vote_account` is typed as `string` but comes from an
+ * unvalidated JSON response — an older backend that predates surfacing `vote_account` on the
+ * stake-proof endpoint would leave it `undefined`, and `new PublicKey(undefined)` throws an opaque
+ * "Invalid public key input" with no hint that the field is missing. This surfaces a clear,
+ * actionable error instead.
+ */
+export function resolveSnapshotVoteAccount(
+  stakeMerkleProof: StakeAccountProofResponse
+): PublicKey {
+  if (!stakeMerkleProof.vote_account) {
+    throw new Error(
+      "Stake account proof is missing the snapshot vote_account; the verifier service may be out of date"
+    );
+  }
+  return new PublicKey(stakeMerkleProof.vote_account);
+}
+
+/**
  * Cross-check that a stake proof and a meta (vote-account) proof belong to the same snapshot
  * lineage before they are paired in an override vote. The override builders derive the vote
  * account from the stake proof's snapshot `vote_account` and fetch the meta proof for it, so these

--- a/frontend/src/chain/instructions/helpers.ts
+++ b/frontend/src/chain/instructions/helpers.ts
@@ -216,6 +216,40 @@ export function getMetaMerkleProofPda(
   return metaMerkleProofPda;
 }
 
+/**
+ * Cross-check that a stake proof and a meta (vote-account) proof belong to the same snapshot
+ * lineage before they are paired in an override vote. The override builders derive the vote
+ * account from the stake proof's snapshot `vote_account` and fetch the meta proof for it, so these
+ * should always agree; this is defense-in-depth against the verifier returning inconsistent
+ * records and surfaces a clear client-side error instead of an opaque on-chain failure.
+ *
+ * The on-chain program enforces the same lineage: `meta_merkle_leaf.vote_account == spl_vote_account`
+ * and the stake leaf must verify nested inside `meta_merkle_leaf.stake_merkle_root`.
+ */
+export function assertOverrideProofLineage(
+  stakeMerkleProof: StakeAccountProofResponse,
+  metaMerkleProof: VoteAccountProofResponse
+): void {
+  if (
+    metaMerkleProof.meta_merkle_leaf.vote_account !== stakeMerkleProof.vote_account
+  ) {
+    throw new Error(
+      `Override proof mismatch: stake proof's snapshot vote account ${stakeMerkleProof.vote_account} ` +
+        `does not match meta proof vote account ${metaMerkleProof.meta_merkle_leaf.vote_account}`
+    );
+  }
+
+  if (
+    metaMerkleProof.meta_merkle_leaf.voting_wallet !==
+    stakeMerkleProof.stake_merkle_leaf.voting_wallet
+  ) {
+    throw new Error(
+      `Override proof mismatch: stake proof voting wallet ${stakeMerkleProof.stake_merkle_leaf.voting_wallet} ` +
+        `does not match meta proof voting wallet ${metaMerkleProof.meta_merkle_leaf.voting_wallet}`
+    );
+  }
+}
+
 // Milliseconds per slot (matches solana_sdk::clock::DEFAULT_MS_PER_SLOT and the svmgov CLI's
 // compute_vote_expiry_timestamp).
 const MS_PER_SLOT = 400;

--- a/frontend/src/chain/instructions/modifyVoteOverride.ts
+++ b/frontend/src/chain/instructions/modifyVoteOverride.ts
@@ -15,6 +15,7 @@ import {
   createGovV1ProgramWithWallet,
   getVoteAccountProof,
   getStakeAccountProof,
+  assertOverrideProofLineage,
   convertMerkleProofStrings,
   convertStakeMerkleLeafDataToIdlType,
   validateVoteBasisPoints,
@@ -41,7 +42,6 @@ export async function modifyVoteOverride(
     abstainVotesBp,
     stakeAccount,
     wallet,
-    voteAccount,
     consensusResult,
   } = params;
 
@@ -61,17 +61,29 @@ export async function modifyVoteOverride(
   validateVoteBasisPoints(forVotesBp, againstVotesBp, abstainVotesBp);
 
   const proposalPubkey = new PublicKey(proposalId);
-  const splVoteAccount = new PublicKey(voteAccount);
   const program = createProgramWithWallet(wallet, blockchainParams.endpoint);
 
   const stakeAccountPubkey = new PublicKey(stakeAccount);
 
-  // Get proofs
+  // Get proofs. Fetch the stake proof first: its `vote_account` is the validator the stake was
+  // delegated to AT SNAPSHOT TIME. We must derive everything (the meta proof, the spl_vote_account
+  // and the validator_vote / vote_override PDAs) from this snapshot validator, not the live
+  // on-chain delegation. If the delegator redelegated after the snapshot, the live vote account
+  // would pair this stake proof with the wrong validator's meta proof and the override would fail
+  // on-chain even though the delegator was eligible at snapshot time.
   const network = blockchainParams.network || "mainnet";
-  const [metaMerkleProof, stakeMerkleProof] = await Promise.all([
-    getVoteAccountProof(splVoteAccount.toBase58(), network, slot),
-    getStakeAccountProof(stakeAccount, network, slot),
-  ]);
+  const stakeMerkleProof = await getStakeAccountProof(
+    stakeAccount,
+    network,
+    slot
+  );
+  const splVoteAccount = new PublicKey(stakeMerkleProof.vote_account);
+  const metaMerkleProof = await getVoteAccountProof(
+    splVoteAccount.toBase58(),
+    network,
+    slot
+  );
+  assertOverrideProofLineage(stakeMerkleProof, metaMerkleProof);
 
   const metaMerkleProofPda = getMetaMerkleProofPda(
     metaMerkleProof,

--- a/frontend/src/chain/instructions/modifyVoteOverride.ts
+++ b/frontend/src/chain/instructions/modifyVoteOverride.ts
@@ -15,6 +15,7 @@ import {
   createGovV1ProgramWithWallet,
   getVoteAccountProof,
   getStakeAccountProof,
+  resolveSnapshotVoteAccount,
   assertOverrideProofLineage,
   convertMerkleProofStrings,
   convertStakeMerkleLeafDataToIdlType,
@@ -77,7 +78,7 @@ export async function modifyVoteOverride(
     network,
     slot
   );
-  const splVoteAccount = new PublicKey(stakeMerkleProof.vote_account);
+  const splVoteAccount = resolveSnapshotVoteAccount(stakeMerkleProof);
   const metaMerkleProof = await getVoteAccountProof(
     splVoteAccount.toBase58(),
     network,

--- a/frontend/src/chain/instructions/types.ts
+++ b/frontend/src/chain/instructions/types.ts
@@ -54,7 +54,6 @@ export interface CastVoteOverrideParams {
   abstainVotesBp: number;
   stakeAccount: string;
   wallet: AnchorWallet | undefined;
-  voteAccount: string;
   consensusResult: PublicKey;
 }
 
@@ -65,7 +64,6 @@ export interface ModifyVoteOverrideParams {
   abstainVotesBp: number;
   stakeAccount: string;
   wallet: AnchorWallet | undefined;
-  voteAccount: string;
   consensusResult: PublicKey;
 }
 
@@ -123,6 +121,13 @@ export interface StakeAccountProofResponse {
   stake_merkle_proof: string[];
   network: string;
   snapshot_slot: number;
+  /**
+   * The validator vote account this stake was delegated to AT SNAPSHOT TIME. This is the
+   * authoritative vote account for an override vote: pairing the stake proof with the live
+   * on-chain delegation instead breaks for redelegated stake. Sourced from the meta leaf at
+   * snapshot upload time by the verifier service.
+   */
+  vote_account: string;
 }
 
 export interface ChainVoteAccountData {

--- a/frontend/src/components/modals/ModifyOverrideVoteModal.tsx
+++ b/frontend/src/components/modals/ModifyOverrideVoteModal.tsx
@@ -189,21 +189,15 @@ export function ModifyOverrideVoteModal({
         return;
       }
 
-      const voteAccount = stakeAccounts.find(
-        (sa) => sa.stakeAccount === selectedStakeAccount
-      )?.voteAccount;
-
       if (selectedStakeAccount === undefined) {
         toast.error("Not able to determine stake account");
         setIsLoading(false);
         return;
       }
-      if (voteAccount === undefined) {
-        toast.error("Not able to determine vote account");
-        setIsLoading(false);
-        return;
-      }
 
+      // The validator vote account is derived server-side from the stake proof's snapshot
+      // delegation inside modifyVoteOverride, not from the live on-chain delegation, so a
+      // redelegated stake account can still override using its snapshot-time validator.
       modifyVoteOverride(
         {
           wallet,
@@ -212,7 +206,6 @@ export function ModifyOverrideVoteModal({
           againstVotesBp: voteDistribution.against * 100,
           abstainVotesBp: voteDistribution.abstain * 100,
           stakeAccount: selectedStakeAccount,
-          voteAccount,
           consensusResult: selectedProposal.consensusResult,
         },
         {

--- a/frontend/src/components/modals/OverrideVoteModal.tsx
+++ b/frontend/src/components/modals/OverrideVoteModal.tsx
@@ -205,20 +205,15 @@ export function OverrideVoteModal({
 
       const stakeAccount = selectedStakeAccount;
 
-      const voteAccount = stakeAccounts.find(
-        (sa) => sa.stakeAccount === stakeAccount
-      )?.voteAccount;
-
       if (stakeAccount === undefined) {
         toast.error("Not able to determine stake account");
         setIsLoading(false);
         return;
       }
-      if (voteAccount === undefined) {
-        toast.error("Not able to determine vote account");
-        return;
-      }
 
+      // The validator vote account is derived server-side from the stake proof's snapshot
+      // delegation inside castVoteOverride, not from the live on-chain delegation, so a
+      // redelegated stake account can still override using its snapshot-time validator.
       castVoteOverride(
         {
           wallet,
@@ -227,7 +222,6 @@ export function OverrideVoteModal({
           againstVotesBp: voteDistribution.against * 100,
           abstainVotesBp: voteDistribution.abstain * 100,
           stakeAccount,
-          voteAccount,
           consensusResult: selectedProposal.consensusResult,
         },
         {

--- a/frontend/src/components/modals/__tests__/OverrideVoteModal.test.tsx
+++ b/frontend/src/components/modals/__tests__/OverrideVoteModal.test.tsx
@@ -130,8 +130,13 @@ describe("OverrideVoteModal", () => {
     expect(mockMutate).toHaveBeenCalledWith(
       expect.objectContaining({
         stakeAccount: "stake-account",
-        voteAccount: "vote-account",
       }),
+      expect.any(Object)
+    );
+    // The validator vote account is no longer derived from the live on-chain delegation in the
+    // modal — castVoteOverride resolves it from the stake proof's snapshot delegation instead.
+    expect(mockMutate).toHaveBeenCalledWith(
+      expect.not.objectContaining({ voteAccount: expect.anything() }),
       expect.any(Object)
     );
   });
@@ -165,8 +170,13 @@ describe("OverrideVoteModal", () => {
     expect(mockMutate).toHaveBeenCalledWith(
       expect.objectContaining({
         stakeAccount: "stake-account",
-        voteAccount: "vote-account",
       }),
+      expect.any(Object)
+    );
+    // The validator vote account is no longer derived from the live on-chain delegation in the
+    // modal — castVoteOverride resolves it from the stake proof's snapshot delegation instead.
+    expect(mockMutate).toHaveBeenCalledWith(
+      expect.not.objectContaining({ voteAccount: expect.anything() }),
       expect.any(Object)
     );
   });


### PR DESCRIPTION
## Summary

Override votes derived the validator vote account from the stake account's **live on-chain delegation**. If a delegator redelegated after the proposal snapshot, the frontend built a mismatched pair — the meta proof for the *live* validator and the stake proof for the *snapshot* validator — and the override transaction failed on-chain even though the delegator was eligible at snapshot time.

The verifier already returns the correct snapshot `vote_account` on the `/proof/stake_account/{...}` endpoint (sourced from the meta leaf at snapshot upload time); the frontend simply discarded it and trusted the live delegation instead.

## Fix

- **`StakeAccountProofResponse`** now surfaces the verifier's snapshot `vote_account`.
- **`castVoteOverride` / `modifyVoteOverride`** fetch the stake proof first and derive `spl_vote_account` and the `validator_vote` / `vote_override` PDAs from its snapshot `vote_account`, then fetch the meta proof for that account. This matches the on-chain invariant (`meta_merkle_leaf.vote_account == spl_vote_account` plus the nested stake-proof check) and makes a legitimate redelegated override **succeed** rather than fail.
- A new `assertOverrideProofLineage` helper cross-checks that the stake proof and meta proof agree on vote account and voting wallet before the transaction is built (defense-in-depth, surfaces a clear client-side error instead of an opaque on-chain failure).
- The live-delegation `voteAccount` param is removed from the override path entirely (both builders, the param types, and both override modals), eliminating the vulnerable input at its source. Side benefit: a delegator can override even if their stake's live delegation changed or was cleared after the snapshot.

No backend change is required — the verifier already returns the snapshot `vote_account`.

## Tests

- `castVoteOverride.test.ts`: proves the meta proof and PDAs are driven by the stake proof's snapshot vote account (not the live/redelegated one), and that a mismatched meta proof is rejected.
- `helpers.test.ts`: positive + negative (`assertOverrideProofLineage`) cases including the redelegation/mismatch case.
- `OverrideVoteModal.test.tsx`: updated to assert the modal no longer passes `voteAccount`.
- Full suite (`pnpm jest`), `pnpm tsc --noEmit`, and `pnpm lint` all pass.

<!-- apex-fix-review:eyJ2IjoidjEiLCJoIjoiMWIxYzc2M2UtYzQyNC00NTQwLTk2MmItNmY5NTc3YWFlYzQ4IiwiZiI6ImVlYTNiODU4LTljNDAtNGEzMy1iMzZkLTcyYWU5NTdkMjNjYSIsImUiOjE3ODI3NTE2ODB9.gz1246LiFzRNTiv4ldzpOARidIx4zT5UhRi5nMLPjIQ -->
