### PR TITLE
zero copy of supporters. changed proposal strings and option into static sized arrays

### DIFF
--- a/svmgov/program/programs/svmgov_program/src/constants.rs
+++ b/svmgov/program/programs/svmgov_program/src/constants.rs
@@ -8,7 +8,8 @@ pub const MAX_TITLE_ACCOUNT_SIZE: usize = 200;
 pub const MAX_DESC_ACCOUNT_SIZE: usize = 500;
 
 // Hard upper bound on the admin-configurable `max_supporters` cap. Every support
-// call must deserialize and re-tally the whole `supporters` list in a single
-// transaction; 2000 staked validators is now the maximum after SIMD-0357:
-// Alpenglow VAT implementation has been activated on all clusters.
+// call must re-tally the whole supporter list (read zero-copy from the proposal
+// account) in a single transaction; 2000 staked validators is now the maximum
+// after SIMD-0357: Alpenglow VAT implementation has been activated on all
+// clusters.
 pub const MAX_SUPPORTERS_LIMIT: u32 = 2_000;

--- a/svmgov/program/programs/svmgov_program/src/instructions/retally_support.rs
+++ b/svmgov/program/programs/svmgov_program/src/instructions/retally_support.rs
@@ -76,15 +76,19 @@ impl<'info> RetallySupport<'info> {
         // threshold config it could activate voting on a proposal nobody
         // supported, so refuse it outright.
         require!(
-            !self.proposal.supporters.is_empty(),
+            self.proposal.num_supporters > 0,
             GovernanceError::NoSupporters
         );
 
         // Rebuild the tally from every supporter's stake at the CURRENT epoch;
-        // nothing from earlier epochs' readings is retained.
-        let total = tally_supporter_stakes(&self.proposal.supporters, |pk| {
-            get_epoch_stake_for_vote_account(pk)
-        })?;
+        // nothing from earlier epochs' readings is retained. The supporter
+        // list is read zero-copy from the account data.
+        let proposal_info = self.proposal.to_account_info();
+        let total = {
+            let proposal_data = proposal_info.try_borrow_data()?;
+            let supporters = self.proposal.supporters(&proposal_data)?;
+            tally_supporter_stakes(supporters, |pk| get_epoch_stake_for_vote_account(pk))?
+        };
         self.proposal.cluster_support_lamports = total;
 
         let cluster_min_stake = min_stake_threshold(

--- a/svmgov/program/programs/svmgov_program/src/instructions/support_proposal.rs
+++ b/svmgov/program/programs/svmgov_program/src/instructions/support_proposal.rs
@@ -26,11 +26,11 @@ pub struct SupportProposal<'info> {
         mut,
         // Grow the proposal by exactly one supporter entry (32 bytes). The
         // supporter pays the rent delta for their own slice. INIT_SPACE
-        // already includes the Vec's 4-byte length prefix (max_len(0)), so
-        // total size is disc + fixed fields + 32 per supporter.
+        // already includes the 4-byte `num_supporters` count, so total size
+        // is disc + fixed fields + 32 per supporter.
         realloc = ANCHOR_DISCRIMINATOR
             + Proposal::INIT_SPACE
-            + (proposal.supporters.len() + 1) * core::mem::size_of::<Pubkey>(),
+            + (proposal.num_supporters as usize + 1) * core::mem::size_of::<Pubkey>(),
         realloc::payer = signer,
         realloc::zero = false,
     )]
@@ -103,7 +103,7 @@ impl<'info> SupportProposal<'info> {
         // exceed Solana's heap/compute limits and brick the proposal. Checked
         // before the new entry is recorded so the list never exceeds the cap.
         require!(
-            (self.proposal.supporters.len() as u64) < self.global_config.max_supporters as u64,
+            (self.proposal.num_supporters as u64) < self.global_config.max_supporters as u64,
             GovernanceError::SupporterLimitReached
         );
 
@@ -131,9 +131,13 @@ impl<'info> SupportProposal<'info> {
         // every prior supporter's stake at the *current* epoch (via the
         // sol_get_epoch_stake syscall — needs only the pubkey, not the
         // account), then add the new supporter measured at the same epoch.
-        let prior_stake = tally_supporter_stakes(&self.proposal.supporters, |pk| {
-            get_epoch_stake_for_vote_account(pk)
-        })?;
+        // The supporter list is read zero-copy from the account data.
+        let proposal_info = self.proposal.to_account_info();
+        let prior_stake = {
+            let proposal_data = proposal_info.try_borrow_data()?;
+            let supporters = self.proposal.supporters(&proposal_data)?;
+            tally_supporter_stakes(supporters, |pk| get_epoch_stake_for_vote_account(pk))?
+        };
         let supporter_stake = get_epoch_stake_for_vote_account(self.spl_vote_account.key);
         // A supporter must clear the same stake floor as a proposal author.
         // This blocks a zero-/dust-stake spam attack that would otherwise let
@@ -151,8 +155,12 @@ impl<'info> SupportProposal<'info> {
         proposal_account.cluster_support_lamports = new_support_stake;
         // Record the supporter's vote account so future support/retally calls
         // can re-measure them. The realloc constraint above already grew the
-        // account by exactly this entry.
-        proposal_account.supporters.push(self.spl_vote_account.key());
+        // account by exactly this entry; the pubkey is written straight into
+        // the account data (only `num_supporters` goes through Anchor).
+        {
+            let mut proposal_data = proposal_info.try_borrow_mut_data()?;
+            proposal_account.append_supporter(&mut proposal_data, self.spl_vote_account.key())?;
+        }
 
         // Initialize the support account
         self.support.set_inner(Support {

--- a/svmgov/program/programs/svmgov_program/src/lib.rs
+++ b/svmgov/program/programs/svmgov_program/src/lib.rs
@@ -11,6 +11,7 @@ use instructions::*;
 
 pub use constants::BASIS_POINTS_MAX;
 pub use error::GovernanceError;
+pub use state::Proposal;
 pub use utils::get_epoch_slot_range;
 
 use ncn_snapshot::StakeMerkleLeaf;

--- a/svmgov/program/programs/svmgov_program/src/state/proposal.rs
+++ b/svmgov/program/programs/svmgov_program/src/state/proposal.rs
@@ -33,17 +33,55 @@ pub struct Proposal {
     // Seeds for CPI
     pub proposal_seed: u64,
     pub vote_account_pubkey: Pubkey,
-    /// Vote-account pubkeys of every supporter, appended by `support_proposal`.
-    /// Kept so the tally can be rebuilt from current-epoch stake on every
-    /// support/retally (stake readings from earlier epochs are never reused).
+    /// Number of supporter entries stored in the account data at the fixed
+    /// offset [`Proposal::SUPPORTERS_OFFSET`].
     ///
-    /// MUST remain the LAST field: Borsh serializes a Vec as
-    /// [u32 len][item][item]..., so the account can grow by exactly one entry
-    /// per support via realloc only if nothing is serialized after it.
-    /// `max_len(0)` keeps INIT_SPACE at the empty-list size (just the 4-byte
-    /// length prefix); growth is paid per-entry by each supporter.
-    #[max_len(0)]
-    pub supporters: Vec<Pubkey>,
+    /// The supporter vote-account pubkeys are intentionally NOT a field of
+    /// this struct: they live past the struct's Borsh capacity boundary
+    /// (`discriminator + INIT_SPACE`), so Anchor only (de)serializes this
+    /// 4-byte count. The entries are read zero-copy via
+    /// [`Proposal::supporters`] and written by [`Proposal::append_supporter`].
+    pub num_supporters: u32,
+}
+
+/// The zero-copy supporter accessors reinterpret raw account bytes as
+/// `[Pubkey]`; that is only sound for this exact layout.
+const _: () = assert!(
+    core::mem::size_of::<Pubkey>() == 32 && core::mem::align_of::<Pubkey>() == 1
+);
+
+impl Proposal {
+    /// Byte offset of the first supporter entry in the account data. Ignores the
+    /// actual serialization size of the `Proposal` for simplicity (`Option` and 
+    /// `String` have variable length when serialized).
+    pub const SUPPORTERS_OFFSET: usize = ANCHOR_DISCRIMINATOR + Self::INIT_SPACE;
+
+    /// Zero-copy view of the supporter vote-account pubkeys. `data` must be
+    /// this proposal's full account data (discriminator included).
+    pub fn supporters<'d>(&self, data: &'d [u8]) -> Result<&'d [Pubkey]> {
+        let len = self.num_supporters as usize;
+        let bytes = data
+            .get(Self::SUPPORTERS_OFFSET..Self::SUPPORTERS_OFFSET + len * core::mem::size_of::<Pubkey>())
+            .ok_or(ProgramError::AccountDataTooSmall)?;
+        // SAFETY: Pubkey is repr(transparent) over [u8; 32] with size 32 and
+        // align 1 (compile-time-asserted above), so any correctly sized byte
+        // region reinterprets as a [Pubkey] with no alignment or validity
+        // requirements to violate; the lifetime stays tied to `data`.
+        Ok(unsafe { core::slice::from_raw_parts(bytes.as_ptr().cast::<Pubkey>(), len) })
+    }
+
+    /// Writes one supporter entry after the existing ones and bumps
+    /// `num_supporters`. The account must already have been realloc'd to hold
+    /// the extra 32 bytes (see the constraint in `support_proposal`).
+    pub fn append_supporter(&mut self, data: &mut [u8], vote_account: Pubkey) -> Result<()> {
+        let entry_size = core::mem::size_of::<Pubkey>();
+        let offset = Self::SUPPORTERS_OFFSET + self.num_supporters as usize * entry_size;
+        data.get_mut(offset..offset + entry_size)
+            .ok_or(ProgramError::AccountDataTooSmall)?
+            .copy_from_slice(vote_account.as_ref());
+        self.num_supporters += 1;
+        Ok(())
+    }
 }
 
 impl Default for Proposal {
@@ -70,7 +108,7 @@ impl Default for Proposal {
             consensus_result: None,
             proposal_seed: 0,
             vote_account_pubkey: Pubkey::default(),
-            supporters: Vec::new(),
+            num_supporters: 0,
         }
     }
 }

--- a/svmgov/program/programs/svmgov_program/tests/common/mod.rs
+++ b/svmgov/program/programs/svmgov_program/tests/common/mod.rs
@@ -1,0 +1,586 @@
+//! Shared LiteSVM harness for the support/retally integration suites.
+//!
+//! The harness is parameterized by validator and supporter counts so suites
+//! at different scales (150-of-1000, 1500-of-2000, ...) reuse the same setup:
+//! `setup_harness` derives the cluster support threshold (in bps) from the
+//! two counts, so crossing the threshold always lands exactly on the
+//! `supporter_count`-th support.
+#![allow(dead_code)]
+
+use {
+    borsh::{BorshDeserialize, BorshSerialize},
+    litesvm::LiteSVM,
+    sha2::{Digest, Sha256},
+    solana_account::Account,
+    solana_address::Address,
+    solana_clock::Clock,
+    solana_compute_budget_interface::ComputeBudgetInstruction,
+    solana_instruction::{AccountMeta, Instruction},
+    solana_instruction_error::InstructionError,
+    solana_keypair::Keypair,
+    solana_message::Message,
+    solana_native_token::LAMPORTS_PER_SOL,
+    solana_sdk_ids::{native_loader, system_program, vote},
+    solana_signer::Signer,
+    solana_transaction::Transaction,
+    solana_vote_interface_host::state::{VoteInit, VoteStateV3, VoteStateVersions},
+    std::{collections::HashMap, path::PathBuf},
+    svmgov_program::GovernanceError,
+};
+
+pub const SVMGOV_PROGRAM_ID: Address =
+    Address::from_str_const("govYkyQ3ePtGULAtY6V75qjWE8UH4vCUVQ1W4HdCAZU");
+pub const NCN_SNAPSHOT_PROGRAM_ID: Address =
+    Address::from_str_const("ncnwF8AgynRcdEnGLcprSQNaKvgSMTgk3yPRc8cf9Zf");
+
+pub const STAKE_PER_VALIDATOR: u64 = LAMPORTS_PER_SOL;
+pub const SLOTS_PER_EPOCH: u64 = 432_000;
+pub const DISCUSSION_EPOCHS: u64 = 1;
+pub const MAX_SUPPORT_EPOCHS: u64 = 10;
+pub const VOTING_EPOCHS: u64 = 3;
+/// Mirrors `constants::MAX_SUPPORTERS_LIMIT` (not exported from the crate).
+pub const MAX_SUPPORTERS: u32 = 2_000;
+/// Anchor `#[error_code]` offset (`anchor_lang::error::ERROR_CODE_OFFSET`).
+pub const ANCHOR_ERROR_CODE_OFFSET: u32 = 6000;
+
+pub fn anchor_custom_error(err: GovernanceError) -> InstructionError {
+    InstructionError::Custom(ANCHOR_ERROR_CODE_OFFSET + err as u32)
+}
+
+pub fn pk_bytes(a: &Address) -> [u8; 32] {
+    a.to_bytes()
+}
+
+pub fn anchor_discriminator(namespace: &str, name: &str) -> [u8; 8] {
+    let preimage = format!("{namespace}:{name}");
+    let hash = Sha256::digest(preimage.as_bytes());
+    let mut out = [0u8; 8];
+    out.copy_from_slice(&hash[..8]);
+    out
+}
+
+pub fn read_program() -> Vec<u8> {
+    // CARGO_MANIFEST_DIR = programs/svmgov_program
+    let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    path.push("../../target/deploy/svmgov_program.so");
+    std::fs::read(&path).unwrap_or_else(|e| {
+        panic!(
+            "failed to read {}: {e}. Build with: cargo-build-sbf -p svmgov_program",
+            path.display()
+        )
+    })
+}
+
+#[derive(BorshSerialize)]
+pub struct GlobalConfigAccount {
+    pub admin: [u8; 32],
+    pub pending_admin: Option<[u8; 32]>,
+    pub max_title_length: u16,
+    pub max_description_length: u16,
+    pub max_support_epochs: u64,
+    pub min_proposal_stake_lamports: u64,
+    pub cluster_support_pct_min_bps: u64,
+    pub discussion_epochs: u64,
+    pub voting_epochs: u64,
+    pub snapshot_epoch_extension: u64,
+    pub snapshot_slot_offset: i64,
+    pub bump: u8,
+    pub max_supporters: u32,
+}
+
+#[derive(BorshSerialize)]
+pub struct ProposalIndexAccount {
+    pub current_index: u32,
+    pub bump: u8,
+}
+
+#[derive(Debug, BorshDeserialize)]
+pub struct ProposalAccount {
+    pub author: [u8; 32],
+    pub title: String,
+    pub description: String,
+    pub creation_epoch: u64,
+    pub start_epoch: u64,
+    pub end_epoch: u64,
+    pub proposer_stake_weight_bp: u64,
+    pub cluster_support_lamports: u64,
+    pub for_votes_lamports: u64,
+    pub against_votes_lamports: u64,
+    pub abstain_votes_lamports: u64,
+    pub voting: bool,
+    pub finalized: bool,
+    pub proposal_bump: u8,
+    pub creation_timestamp: i64,
+    pub vote_count: u32,
+    pub index: u32,
+    pub consensus_result: Option<[u8; 32]>,
+    pub snapshot_slot: u64,
+    pub proposal_seed: u64,
+    pub vote_account_pubkey: [u8; 32],
+    pub num_supporters: u32,
+    /// Not part of the Borsh payload: the entries live at the fixed offset
+    /// `Proposal::SUPPORTERS_OFFSET` (= 8 + INIT_SPACE, past any slack left
+    /// by shorter-than-max strings / a None consensus_result);
+    /// `fetch_proposal` fills this in.
+    #[borsh(skip)]
+    pub supporters: Vec<[u8; 32]>,
+}
+
+pub struct Validator {
+    pub identity: Keypair,
+    pub vote: Keypair,
+}
+
+pub struct Harness {
+    pub svm: LiteSVM,
+    pub validators: Vec<Validator>,
+    /// Total validators in the cluster (each staked `STAKE_PER_VALIDATOR`).
+    pub validator_count: usize,
+    /// Validators with funded identities + vote accounts, i.e. the number of
+    /// supports needed to cross the threshold exactly.
+    pub supporter_count: usize,
+    /// Threshold written to the global config, derived from the two counts:
+    /// `supporter_count / validator_count` in basis points.
+    pub cluster_support_pct_min_bps: u64,
+    pub global_config: Address,
+    pub proposal_index: Address,
+    pub program_config: Address,
+}
+
+pub fn make_vote_account_data(node: &Address) -> Vec<u8> {
+    let vote_init = VoteInit {
+        node_pubkey: *node,
+        authorized_voter: *node,
+        authorized_withdrawer: *node,
+        commission: 0,
+    };
+    let state = VoteStateV3::new(&vote_init, &Clock::default());
+    let versioned = VoteStateVersions::V3(Box::new(state));
+    let mut data = vec![0u8; VoteStateV3::size_of()];
+    VoteStateV3::serialize(&versioned, &mut data).expect("serialize VoteStateV3");
+    data
+}
+
+pub fn write_anchor_account<T: BorshSerialize>(
+    svm: &mut LiteSVM,
+    address: Address,
+    owner: Address,
+    discriminator: [u8; 8],
+    data: &T,
+) {
+    let mut bytes = discriminator.to_vec();
+    bytes.extend(borsh::to_vec(data).expect("borsh serialize"));
+    let lamports = svm.minimum_balance_for_rent_exemption(bytes.len());
+    svm.set_account(
+        address,
+        Account {
+            lamports,
+            data: bytes,
+            owner,
+            executable: false,
+            rent_epoch: 0,
+        },
+    )
+    .unwrap();
+}
+
+pub fn try_send_ix(
+    svm: &mut LiteSVM,
+    payer: &Keypair,
+    ixs: &[Instruction],
+) -> Result<litesvm::types::TransactionMetadata, litesvm::types::FailedTransactionMetadata> {
+    let blockhash = svm.latest_blockhash();
+    let msg = Message::new(ixs, Some(&payer.pubkey()));
+    let tx = Transaction::new(&[payer], msg, blockhash);
+    svm.send_transaction(tx)
+}
+
+pub fn send_ix(
+    svm: &mut LiteSVM,
+    payer: &Keypair,
+    ixs: &[Instruction],
+) -> litesvm::types::TransactionMetadata {
+    try_send_ix(svm, payer, ixs).unwrap_or_else(|e| {
+        panic!("tx failed: {:#?}\nlogs: {:#?}", e.err, e.meta.logs);
+    })
+}
+
+pub fn create_proposal_ix(
+    author: &Address,
+    proposal: Address,
+    proposal_index: Address,
+    vote_account: Address,
+    global_config: Address,
+    seed: u64,
+    title: &str,
+    description: &str,
+) -> Instruction {
+    let mut data = anchor_discriminator("global", "create_proposal").to_vec();
+    data.extend(seed.to_le_bytes());
+    data.extend((title.len() as u32).to_le_bytes());
+    data.extend(title.as_bytes());
+    data.extend((description.len() as u32).to_le_bytes());
+    data.extend(description.as_bytes());
+
+    Instruction {
+        program_id: SVMGOV_PROGRAM_ID,
+        accounts: vec![
+            AccountMeta::new(*author, true),
+            AccountMeta::new(proposal, false),
+            AccountMeta::new(proposal_index, false),
+            AccountMeta::new_readonly(vote_account, false),
+            AccountMeta::new_readonly(global_config, false),
+            AccountMeta::new_readonly(system_program::ID, false),
+        ],
+        data,
+    }
+}
+
+pub fn support_proposal_ix(
+    supporter: &Address,
+    proposal: Address,
+    support: Address,
+    vote_account: Address,
+    ballot_box: Address,
+    program_config: Address,
+    global_config: Address,
+) -> Instruction {
+    Instruction {
+        program_id: SVMGOV_PROGRAM_ID,
+        accounts: vec![
+            AccountMeta::new(*supporter, true),
+            AccountMeta::new(proposal, false),
+            AccountMeta::new(support, false),
+            AccountMeta::new_readonly(vote_account, false),
+            AccountMeta::new(ballot_box, false),
+            AccountMeta::new_readonly(NCN_SNAPSHOT_PROGRAM_ID, false),
+            AccountMeta::new_readonly(program_config, false),
+            AccountMeta::new_readonly(global_config, false),
+            AccountMeta::new_readonly(system_program::ID, false),
+        ],
+        data: anchor_discriminator("global", "support_proposal").to_vec(),
+    }
+}
+
+pub fn retally_support_ix(
+    caller: &Address,
+    proposal: Address,
+    ballot_box: Address,
+    program_config: Address,
+    global_config: Address,
+) -> Instruction {
+    Instruction {
+        program_id: SVMGOV_PROGRAM_ID,
+        accounts: vec![
+            AccountMeta::new(*caller, true),
+            AccountMeta::new(proposal, false),
+            AccountMeta::new(ballot_box, false),
+            AccountMeta::new_readonly(NCN_SNAPSHOT_PROGRAM_ID, false),
+            AccountMeta::new_readonly(program_config, false),
+            AccountMeta::new_readonly(global_config, false),
+            AccountMeta::new_readonly(system_program::ID, false),
+        ],
+        data: anchor_discriminator("global", "retally_support").to_vec(),
+    }
+}
+
+pub fn fetch_proposal(svm: &LiteSVM, proposal: &Address) -> ProposalAccount {
+    let account = svm.get_account(proposal).expect("proposal account");
+    assert!(account.data.len() > 8, "proposal too small");
+    // The Borsh payload ends at or before SUPPORTERS_OFFSET; ignore the slack.
+    let mut data: &[u8] = &account.data[8..];
+    let mut state = ProposalAccount::deserialize(&mut data).expect("deserialize proposal");
+    // Supporter entries are not part of the Borsh payload: the account is
+    // always sized 8 + INIT_SPACE + 32 * num_supporters, with the entries
+    // pinned at the fixed capacity boundary.
+    let offset = svmgov_program::Proposal::SUPPORTERS_OFFSET;
+    assert_eq!(
+        account.data.len(),
+        offset + 32 * state.num_supporters as usize,
+        "proposal account must be sized 8 + INIT_SPACE + 32 * num_supporters"
+    );
+    state.supporters = (0..state.num_supporters as usize)
+        .map(|i| {
+            account.data[offset + 32 * i..offset + 32 * (i + 1)]
+                .try_into()
+                .unwrap()
+        })
+        .collect();
+    state
+}
+
+pub fn expected_snapshot_slot(crossing_epoch: u64) -> u64 {
+    // discussion_epochs=1, snapshot_epoch_extension=0, snapshot_slot_offset=0
+    (crossing_epoch + DISCUSSION_EPOCHS) * SLOTS_PER_EPOCH
+}
+
+pub fn set_clock(svm: &mut LiteSVM, epoch: u64) {
+    let mut clock = svm.get_sysvar::<Clock>();
+    clock.epoch = epoch;
+    // Stay inside the epoch so snapshot_slot (= next epoch start) remains in the future.
+    clock.slot = epoch * SLOTS_PER_EPOCH + 1;
+    svm.set_sysvar(&clock);
+}
+
+pub fn seed_ballot_box(svm: &mut LiteSVM, snapshot_slot: u64) -> Address {
+    let (ballot_box, _) = Address::find_program_address(
+        &[b"BallotBox", &snapshot_slot.to_le_bytes()],
+        &NCN_SNAPSHOT_PROGRAM_ID,
+    );
+    if svm.get_account(&ballot_box).is_none() {
+        svm.set_account(
+            ballot_box,
+            Account {
+                lamports: svm.minimum_balance_for_rent_exemption(1),
+                data: vec![1],
+                owner: NCN_SNAPSHOT_PROGRAM_ID,
+                executable: false,
+                rent_epoch: 0,
+            },
+        )
+        .unwrap();
+    }
+    ballot_box
+}
+
+/// Builds a cluster of `validator_count` equally staked validators where the
+/// first `supporter_count` have funded identities and real vote accounts, and
+/// writes a global config whose support threshold is crossed exactly when all
+/// of them support (threshold bps = supporter_count / validator_count).
+pub fn setup_harness(
+    creation_epoch: u64,
+    validator_count: usize,
+    supporter_count: usize,
+) -> Harness {
+    assert!(supporter_count <= validator_count);
+    assert!(supporter_count as u32 <= MAX_SUPPORTERS);
+    // The threshold must be exactly representable in basis points, otherwise
+    // the crossing would not land precisely on the supporter_count-th support.
+    assert_eq!(
+        supporter_count * 10_000 % validator_count,
+        0,
+        "supporter_count/validator_count must be an exact bps fraction"
+    );
+    let cluster_support_pct_min_bps = (supporter_count * 10_000 / validator_count) as u64;
+
+    let mut svm = LiteSVM::new();
+    svm.add_program(SVMGOV_PROGRAM_ID, &read_program()).unwrap();
+    set_clock(&mut svm, creation_epoch);
+
+    let (global_config, global_bump) =
+        Address::find_program_address(&[b"global_config"], &SVMGOV_PROGRAM_ID);
+    let (proposal_index, index_bump) =
+        Address::find_program_address(&[b"index"], &SVMGOV_PROGRAM_ID);
+    let (program_config, _) =
+        Address::find_program_address(&[b"ProgramConfig"], &NCN_SNAPSHOT_PROGRAM_ID);
+
+    write_anchor_account(
+        &mut svm,
+        global_config,
+        SVMGOV_PROGRAM_ID,
+        anchor_discriminator("account", "GlobalConfig"),
+        &GlobalConfigAccount {
+            admin: pk_bytes(&Address::new_unique()),
+            pending_admin: None,
+            max_title_length: 200,
+            max_description_length: 500,
+            max_support_epochs: MAX_SUPPORT_EPOCHS,
+            min_proposal_stake_lamports: 0,
+            cluster_support_pct_min_bps,
+            discussion_epochs: DISCUSSION_EPOCHS,
+            voting_epochs: VOTING_EPOCHS,
+            snapshot_epoch_extension: 0,
+            snapshot_slot_offset: 0,
+            bump: global_bump,
+            max_supporters: MAX_SUPPORTERS,
+        },
+    );
+    write_anchor_account(
+        &mut svm,
+        proposal_index,
+        SVMGOV_PROGRAM_ID,
+        anchor_discriminator("account", "ProposalIndex"),
+        &ProposalIndexAccount {
+            current_index: 0,
+            bump: index_bump,
+        },
+    );
+
+    // Stand-ins so constraints pass; non-empty ballot box skips ncn_snapshot CPI.
+    svm.set_account(
+        NCN_SNAPSHOT_PROGRAM_ID,
+        Account {
+            lamports: 1,
+            data: vec![0],
+            owner: native_loader::ID,
+            executable: true,
+            rent_epoch: 0,
+        },
+    )
+    .unwrap();
+    svm.set_account(
+        program_config,
+        Account {
+            lamports: svm.minimum_balance_for_rent_exemption(1),
+            data: vec![0],
+            owner: NCN_SNAPSHOT_PROGRAM_ID,
+            executable: false,
+            rent_epoch: 0,
+        },
+    )
+    .unwrap();
+
+    let validators: Vec<Validator> = (0..validator_count)
+        .map(|_| Validator {
+            identity: Keypair::new(),
+            vote: Keypair::new(),
+        })
+        .collect();
+
+    let mut stakes = HashMap::with_capacity(validator_count);
+    for v in &validators {
+        stakes.insert(v.vote.pubkey(), STAKE_PER_VALIDATOR);
+    }
+    svm.set_epoch_stakes(stakes).unwrap();
+
+    for v in validators.iter().take(supporter_count) {
+        let data = make_vote_account_data(&v.identity.pubkey());
+        let lamports = svm.minimum_balance_for_rent_exemption(data.len());
+        svm.set_account(
+            v.vote.pubkey(),
+            Account {
+                lamports,
+                data,
+                owner: vote::ID,
+                executable: false,
+                rent_epoch: 0,
+            },
+        )
+        .unwrap();
+        // Enough lamports for many proposals / reallocs across sub-tests.
+        svm.airdrop(&v.identity.pubkey(), 100 * LAMPORTS_PER_SOL)
+            .unwrap();
+    }
+
+    Harness {
+        svm,
+        validators,
+        validator_count,
+        supporter_count,
+        cluster_support_pct_min_bps,
+        global_config,
+        proposal_index,
+        program_config,
+    }
+}
+
+pub fn create_proposal(h: &mut Harness, seed: u64, title: &str) -> Address {
+    let author = h.validators[0].identity.insecure_clone();
+    let author_vote = h.validators[0].vote.pubkey();
+    let (proposal, _) = Address::find_program_address(
+        &[b"proposal", &seed.to_le_bytes(), author_vote.as_ref()],
+        &SVMGOV_PROGRAM_ID,
+    );
+    send_ix(
+        &mut h.svm,
+        &author,
+        &[create_proposal_ix(
+            &author.pubkey(),
+            proposal,
+            h.proposal_index,
+            author_vote,
+            h.global_config,
+            seed,
+            title,
+            "https://github.com/solana-foundation/solana-governance",
+        )],
+    );
+    proposal
+}
+
+pub fn try_support_one(
+    h: &mut Harness,
+    proposal: Address,
+    validator_idx: usize,
+    ballot_box: Address,
+) -> Result<litesvm::types::TransactionMetadata, litesvm::types::FailedTransactionMetadata> {
+    let identity = h.validators[validator_idx].identity.insecure_clone();
+    let vote = h.validators[validator_idx].vote.pubkey();
+    let (support, _) = Address::find_program_address(
+        &[b"support", proposal.as_ref(), vote.as_ref()],
+        &SVMGOV_PROGRAM_ID,
+    );
+    try_send_ix(
+        &mut h.svm,
+        &identity,
+        &[
+            ComputeBudgetInstruction::set_compute_unit_limit(1_400_000),
+            support_proposal_ix(
+                &identity.pubkey(),
+                proposal,
+                support,
+                vote,
+                ballot_box,
+                h.program_config,
+                h.global_config,
+            ),
+        ],
+    )
+}
+
+pub fn support_one(h: &mut Harness, proposal: Address, validator_idx: usize, ballot_box: Address) {
+    try_support_one(h, proposal, validator_idx, ballot_box).unwrap_or_else(|e| {
+        panic!("support failed: {:#?}\nlogs: {:#?}", e.err, e.meta.logs);
+    });
+}
+
+pub fn try_retally_one(
+    h: &mut Harness,
+    proposal: Address,
+    caller_idx: usize,
+    ballot_box: Address,
+) -> Result<litesvm::types::TransactionMetadata, litesvm::types::FailedTransactionMetadata> {
+    let caller = h.validators[caller_idx].identity.insecure_clone();
+    try_send_ix(
+        &mut h.svm,
+        &caller,
+        &[
+            ComputeBudgetInstruction::set_compute_unit_limit(1_400_000),
+            retally_support_ix(
+                &caller.pubkey(),
+                proposal,
+                ballot_box,
+                h.program_config,
+                h.global_config,
+            ),
+        ],
+    )
+}
+
+pub fn retally_one(h: &mut Harness, proposal: Address, caller_idx: usize, ballot_box: Address) {
+    try_retally_one(h, proposal, caller_idx, ballot_box).unwrap_or_else(|e| {
+        panic!("retally failed: {:#?}\nlogs: {:#?}", e.err, e.meta.logs);
+    });
+}
+
+/// Asserts the proposal crossed the threshold with exactly
+/// `h.supporter_count` supporters at `crossing_epoch`.
+pub fn assert_threshold_reached(h: &Harness, proposal: &ProposalAccount, crossing_epoch: u64) {
+    let expected_support = STAKE_PER_VALIDATOR * h.supporter_count as u64;
+    let cluster = STAKE_PER_VALIDATOR * h.validator_count as u64;
+    assert_eq!(proposal.cluster_support_lamports, expected_support);
+    assert_eq!(proposal.supporters.len(), h.supporter_count);
+    assert!(
+        proposal.voting,
+        "expected voting activated at {} bps support",
+        h.cluster_support_pct_min_bps
+    );
+    assert_eq!(
+        expected_support * 10_000 / cluster,
+        h.cluster_support_pct_min_bps
+    );
+    assert_eq!(
+        proposal.snapshot_slot,
+        expected_snapshot_slot(crossing_epoch)
+    );
+}

--- a/svmgov/program/programs/svmgov_program/tests/support_1500_of_2000.rs
+++ b/svmgov/program/programs/svmgov_program/tests/support_1500_of_2000.rs
@@ -1,0 +1,49 @@
+//! Support threshold suite at 1500 supporters out of 2000 validators (75%
+//! threshold) — the same scenario as `support_150_of_1000.rs` but near the
+//! `MAX_SUPPORTERS_LIMIT` scale, exercising the zero-copy supporter storage
+//! and per-support full re-tally with a four-digit list.
+
+mod common;
+
+use {common::*, solana_signer::Signer};
+
+const VALIDATOR_COUNT: usize = 2_000;
+const SUPPORTER_COUNT: usize = 1_500; // 1500/2000 = 75% => 7_500 bps threshold
+
+/// 75% of the cluster shows support in a single epoch; voting activates on
+/// the 1500th support, with every prior supporter re-tallied each time.
+#[test_log::test]
+fn support_proposal_reaches_threshold_at_1500_of_2000() {
+    const CREATION_EPOCH: u64 = 10;
+    let mut h = setup_harness(CREATION_EPOCH, VALIDATOR_COUNT, SUPPORTER_COUNT);
+
+    // Same-epoch activation: ballot box for crossing_epoch == creation_epoch.
+    let ballot_box = seed_ballot_box(&mut h.svm, expected_snapshot_slot(CREATION_EPOCH));
+    let proposal = create_proposal(&mut h, 42, "same-epoch support at cap scale");
+
+    for i in 0..SUPPORTER_COUNT {
+        support_one(&mut h, proposal, i, ballot_box);
+        if (i + 1) % 250 == 0 {
+            println!("supported {}/{} (same epoch)", i + 1, SUPPORTER_COUNT);
+        }
+    }
+
+    let state = fetch_proposal(&h.svm, &proposal);
+    assert_eq!(state.creation_epoch, CREATION_EPOCH);
+    assert_threshold_reached(&h, &state, CREATION_EPOCH);
+    // Entry-level check: all 1500 supporter keys intact, in insertion order.
+    let expected: Vec<[u8; 32]> = h.validators[..SUPPORTER_COUNT]
+        .iter()
+        .map(|v| pk_bytes(&v.vote.pubkey()))
+        .collect();
+    assert_eq!(
+        state.supporters, expected,
+        "supporter entries must be intact, in insertion order"
+    );
+    println!(
+        "ok same-epoch: {}/{} supported; voting={}",
+        state.supporters.len(),
+        VALIDATOR_COUNT,
+        state.voting
+    );
+}

--- a/svmgov/program/programs/svmgov_program/tests/support_150_of_1000.rs
+++ b/svmgov/program/programs/svmgov_program/tests/support_150_of_1000.rs
@@ -1,519 +1,19 @@
+//! Support/retally integration suite at 150 supporters out of 1000
+//! validators (15% threshold). Harness lives in `common`; see
+//! `support_1500_of_2000.rs` for the same scenario at the supporter cap.
+
+mod common;
+
 use {
-    borsh::{BorshDeserialize, BorshSerialize},
-    litesvm::LiteSVM,
-    sha2::{Digest, Sha256},
-    solana_account::Account,
-    solana_address::Address,
-    solana_clock::Clock,
-    solana_compute_budget_interface::ComputeBudgetInstruction,
-    solana_instruction::{AccountMeta, Instruction},
-    solana_instruction_error::InstructionError,
-    solana_keypair::Keypair,
-    solana_message::Message,
-    solana_native_token::LAMPORTS_PER_SOL,
-    solana_sdk_ids::{native_loader, system_program, vote},
-    solana_signer::Signer,
-    solana_transaction::Transaction,
-    solana_transaction_error::TransactionError,
-    solana_vote_interface_host::state::{VoteInit, VoteStateV3, VoteStateVersions},
-    std::{collections::HashMap, path::PathBuf},
+    common::*, solana_signer::Signer, solana_transaction_error::TransactionError,
     svmgov_program::GovernanceError,
 };
 
-const SVMGOV_PROGRAM_ID: Address =
-    Address::from_str_const("govYkyQ3ePtGULAtY6V75qjWE8UH4vCUVQ1W4HdCAZU");
-const NCN_SNAPSHOT_PROGRAM_ID: Address =
-    Address::from_str_const("ncnwF8AgynRcdEnGLcprSQNaKvgSMTgk3yPRc8cf9Zf");
-
 const VALIDATOR_COUNT: usize = 1_000;
-const SUPPORTER_COUNT: usize = 150;
-const STAKE_PER_VALIDATOR: u64 = LAMPORTS_PER_SOL;
-const CLUSTER_SUPPORT_PCT_MIN_BPS: u64 = 1_500; // 15%
-const SLOTS_PER_EPOCH: u64 = 432_000;
-const DISCUSSION_EPOCHS: u64 = 1;
-const MAX_SUPPORT_EPOCHS: u64 = 10;
-/// Anchor `#[error_code]` offset (`anchor_lang::error::ERROR_CODE_OFFSET`).
-const ANCHOR_ERROR_CODE_OFFSET: u32 = 6000;
+const SUPPORTER_COUNT: usize = 150; // 150/1000 = 15% => 1_500 bps threshold
 
-fn anchor_custom_error(err: GovernanceError) -> InstructionError {
-    InstructionError::Custom(ANCHOR_ERROR_CODE_OFFSET + err as u32)
-}
-
-fn pk_bytes(a: &Address) -> [u8; 32] {
-    a.to_bytes()
-}
-
-fn anchor_discriminator(namespace: &str, name: &str) -> [u8; 8] {
-    let preimage = format!("{namespace}:{name}");
-    let hash = Sha256::digest(preimage.as_bytes());
-    let mut out = [0u8; 8];
-    out.copy_from_slice(&hash[..8]);
-    out
-}
-
-fn read_program() -> Vec<u8> {
-    // CARGO_MANIFEST_DIR = programs/svmgov_program
-    let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-    path.push("../../target/deploy/svmgov_program.so");
-    std::fs::read(&path).unwrap_or_else(|e| {
-        panic!(
-            "failed to read {}: {e}. Build with: cargo-build-sbf -p svmgov_program",
-            path.display()
-        )
-    })
-}
-
-#[derive(BorshSerialize)]
-struct GlobalConfigAccount {
-    admin: [u8; 32],
-    pending_admin: Option<[u8; 32]>,
-    max_title_length: u16,
-    max_description_length: u16,
-    max_support_epochs: u64,
-    min_proposal_stake_lamports: u64,
-    cluster_support_pct_min_bps: u64,
-    discussion_epochs: u64,
-    voting_epochs: u64,
-    snapshot_epoch_extension: u64,
-    snapshot_slot_offset: i64,
-    bump: u8,
-    max_supporters: u32,
-}
-
-#[derive(BorshSerialize)]
-struct ProposalIndexAccount {
-    current_index: u32,
-    bump: u8,
-}
-
-#[derive(Debug, BorshDeserialize)]
-#[allow(dead_code)]
-struct ProposalAccount {
-    author: [u8; 32],
-    title: String,
-    description: String,
-    creation_epoch: u64,
-    start_epoch: u64,
-    end_epoch: u64,
-    proposer_stake_weight_bp: u64,
-    cluster_support_lamports: u64,
-    for_votes_lamports: u64,
-    against_votes_lamports: u64,
-    abstain_votes_lamports: u64,
-    voting: bool,
-    finalized: bool,
-    proposal_bump: u8,
-    creation_timestamp: i64,
-    vote_count: u32,
-    index: u32,
-    consensus_result: Option<[u8; 32]>,
-    snapshot_slot: u64,
-    proposal_seed: u64,
-    vote_account_pubkey: [u8; 32],
-    supporters: Vec<[u8; 32]>,
-}
-
-struct Validator {
-    identity: Keypair,
-    vote: Keypair,
-}
-
-struct Harness {
-    svm: LiteSVM,
-    validators: Vec<Validator>,
-    global_config: Address,
-    proposal_index: Address,
-    program_config: Address,
-}
-
-fn make_vote_account_data(node: &Address) -> Vec<u8> {
-    let vote_init = VoteInit {
-        node_pubkey: *node,
-        authorized_voter: *node,
-        authorized_withdrawer: *node,
-        commission: 0,
-    };
-    let state = VoteStateV3::new(&vote_init, &Clock::default());
-    let versioned = VoteStateVersions::V3(Box::new(state));
-    let mut data = vec![0u8; VoteStateV3::size_of()];
-    VoteStateV3::serialize(&versioned, &mut data).expect("serialize VoteStateV3");
-    data
-}
-
-fn write_anchor_account<T: BorshSerialize>(
-    svm: &mut LiteSVM,
-    address: Address,
-    owner: Address,
-    discriminator: [u8; 8],
-    data: &T,
-) {
-    let mut bytes = discriminator.to_vec();
-    bytes.extend(borsh::to_vec(data).expect("borsh serialize"));
-    let lamports = svm.minimum_balance_for_rent_exemption(bytes.len());
-    svm.set_account(
-        address,
-        Account {
-            lamports,
-            data: bytes,
-            owner,
-            executable: false,
-            rent_epoch: 0,
-        },
-    )
-    .unwrap();
-}
-
-fn try_send_ix(
-    svm: &mut LiteSVM,
-    payer: &Keypair,
-    ixs: &[Instruction],
-) -> Result<litesvm::types::TransactionMetadata, litesvm::types::FailedTransactionMetadata> {
-    let blockhash = svm.latest_blockhash();
-    let msg = Message::new(ixs, Some(&payer.pubkey()));
-    let tx = Transaction::new(&[payer], msg, blockhash);
-    svm.send_transaction(tx)
-}
-
-fn send_ix(
-    svm: &mut LiteSVM,
-    payer: &Keypair,
-    ixs: &[Instruction],
-) -> litesvm::types::TransactionMetadata {
-    try_send_ix(svm, payer, ixs).unwrap_or_else(|e| {
-        panic!("tx failed: {:#?}\nlogs: {:#?}", e.err, e.meta.logs);
-    })
-}
-
-fn create_proposal_ix(
-    author: &Address,
-    proposal: Address,
-    proposal_index: Address,
-    vote_account: Address,
-    global_config: Address,
-    seed: u64,
-    title: &str,
-    description: &str,
-) -> Instruction {
-    let mut data = anchor_discriminator("global", "create_proposal").to_vec();
-    data.extend(seed.to_le_bytes());
-    data.extend((title.len() as u32).to_le_bytes());
-    data.extend(title.as_bytes());
-    data.extend((description.len() as u32).to_le_bytes());
-    data.extend(description.as_bytes());
-
-    Instruction {
-        program_id: SVMGOV_PROGRAM_ID,
-        accounts: vec![
-            AccountMeta::new(*author, true),
-            AccountMeta::new(proposal, false),
-            AccountMeta::new(proposal_index, false),
-            AccountMeta::new_readonly(vote_account, false),
-            AccountMeta::new_readonly(global_config, false),
-            AccountMeta::new_readonly(system_program::ID, false),
-        ],
-        data,
-    }
-}
-
-fn support_proposal_ix(
-    supporter: &Address,
-    proposal: Address,
-    support: Address,
-    vote_account: Address,
-    ballot_box: Address,
-    program_config: Address,
-    global_config: Address,
-) -> Instruction {
-    Instruction {
-        program_id: SVMGOV_PROGRAM_ID,
-        accounts: vec![
-            AccountMeta::new(*supporter, true),
-            AccountMeta::new(proposal, false),
-            AccountMeta::new(support, false),
-            AccountMeta::new_readonly(vote_account, false),
-            AccountMeta::new(ballot_box, false),
-            AccountMeta::new_readonly(NCN_SNAPSHOT_PROGRAM_ID, false),
-            AccountMeta::new_readonly(program_config, false),
-            AccountMeta::new_readonly(global_config, false),
-            AccountMeta::new_readonly(system_program::ID, false),
-        ],
-        data: anchor_discriminator("global", "support_proposal").to_vec(),
-    }
-}
-
-fn retally_support_ix(
-    caller: &Address,
-    proposal: Address,
-    ballot_box: Address,
-    program_config: Address,
-    global_config: Address,
-) -> Instruction {
-    Instruction {
-        program_id: SVMGOV_PROGRAM_ID,
-        accounts: vec![
-            AccountMeta::new(*caller, true),
-            AccountMeta::new(proposal, false),
-            AccountMeta::new(ballot_box, false),
-            AccountMeta::new_readonly(NCN_SNAPSHOT_PROGRAM_ID, false),
-            AccountMeta::new_readonly(program_config, false),
-            AccountMeta::new_readonly(global_config, false),
-            AccountMeta::new_readonly(system_program::ID, false),
-        ],
-        data: anchor_discriminator("global", "retally_support").to_vec(),
-    }
-}
-
-fn fetch_proposal(svm: &LiteSVM, proposal: &Address) -> ProposalAccount {
-    let account = svm.get_account(proposal).expect("proposal account");
-    assert!(account.data.len() > 8, "proposal too small");
-    // Realloc leaves trailing capacity; ignore unread bytes after the Borsh payload.
-    let mut data: &[u8] = &account.data[8..];
-    ProposalAccount::deserialize(&mut data).expect("deserialize proposal")
-}
-
-fn expected_snapshot_slot(crossing_epoch: u64) -> u64 {
-    // discussion_epochs=1, snapshot_epoch_extension=0, snapshot_slot_offset=0
-    (crossing_epoch + DISCUSSION_EPOCHS) * SLOTS_PER_EPOCH
-}
-
-fn set_clock(svm: &mut LiteSVM, epoch: u64) {
-    let mut clock = svm.get_sysvar::<Clock>();
-    clock.epoch = epoch;
-    // Stay inside the epoch so snapshot_slot (= next epoch start) remains in the future.
-    clock.slot = epoch * SLOTS_PER_EPOCH + 1;
-    svm.set_sysvar(&clock);
-}
-
-fn seed_ballot_box(svm: &mut LiteSVM, snapshot_slot: u64) -> Address {
-    let (ballot_box, _) = Address::find_program_address(
-        &[b"BallotBox", &snapshot_slot.to_le_bytes()],
-        &NCN_SNAPSHOT_PROGRAM_ID,
-    );
-    if svm.get_account(&ballot_box).is_none() {
-        svm.set_account(
-            ballot_box,
-            Account {
-                lamports: svm.minimum_balance_for_rent_exemption(1),
-                data: vec![1],
-                owner: NCN_SNAPSHOT_PROGRAM_ID,
-                executable: false,
-                rent_epoch: 0,
-            },
-        )
-        .unwrap();
-    }
-    ballot_box
-}
-
-fn setup_harness(creation_epoch: u64) -> Harness {
-    let mut svm = LiteSVM::new();
-    svm.add_program(SVMGOV_PROGRAM_ID, &read_program()).unwrap();
-    set_clock(&mut svm, creation_epoch);
-
-    let (global_config, global_bump) =
-        Address::find_program_address(&[b"global_config"], &SVMGOV_PROGRAM_ID);
-    let (proposal_index, index_bump) =
-        Address::find_program_address(&[b"index"], &SVMGOV_PROGRAM_ID);
-    let (program_config, _) =
-        Address::find_program_address(&[b"ProgramConfig"], &NCN_SNAPSHOT_PROGRAM_ID);
-
-    write_anchor_account(
-        &mut svm,
-        global_config,
-        SVMGOV_PROGRAM_ID,
-        anchor_discriminator("account", "GlobalConfig"),
-        &GlobalConfigAccount {
-            admin: pk_bytes(&Address::new_unique()),
-            pending_admin: None,
-            max_title_length: 200,
-            max_description_length: 500,
-            max_support_epochs: MAX_SUPPORT_EPOCHS,
-            min_proposal_stake_lamports: 0,
-            cluster_support_pct_min_bps: CLUSTER_SUPPORT_PCT_MIN_BPS,
-            discussion_epochs: DISCUSSION_EPOCHS,
-            voting_epochs: 3,
-            snapshot_epoch_extension: 0,
-            snapshot_slot_offset: 0,
-            bump: global_bump,
-            max_supporters: 2000,
-        },
-    );
-    write_anchor_account(
-        &mut svm,
-        proposal_index,
-        SVMGOV_PROGRAM_ID,
-        anchor_discriminator("account", "ProposalIndex"),
-        &ProposalIndexAccount {
-            current_index: 0,
-            bump: index_bump,
-        },
-    );
-
-    // Stand-ins so constraints pass; non-empty ballot box skips ncn_snapshot CPI.
-    svm.set_account(
-        NCN_SNAPSHOT_PROGRAM_ID,
-        Account {
-            lamports: 1,
-            data: vec![0],
-            owner: native_loader::ID,
-            executable: true,
-            rent_epoch: 0,
-        },
-    )
-    .unwrap();
-    svm.set_account(
-        program_config,
-        Account {
-            lamports: svm.minimum_balance_for_rent_exemption(1),
-            data: vec![0],
-            owner: NCN_SNAPSHOT_PROGRAM_ID,
-            executable: false,
-            rent_epoch: 0,
-        },
-    )
-    .unwrap();
-
-    let validators: Vec<Validator> = (0..VALIDATOR_COUNT)
-        .map(|_| Validator {
-            identity: Keypair::new(),
-            vote: Keypair::new(),
-        })
-        .collect();
-
-    let mut stakes = HashMap::with_capacity(VALIDATOR_COUNT);
-    for v in &validators {
-        stakes.insert(v.vote.pubkey(), STAKE_PER_VALIDATOR);
-    }
-    svm.set_epoch_stakes(stakes).unwrap();
-
-    for v in validators.iter().take(SUPPORTER_COUNT) {
-        let data = make_vote_account_data(&v.identity.pubkey());
-        let lamports = svm.minimum_balance_for_rent_exemption(data.len());
-        svm.set_account(
-            v.vote.pubkey(),
-            Account {
-                lamports,
-                data,
-                owner: vote::ID,
-                executable: false,
-                rent_epoch: 0,
-            },
-        )
-        .unwrap();
-        // Enough lamports for many proposals / reallocs across sub-tests.
-        svm.airdrop(&v.identity.pubkey(), 100 * LAMPORTS_PER_SOL)
-            .unwrap();
-    }
-
-    Harness {
-        svm,
-        validators,
-        global_config,
-        proposal_index,
-        program_config,
-    }
-}
-
-fn create_proposal(h: &mut Harness, seed: u64, title: &str) -> Address {
-    let author = h.validators[0].identity.insecure_clone();
-    let author_vote = h.validators[0].vote.pubkey();
-    let (proposal, _) = Address::find_program_address(
-        &[b"proposal", &seed.to_le_bytes(), author_vote.as_ref()],
-        &SVMGOV_PROGRAM_ID,
-    );
-    send_ix(
-        &mut h.svm,
-        &author,
-        &[create_proposal_ix(
-            &author.pubkey(),
-            proposal,
-            h.proposal_index,
-            author_vote,
-            h.global_config,
-            seed,
-            title,
-            "https://github.com/solana-foundation/solana-governance",
-        )],
-    );
-    proposal
-}
-
-fn try_support_one(
-    h: &mut Harness,
-    proposal: Address,
-    validator_idx: usize,
-    ballot_box: Address,
-) -> Result<litesvm::types::TransactionMetadata, litesvm::types::FailedTransactionMetadata> {
-    let identity = h.validators[validator_idx].identity.insecure_clone();
-    let vote = h.validators[validator_idx].vote.pubkey();
-    let (support, _) = Address::find_program_address(
-        &[b"support", proposal.as_ref(), vote.as_ref()],
-        &SVMGOV_PROGRAM_ID,
-    );
-    try_send_ix(
-        &mut h.svm,
-        &identity,
-        &[
-            ComputeBudgetInstruction::set_compute_unit_limit(1_400_000),
-            support_proposal_ix(
-                &identity.pubkey(),
-                proposal,
-                support,
-                vote,
-                ballot_box,
-                h.program_config,
-                h.global_config,
-            ),
-        ],
-    )
-}
-
-fn support_one(h: &mut Harness, proposal: Address, validator_idx: usize, ballot_box: Address) {
-    try_support_one(h, proposal, validator_idx, ballot_box).unwrap_or_else(|e| {
-        panic!("support failed: {:#?}\nlogs: {:#?}", e.err, e.meta.logs);
-    });
-}
-
-fn try_retally_one(
-    h: &mut Harness,
-    proposal: Address,
-    caller_idx: usize,
-    ballot_box: Address,
-) -> Result<litesvm::types::TransactionMetadata, litesvm::types::FailedTransactionMetadata> {
-    let caller = h.validators[caller_idx].identity.insecure_clone();
-    try_send_ix(
-        &mut h.svm,
-        &caller,
-        &[
-            ComputeBudgetInstruction::set_compute_unit_limit(1_400_000),
-            retally_support_ix(
-                &caller.pubkey(),
-                proposal,
-                ballot_box,
-                h.program_config,
-                h.global_config,
-            ),
-        ],
-    )
-}
-
-fn retally_one(h: &mut Harness, proposal: Address, caller_idx: usize, ballot_box: Address) {
-    try_retally_one(h, proposal, caller_idx, ballot_box).unwrap_or_else(|e| {
-        panic!("retally failed: {:#?}\nlogs: {:#?}", e.err, e.meta.logs);
-    });
-}
-
-fn assert_threshold_reached(proposal: &ProposalAccount, crossing_epoch: u64) {
-    let expected_support = STAKE_PER_VALIDATOR * SUPPORTER_COUNT as u64;
-    let cluster = STAKE_PER_VALIDATOR * VALIDATOR_COUNT as u64;
-    assert_eq!(proposal.cluster_support_lamports, expected_support);
-    assert_eq!(proposal.supporters.len(), SUPPORTER_COUNT);
-    assert!(proposal.voting, "expected voting activated at 15% support");
-    assert_eq!(expected_support * 100 / cluster, 15);
-    assert_eq!(
-        proposal.snapshot_slot,
-        expected_snapshot_slot(crossing_epoch)
-    );
+fn setup(creation_epoch: u64) -> Harness {
+    setup_harness(creation_epoch, VALIDATOR_COUNT, SUPPORTER_COUNT)
 }
 
 /// Stake drift alone (no new supporter) can activate voting via `retally_support`.
@@ -525,7 +25,7 @@ fn assert_threshold_reached(proposal: &ProposalAccount, crossing_epoch: u64) {
 fn retally_support_activates_voting_after_stake_drift() {
     const CREATION_EPOCH: u64 = 10;
     const UNDER_THRESHOLD: usize = SUPPORTER_COUNT - 1; // 149 / 1000 = 14.9%
-    let mut h = setup_harness(CREATION_EPOCH);
+    let mut h = setup(CREATION_EPOCH);
 
     // Placeholder ballot box for the under-threshold supports (activation skipped).
     let early_ballot = seed_ballot_box(&mut h.svm, expected_snapshot_slot(CREATION_EPOCH));
@@ -588,7 +88,7 @@ fn support_proposal_remeasures_prior_stake_across_epochs() {
     // 148 @ 1 SOL; after +1 SOL drift on one prior, a 149th support remeasures
     // to 149 + 1 = 150. Stale (support-time) weights would only reach 149.
     const PRIOR: usize = SUPPORTER_COUNT - 2;
-    let mut h = setup_harness(CREATION_EPOCH);
+    let mut h = setup(CREATION_EPOCH);
     let early_ballot = seed_ballot_box(&mut h.svm, expected_snapshot_slot(CREATION_EPOCH));
     let proposal = create_proposal(&mut h, 98, "remeasure on support");
 
@@ -625,7 +125,7 @@ fn support_proposal_remeasures_prior_stake_across_epochs() {
 fn support_and_retally_reject_after_voting_activated() {
     const CREATION_EPOCH: u64 = 10;
     const UNDER_THRESHOLD: usize = SUPPORTER_COUNT - 1;
-    let mut h = setup_harness(CREATION_EPOCH);
+    let mut h = setup(CREATION_EPOCH);
     let ballot_box = seed_ballot_box(&mut h.svm, expected_snapshot_slot(CREATION_EPOCH));
     let proposal = create_proposal(&mut h, 97, "closed after voting");
 
@@ -661,7 +161,7 @@ fn support_and_retally_reject_after_voting_activated() {
 #[test_log::test]
 fn retally_support_rejects_after_support_window() {
     const CREATION_EPOCH: u64 = 10;
-    let mut h = setup_harness(CREATION_EPOCH);
+    let mut h = setup(CREATION_EPOCH);
     let ballot_box = seed_ballot_box(&mut h.svm, expected_snapshot_slot(CREATION_EPOCH));
     let proposal = create_proposal(&mut h, 8, "expired retally window");
 
@@ -693,7 +193,7 @@ fn retally_support_rejects_after_support_window() {
 #[test_log::test]
 fn support_proposal_rejects_after_support_window() {
     const CREATION_EPOCH: u64 = 10;
-    let mut h = setup_harness(CREATION_EPOCH);
+    let mut h = setup(CREATION_EPOCH);
     // Ballot box is unused on the failing path (activation never runs), but the
     // account meta is still required by the instruction.
     let ballot_box = seed_ballot_box(&mut h.svm, expected_snapshot_slot(CREATION_EPOCH));
@@ -728,7 +228,7 @@ fn support_proposal_rejects_after_support_window() {
 #[test_log::test]
 fn support_proposal_reaches_threshold_at_150_of_1000() {
     const CREATION_EPOCH: u64 = 10;
-    let mut h = setup_harness(CREATION_EPOCH);
+    let mut h = setup(CREATION_EPOCH);
 
     // Same-epoch activation: ballot box for crossing_epoch == creation_epoch.
     let ballot_box = seed_ballot_box(&mut h.svm, expected_snapshot_slot(CREATION_EPOCH));
@@ -743,7 +243,18 @@ fn support_proposal_reaches_threshold_at_150_of_1000() {
 
     let state = fetch_proposal(&h.svm, &proposal);
     assert_eq!(state.creation_epoch, CREATION_EPOCH);
-    assert_threshold_reached(&state, CREATION_EPOCH);
+    assert_threshold_reached(&h, &state, CREATION_EPOCH);
+    // Entry-level check: the raw supporter keys written past the Borsh
+    // capacity boundary must be intact after voting activation.
+    let expected: Vec<[u8; 32]> = h.validators[..SUPPORTER_COUNT]
+        .iter()
+        .map(|v| pk_bytes(&v.vote.pubkey()))
+        .collect();
+    assert_eq!(state.supporters.len(), expected.len());
+    assert_eq!(
+        state.supporters, expected,
+        "supporter entries must be intact, in insertion order"
+    );
     println!(
         "ok same-epoch: {}/{} supported; voting={}",
         state.supporters.len(),
@@ -760,7 +271,7 @@ fn support_proposal_reaches_threshold_across_2_to_10_epochs() {
     const CREATION_EPOCH: u64 = 100;
 
     for span in 2u64..=10 {
-        let mut h = setup_harness(CREATION_EPOCH);
+        let mut h = setup(CREATION_EPOCH);
         let crossing_epoch = CREATION_EPOCH + span - 1;
         let ballot_box = seed_ballot_box(&mut h.svm, expected_snapshot_slot(crossing_epoch));
         let proposal = create_proposal(&mut h, 42, &format!("{span}-epoch support"));
@@ -798,10 +309,10 @@ fn support_proposal_reaches_threshold_across_2_to_10_epochs() {
 
         let state = fetch_proposal(&h.svm, &proposal);
         assert_eq!(state.creation_epoch, CREATION_EPOCH);
-        assert_threshold_reached(&state, crossing_epoch);
+        assert_threshold_reached(&h, &state, crossing_epoch);
         // Schedule anchors on the crossing epoch (discussion_epochs=1).
         assert_eq!(state.start_epoch, crossing_epoch + DISCUSSION_EPOCHS + 1);
-        assert_eq!(state.end_epoch, state.start_epoch + 3);
+        assert_eq!(state.end_epoch, state.start_epoch + VOTING_EPOCHS);
 
         println!(
             "ok span={span}: crossed at epoch {crossing_epoch}; supporters={}; snapshot_slot={}",


### PR DESCRIPTION
- Supporters vec is now zero-copy read
- Parameterized the harness and created a 1500 out of 2000 supporters test