### PR TITLE
fix(frontend): use configured ncn api for vote proofs

### DIFF
--- a/frontend/src/chain/instructions/castVote.ts
+++ b/frontend/src/chain/instructions/castVote.ts
@@ -90,7 +90,8 @@ export async function castVote(
   const voteAccountProof = await getVoteAccountProof(
     validatorVoteAccount.votePubkey,
     blockchainParams.network,
-    slot
+    slot,
+    blockchainParams.ncnApiUrl
   );
 
   const metaMerkleProofPda = getMetaMerkleProofPda(

--- a/frontend/src/chain/instructions/castVoteOverride.ts
+++ b/frontend/src/chain/instructions/castVoteOverride.ts
@@ -76,13 +76,15 @@ export async function castVoteOverride(
   const stakeMerkleProof = await getStakeAccountProof(
     stakeAccount,
     network,
-    slot
+    slot,
+    blockchainParams.ncnApiUrl
   );
   const splVoteAccount = resolveSnapshotVoteAccount(stakeMerkleProof);
   const metaMerkleProof = await getVoteAccountProof(
     splVoteAccount.toBase58(),
     network,
-    slot
+    slot,
+    blockchainParams.ncnApiUrl
   );
   assertOverrideProofLineage(stakeMerkleProof, metaMerkleProof);
 

--- a/frontend/src/chain/instructions/modifyVote.ts
+++ b/frontend/src/chain/instructions/modifyVote.ts
@@ -84,7 +84,8 @@ export async function modifyVote(
   const voteAccountProof = await getVoteAccountProof(
     validatorVoteAccount.votePubkey,
     blockchainParams.network,
-    slot
+    slot,
+    blockchainParams.ncnApiUrl
   );
   console.log("fetched voteAccountProof", voteAccountProof);
 

--- a/frontend/src/chain/instructions/modifyVoteOverride.ts
+++ b/frontend/src/chain/instructions/modifyVoteOverride.ts
@@ -76,13 +76,15 @@ export async function modifyVoteOverride(
   const stakeMerkleProof = await getStakeAccountProof(
     stakeAccount,
     network,
-    slot
+    slot,
+    blockchainParams.ncnApiUrl
   );
   const splVoteAccount = resolveSnapshotVoteAccount(stakeMerkleProof);
   const metaMerkleProof = await getVoteAccountProof(
     splVoteAccount.toBase58(),
     network,
-    slot
+    slot,
+    blockchainParams.ncnApiUrl
   );
   assertOverrideProofLineage(stakeMerkleProof, metaMerkleProof);
 

--- a/frontend/src/chain/instructions/types.ts
+++ b/frontend/src/chain/instructions/types.ts
@@ -16,6 +16,7 @@ export interface TransactionResult {
 export interface BlockchainParams {
   network: RPCEndpoint;
   endpoint: string;
+  ncnApiUrl?: string;
 }
 
 // Instruction parameter types

--- a/frontend/src/hooks/useCastVote.ts
+++ b/frontend/src/hooks/useCastVote.ts
@@ -1,5 +1,6 @@
 import { CastVoteParams } from "@/chain";
 import { useEndpoint } from "@/contexts/EndpointContext";
+import { useNcnApi } from "@/contexts/NcnApiContext";
 import { castVoteMutation } from "@/data";
 import { useMutation } from "@tanstack/react-query";
 import { useSnapshotMeta } from "./useSnapshotMeta";
@@ -7,6 +8,7 @@ import { track } from "@vercel/analytics";
 
 export function useCastVote() {
   const { endpointUrl: endpoint, endpointType } = useEndpoint();
+  const { ncnApiUrl } = useNcnApi();
   const { data: meta } = useSnapshotMeta();
 
   return useMutation({
@@ -17,6 +19,7 @@ export function useCastVote() {
         {
           endpoint,
           network: endpointType,
+          ncnApiUrl,
         },
         meta?.slot
       ),

--- a/frontend/src/hooks/useCastVoteOverride.ts
+++ b/frontend/src/hooks/useCastVoteOverride.ts
@@ -1,5 +1,6 @@
 import { CastVoteOverrideParams } from "@/chain";
 import { useEndpoint } from "@/contexts/EndpointContext";
+import { useNcnApi } from "@/contexts/NcnApiContext";
 import { castVoteOverrideMutation } from "@/data";
 import { useMutation } from "@tanstack/react-query";
 import { useSnapshotMeta } from "./useSnapshotMeta";
@@ -7,6 +8,7 @@ import { track } from "@vercel/analytics";
 
 export function useCastVoteOverride() {
   const { endpointUrl: endpoint, endpointType } = useEndpoint();
+  const { ncnApiUrl } = useNcnApi();
   const { data: meta } = useSnapshotMeta();
 
   return useMutation({
@@ -17,6 +19,7 @@ export function useCastVoteOverride() {
         {
           endpoint,
           network: endpointType,
+          ncnApiUrl,
         },
         meta?.slot
       ),

--- a/frontend/src/hooks/useModifyVote.ts
+++ b/frontend/src/hooks/useModifyVote.ts
@@ -1,5 +1,6 @@
 import { ModifyVoteParams } from "@/chain";
 import { useEndpoint } from "@/contexts/EndpointContext";
+import { useNcnApi } from "@/contexts/NcnApiContext";
 import { modifyVoteMutation } from "@/data";
 import { useMutation } from "@tanstack/react-query";
 import { useSnapshotMeta } from "./useSnapshotMeta";
@@ -7,6 +8,7 @@ import { track } from "@vercel/analytics";
 
 export function useModifyVote() {
   const { endpointUrl: endpoint, endpointType } = useEndpoint();
+  const { ncnApiUrl } = useNcnApi();
 
   const { data: meta } = useSnapshotMeta();
 
@@ -15,7 +17,7 @@ export function useModifyVote() {
     mutationFn: (params: ModifyVoteParams) =>
       modifyVoteMutation(
         params,
-        { endpoint, network: endpointType },
+        { endpoint, network: endpointType, ncnApiUrl },
         meta?.slot
       ),
     onMutate: (params) => {

--- a/frontend/src/hooks/useModifyVoteOverride.ts
+++ b/frontend/src/hooks/useModifyVoteOverride.ts
@@ -1,5 +1,6 @@
 import { CastVoteOverrideParams } from "@/chain";
 import { useEndpoint } from "@/contexts/EndpointContext";
+import { useNcnApi } from "@/contexts/NcnApiContext";
 import { modifyVoteOverrideMutation } from "@/data";
 import { useMutation } from "@tanstack/react-query";
 import { useSnapshotMeta } from "./useSnapshotMeta";
@@ -7,6 +8,7 @@ import { track } from "@vercel/analytics";
 
 export function useModifyVoteOverride() {
   const { endpointUrl: endpoint, endpointType } = useEndpoint();
+  const { ncnApiUrl } = useNcnApi();
 
   const { data: meta } = useSnapshotMeta();
   return useMutation({
@@ -17,6 +19,7 @@ export function useModifyVoteOverride() {
         {
           endpoint,
           network: endpointType,
+          ncnApiUrl,
         },
         meta?.slot
       ),


### PR DESCRIPTION
## Summary
- Thread the configured NCN API URL through vote mutation hooks
- Pass that URL into vote and stake proof helpers for cast/modify vote flows
- Keep existing default fallback behavior when no URL is supplied

## Test Plan
- git diff --check
- pnpm lint (not run: pnpm is not installed on PATH and frontend/node_modules is absent)