### PR TITLE
chore(svmgov): Request a Compute Budget For `support_proposal` and `retally_support`

### DIFF
--- a/frontend/src/chain/instructions/__tests__/supportComputeUnitLimit.test.ts
+++ b/frontend/src/chain/instructions/__tests__/supportComputeUnitLimit.test.ts
@@ -1,0 +1,38 @@
+import { supportComputeUnitLimit } from "../types";
+
+/** Peak measured in the program's tests/support_compute_budget.rs at the cap. */
+const MEASURED_AT_CAP = 284_953;
+/** Most expensive activating call measured in the program's tests/ncn_flow.rs. */
+const MEASURED_ACTIVATION = 47_610;
+
+describe("supportComputeUnitLimit", () => {
+  it("covers the measured cost with headroom", () => {
+    // An empty list can still be the call that activates voting and creates the
+    // ballot box via CPI, which is the expensive path at that size.
+    expect(supportComputeUnitLimit(0)).toBeGreaterThan(MEASURED_ACTIVATION);
+    expect(supportComputeUnitLimit(2_000)).toBeGreaterThan(MEASURED_AT_CAP);
+  });
+
+  it("scales with the supporter count", () => {
+    // The point of modelling: a small list must request far less than the flat
+    // 600k it used to.
+    expect(supportComputeUnitLimit(0)).toBeLessThan(100_000);
+    expect(supportComputeUnitLimit(50)).toBeLessThan(
+      supportComputeUnitLimit(500),
+    );
+    expect(supportComputeUnitLimit(500)).toBeLessThan(
+      supportComputeUnitLimit(2_000),
+    );
+  });
+
+  it("never exceeds the per-transaction maximum", () => {
+    expect(supportComputeUnitLimit(1_000_000)).toBe(1_400_000);
+  });
+
+  it("matches the Rust mirror in svmgov/cli/src/constants.rs", () => {
+    // Both clients must request the same budget for the same state; these are
+    // the values support_compute_unit_limit() produces.
+    expect(supportComputeUnitLimit(0)).toBe(54_625);
+    expect(supportComputeUnitLimit(2_000)).toBe(358_225);
+  });
+});

--- a/frontend/src/chain/instructions/__tests__/supportComputeUnitLimit.test.ts
+++ b/frontend/src/chain/instructions/__tests__/supportComputeUnitLimit.test.ts
@@ -3,7 +3,7 @@ import { supportComputeUnitLimit } from "../types";
 /** Peak measured in the program's tests/support_compute_budget.rs at the cap. */
 const MEASURED_AT_CAP = 284_953;
 /** Most expensive activating call measured in the program's tests/ncn_flow.rs. */
-const MEASURED_ACTIVATION = 47_610;
+const MEASURED_ACTIVATION = 49_473;
 
 describe("supportComputeUnitLimit", () => {
   it("covers the measured cost with headroom", () => {
@@ -32,7 +32,7 @@ describe("supportComputeUnitLimit", () => {
   it("matches the Rust mirror in svmgov/cli/src/constants.rs", () => {
     // Both clients must request the same budget for the same state; these are
     // the values support_compute_unit_limit() produces.
-    expect(supportComputeUnitLimit(0)).toBe(54_625);
-    expect(supportComputeUnitLimit(2_000)).toBe(358_225);
+    expect(supportComputeUnitLimit(0)).toBe(58_075);
+    expect(supportComputeUnitLimit(2_000)).toBe(361_675);
   });
 });

--- a/frontend/src/chain/instructions/__tests__/supportComputeUnitLimit.test.ts
+++ b/frontend/src/chain/instructions/__tests__/supportComputeUnitLimit.test.ts
@@ -1,4 +1,4 @@
-import { supportComputeUnitLimit } from "../types";
+import { MAX_SUPPORTERS, supportComputeUnitLimit } from "../types";
 
 /** Peak measured in the program's tests/support_compute_budget.rs at the cap. */
 const MEASURED_AT_CAP = 284_953;
@@ -23,6 +23,16 @@ describe("supportComputeUnitLimit", () => {
     expect(supportComputeUnitLimit(500)).toBeLessThan(
       supportComputeUnitLimit(2_000),
     );
+  });
+
+  it("the fallback supporter count covers the worst case", () => {
+    // supportProposal passes MAX_SUPPORTERS when the real count cannot be read,
+    // so that request must be at least as large as any real list would need.
+    const fallback = supportComputeUnitLimit(MAX_SUPPORTERS);
+    expect(fallback).toBeGreaterThan(MEASURED_AT_CAP);
+    for (const n of [0, 1, 500, 1_999, MAX_SUPPORTERS]) {
+      expect(supportComputeUnitLimit(n)).toBeLessThanOrEqual(fallback);
+    }
   });
 
   it("never exceeds the per-transaction maximum", () => {

--- a/frontend/src/chain/instructions/supportProposal.ts
+++ b/frontend/src/chain/instructions/supportProposal.ts
@@ -11,6 +11,7 @@ import {
   SupportProposalParams,
   TransactionResult,
   SNAPSHOT_PROGRAM_ID,
+  MAX_SUPPORTERS,
   supportComputeUnitLimit,
   ChainVoteAccountData,
 } from "./types";
@@ -52,9 +53,19 @@ export async function supportProposal(
   const splVoteAccount = new PublicKey(validatorVoteAccount.voteAccount);
 
   // The handler re-tallies every existing supporter, so the compute budget is
-  // sized from the current list length rather than a flat worst case.
-  const proposalAccount = await program.account.proposal.fetch(proposalPubkey);
-  const numSupporters = Number(proposalAccount.numSupporters ?? 0);
+  // sized from the current list length rather than a flat worst case. If the
+  // read fails the support itself may still succeed, so fall back to the
+  // program's supporter cap rather than aborting on a budgeting detail.
+  let numSupporters = MAX_SUPPORTERS;
+  try {
+    const proposalAccount = await program.account.proposal.fetch(proposalPubkey);
+    numSupporters = proposalAccount.numSupporters;
+  } catch (error) {
+    console.warn(
+      `Could not read the supporter count for ${proposalId}; requesting the compute budget for a full ${MAX_SUPPORTERS}-supporter list`,
+      error,
+    );
+  }
 
   // Derive support PDA - based on IDL, it uses proposal and signer
   const supportPda = deriveSupportPda(

--- a/frontend/src/chain/instructions/supportProposal.ts
+++ b/frontend/src/chain/instructions/supportProposal.ts
@@ -11,7 +11,7 @@ import {
   SupportProposalParams,
   TransactionResult,
   SNAPSHOT_PROGRAM_ID,
-  SUPPORT_COMPUTE_UNIT_LIMIT,
+  supportComputeUnitLimit,
   ChainVoteAccountData,
 } from "./types";
 import {
@@ -50,6 +50,11 @@ export async function supportProposal(
 
   const proposalPubkey = new PublicKey(proposalId);
   const splVoteAccount = new PublicKey(validatorVoteAccount.voteAccount);
+
+  // The handler re-tallies every existing supporter, so the compute budget is
+  // sized from the current list length rather than a flat worst case.
+  const proposalAccount = await program.account.proposal.fetch(proposalPubkey);
+  const numSupporters = Number(proposalAccount.numSupporters ?? 0);
 
   // Derive support PDA - based on IDL, it uses proposal and signer
   const supportPda = deriveSupportPda(
@@ -98,11 +103,11 @@ export async function supportProposal(
     .instruction();
 
   const transaction = new Transaction();
-  // Covers the supporter re-tally past the 200k default; see
-  // SUPPORT_COMPUTE_UNIT_LIMIT.
+  // Sized from the current supporter count — the handler re-tallies the whole
+  // list. See supportComputeUnitLimit.
   transaction.add(
     ComputeBudgetProgram.setComputeUnitLimit({
-      units: SUPPORT_COMPUTE_UNIT_LIMIT,
+      units: supportComputeUnitLimit(numSupporters),
     }),
   );
   transaction.add(supportProposalInstruction);

--- a/frontend/src/chain/instructions/supportProposal.ts
+++ b/frontend/src/chain/instructions/supportProposal.ts
@@ -1,4 +1,9 @@
-import { PublicKey, SystemProgram, Transaction } from "@solana/web3.js";
+import {
+  ComputeBudgetProgram,
+  PublicKey,
+  SystemProgram,
+  Transaction,
+} from "@solana/web3.js";
 import { BN } from "@coral-xyz/anchor";
 import {
   BlockchainParams,
@@ -6,6 +11,7 @@ import {
   SupportProposalParams,
   TransactionResult,
   SNAPSHOT_PROGRAM_ID,
+  SUPPORT_COMPUTE_UNIT_LIMIT,
   ChainVoteAccountData,
 } from "./types";
 import {
@@ -92,6 +98,13 @@ export async function supportProposal(
     .instruction();
 
   const transaction = new Transaction();
+  // Covers the supporter re-tally past the 200k default; see
+  // SUPPORT_COMPUTE_UNIT_LIMIT.
+  transaction.add(
+    ComputeBudgetProgram.setComputeUnitLimit({
+      units: SUPPORT_COMPUTE_UNIT_LIMIT,
+    }),
+  );
   transaction.add(supportProposalInstruction);
   transaction.feePayer = wallet.publicKey;
   transaction.recentBlockhash = (

--- a/frontend/src/chain/instructions/types.ts
+++ b/frontend/src/chain/instructions/types.ts
@@ -191,6 +191,12 @@ const SUPPORT_CU_ACTIVATION = 28_000;
 const SUPPORT_CU_HEADROOM_PERCENT = 15;
 /** Per-transaction maximum a client may request. */
 const MAX_COMPUTE_UNIT_LIMIT = 1_400_000;
+/**
+ * The program's `MAX_SUPPORTERS_LIMIT`. Used as the supporter count when the
+ * real one cannot be read, so the request still covers the largest list the
+ * program permits.
+ */
+export const MAX_SUPPORTERS = 2_000;
 
 /**
  * Compute-unit limit to request for a support against a proposal that currently

--- a/frontend/src/chain/instructions/types.ts
+++ b/frontend/src/chain/instructions/types.ts
@@ -165,17 +165,43 @@ export const BASIS_POINTS_TOTAL = 10000;
 export const SVMGOV_PROGRAM_ID = new PublicKey(svmgovProgramIdl.address);
 export const SNAPSHOT_PROGRAM_ID = new PublicKey(govV1idl.address);
 
+// --- Compute budget for support_proposal -----------------------------------
+//
+// The handler re-tallies the whole supporter list on every call, so its cost is
+// linear in `num_supporters`. Requesting a flat worst case would overshoot a
+// typical call by ~10x, and priority fees price the *requested* limit rather
+// than what is consumed, so the request is modelled instead.
+//
+// Keep in sync with the mirror in `svmgov/cli/src/constants.rs`. The program's
+// `tests/support_compute_budget.rs` asserts the model covers measured cost.
+
+/** Fixed cost before the per-supporter re-tally. Measured at 22,434 CU. */
+const SUPPORT_CU_BASE = 22_500;
+/** Per existing supporter: a `sol_get_epoch_stake` syscall plus loop overhead. */
+const SUPPORT_CU_PER_SUPPORTER = 132;
 /**
- * Compute-unit limit requested for `support_proposal`, which re-tallies the
- * whole supporter list on every call (~20k CU + ~132 per supporter, so ~285k at
- * the 2000 cap) and outgrows the 200k default at 1347 supporters. Headroom
- * only: mainnet's ~800 validators cannot reach that.
- *
- * 600k is >2x the worst case at the cap and well under the 1.4M ceiling.
- * Priority fees price the requested limit rather than the amount consumed, so
- * right-size this off simulation if a compute-unit price is ever added.
- *
- * Measured by the program's `tests/support_compute_budget.rs`; keep in sync
- * with the copy in `svmgov/cli/src/constants.rs`.
+ * Extra units for the call that crosses the threshold: it activates voting and,
+ * unless the ballot box exists, creates it via the `init_ballot_box` CPI.
+ * Measured at ~21-25k above a non-activating call. Always included — a caller
+ * cannot know whether its own call will be the one that crosses.
  */
-export const SUPPORT_COMPUTE_UNIT_LIMIT = 600_000;
+const SUPPORT_CU_ACTIVATION = 25_000;
+/** Covers supporters landing between reading the count and executing. */
+const SUPPORT_CU_HEADROOM_PERCENT = 15;
+/** Per-transaction maximum a client may request. */
+const MAX_COMPUTE_UNIT_LIMIT = 1_400_000;
+
+/**
+ * Compute-unit limit to request for a support against a proposal that currently
+ * has `numSupporters` supporters.
+ */
+export function supportComputeUnitLimit(numSupporters: number): number {
+  const modelled =
+    SUPPORT_CU_BASE +
+    SUPPORT_CU_PER_SUPPORTER * Math.max(0, numSupporters) +
+    SUPPORT_CU_ACTIVATION;
+  const withHeadroom = Math.ceil(
+    (modelled * (100 + SUPPORT_CU_HEADROOM_PERCENT)) / 100,
+  );
+  return Math.min(withHeadroom, MAX_COMPUTE_UNIT_LIMIT);
+}

--- a/frontend/src/chain/instructions/types.ts
+++ b/frontend/src/chain/instructions/types.ts
@@ -164,3 +164,18 @@ export interface NetworkMetaResponse {
 export const BASIS_POINTS_TOTAL = 10000;
 export const SVMGOV_PROGRAM_ID = new PublicKey(svmgovProgramIdl.address);
 export const SNAPSHOT_PROGRAM_ID = new PublicKey(govV1idl.address);
+
+/**
+ * Compute-unit limit requested for `support_proposal`, which re-tallies the
+ * whole supporter list on every call (~20k CU + ~132 per supporter, so ~285k at
+ * the 2000 cap) and outgrows the 200k default at 1347 supporters. Headroom
+ * only: mainnet's ~800 validators cannot reach that.
+ *
+ * 600k is >2x the worst case at the cap and well under the 1.4M ceiling.
+ * Priority fees price the requested limit rather than the amount consumed, so
+ * right-size this off simulation if a compute-unit price is ever added.
+ *
+ * Measured by the program's `tests/support_compute_budget.rs`; keep in sync
+ * with the copy in `svmgov/cli/src/constants.rs`.
+ */
+export const SUPPORT_COMPUTE_UNIT_LIMIT = 600_000;

--- a/frontend/src/chain/instructions/types.ts
+++ b/frontend/src/chain/instructions/types.ts
@@ -182,10 +182,11 @@ const SUPPORT_CU_PER_SUPPORTER = 132;
 /**
  * Extra units for the call that crosses the threshold: it activates voting and,
  * unless the ballot box exists, creates it via the `init_ballot_box` CPI.
- * Measured at ~21-25k above a non-activating call. Always included — a caller
- * cannot know whether its own call will be the one that crosses.
+ * Measured at ~26.8k above a non-activating call, at the 64-operator whitelist
+ * maximum (init_ballot_box clones the whitelist, so a longer list costs more).
+ * Always included — a caller cannot know whether its own call will cross.
  */
-const SUPPORT_CU_ACTIVATION = 25_000;
+const SUPPORT_CU_ACTIVATION = 28_000;
 /** Covers supporters landing between reading the count and executing. */
 const SUPPORT_CU_HEADROOM_PERCENT = 15;
 /** Per-transaction maximum a client may request. */

--- a/svmgov/cli/src/constants.rs
+++ b/svmgov/cli/src/constants.rs
@@ -10,6 +10,19 @@ pub const DEFAULT_OPERATOR_API_URL: &str = "https://ncn-governance.solana.com";
 // Voting constants
 pub const BASIS_POINTS_TOTAL: u64 = 10_000;
 
+/// Compute-unit limit requested for `support_proposal` and `retally_support`,
+/// which re-tally the whole supporter list on every call (~20k CU + ~132 per
+/// supporter, so ~285k at the 2000 cap) and outgrow the 200k default at 1347
+/// supporters. Headroom only: mainnet's ~800 validators cannot reach that.
+///
+/// 600k is >2x the worst case at the cap and well under the 1.4M ceiling.
+/// Priority fees price the requested limit rather than the amount consumed, so
+/// right-size this off simulation if a compute-unit price is ever added.
+///
+/// Measured by `tests/support_compute_budget.rs`; keep in sync with the copy in
+/// `frontend/src/chain/instructions/types.ts`.
+pub const SUPPORT_COMPUTE_UNIT_LIMIT: u32 = 600_000;
+
 // UI constants
 pub const SPINNER_TICK_DURATION_MS: u64 = 100;
 

--- a/svmgov/cli/src/constants.rs
+++ b/svmgov/cli/src/constants.rs
@@ -10,18 +10,90 @@ pub const DEFAULT_OPERATOR_API_URL: &str = "https://ncn-governance.solana.com";
 // Voting constants
 pub const BASIS_POINTS_TOTAL: u64 = 10_000;
 
-/// Compute-unit limit requested for `support_proposal` and `retally_support`,
-/// which re-tally the whole supporter list on every call (~20k CU + ~132 per
-/// supporter, so ~285k at the 2000 cap) and outgrow the 200k default at 1347
-/// supporters. Headroom only: mainnet's ~800 validators cannot reach that.
-///
-/// 600k is >2x the worst case at the cap and well under the 1.4M ceiling.
-/// Priority fees price the requested limit rather than the amount consumed, so
-/// right-size this off simulation if a compute-unit price is ever added.
-///
-/// Measured by `tests/support_compute_budget.rs`; keep in sync with the copy in
-/// `frontend/src/chain/instructions/types.ts`.
-pub const SUPPORT_COMPUTE_UNIT_LIMIT: u32 = 600_000;
+// --- Compute budget for support_proposal / retally_support -----------------
+//
+// Both instructions re-tally the whole supporter list on every call, so their
+// cost is linear in `num_supporters`. Requesting a flat worst-case limit would
+// overshoot a typical call by ~10x; priority fees price the *requested* limit
+// rather than what is consumed, so the request is modelled instead.
+//
+// Keep in sync with the mirror in `frontend/src/chain/instructions/types.ts`.
+// `tests/support_compute_budget.rs` asserts the model covers measured cost.
+
+/// Fixed cost before the per-supporter re-tally. Measured at 22,434 CU for a
+/// support with no prior supporters.
+pub const SUPPORT_CU_BASE: u32 = 22_500;
+
+/// Added per existing supporter: one `sol_get_epoch_stake` syscall (a fixed
+/// ~110 CU under SIMD-0133) plus loop overhead. Measured slope ~132.
+pub const SUPPORT_CU_PER_SUPPORTER: u32 = 132;
+
+/// Extra units for the call that crosses the support threshold: it activates
+/// voting and, unless the ballot box already exists, creates it through the
+/// `init_ballot_box` CPI. Measured at ~21-25k above a non-activating call in
+/// `tests/ncn_flow.rs`, which exercises the real CPI. Always included — a
+/// caller cannot know whether its own call will be the one that crosses.
+pub const SUPPORT_CU_ACTIVATION: u32 = 25_000;
+
+/// Margin over the modelled cost. Chiefly covers supporters that land between
+/// reading `num_supporters` and the transaction executing, at ~132 CU each.
+pub const SUPPORT_CU_HEADROOM_PERCENT: u32 = 15;
+
+/// Per-transaction maximum a client may request.
+pub const MAX_COMPUTE_UNIT_LIMIT: u32 = 1_400_000;
+
+/// Compute-unit limit to request for a support/retally against a proposal that
+/// currently has `num_supporters` supporters.
+pub fn support_compute_unit_limit(num_supporters: u32) -> u32 {
+    let modelled = SUPPORT_CU_BASE
+        .saturating_add(SUPPORT_CU_PER_SUPPORTER.saturating_mul(num_supporters))
+        .saturating_add(SUPPORT_CU_ACTIVATION);
+    // div_ceil, matching Math.ceil in the TypeScript mirror — plain integer
+    // division would round the two clients apart on inexact results.
+    let with_headroom =
+        (u64::from(modelled) * u64::from(100 + SUPPORT_CU_HEADROOM_PERCENT)).div_ceil(100);
+    with_headroom.min(u64::from(MAX_COMPUTE_UNIT_LIMIT)) as u32
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Mirrors the peak measured in `tests/support_compute_budget.rs` at the
+    /// 2000-supporter cap (284,953 CU, ballot box already created).
+    const MEASURED_AT_CAP: u32 = 284_953;
+
+    #[test]
+    fn covers_measured_cost_with_headroom() {
+        // No supporters yet, and this call could be the one that activates:
+        // ncn_flow measured 43,817-47,610 CU for that path.
+        assert!(support_compute_unit_limit(0) > 47_610);
+        assert!(support_compute_unit_limit(2_000) > MEASURED_AT_CAP);
+    }
+
+    #[test]
+    fn scales_with_the_supporter_count() {
+        // A small list must request far less than the old flat 600k, otherwise
+        // the modelling gains nothing.
+        assert!(support_compute_unit_limit(0) < 100_000);
+        assert!(support_compute_unit_limit(50) < support_compute_unit_limit(500));
+        assert!(support_compute_unit_limit(500) < support_compute_unit_limit(2_000));
+    }
+
+    #[test]
+    fn matches_the_typescript_mirror() {
+        // Both clients must request the same budget for the same state; these
+        // values are pinned identically in the frontend's
+        // supportComputeUnitLimit test.
+        assert_eq!(support_compute_unit_limit(0), 54_625);
+        assert_eq!(support_compute_unit_limit(2_000), 358_225);
+    }
+
+    #[test]
+    fn never_exceeds_the_per_transaction_maximum() {
+        assert_eq!(support_compute_unit_limit(u32::MAX), MAX_COMPUTE_UNIT_LIMIT);
+    }
+}
 
 // UI constants
 pub const SPINNER_TICK_DURATION_MS: u64 = 100;

--- a/svmgov/cli/src/constants.rs
+++ b/svmgov/cli/src/constants.rs
@@ -44,6 +44,11 @@ pub const SUPPORT_CU_HEADROOM_PERCENT: u32 = 15;
 /// Per-transaction maximum a client may request.
 pub const MAX_COMPUTE_UNIT_LIMIT: u32 = 1_400_000;
 
+/// The program's `MAX_SUPPORTERS_LIMIT`. Used as the supporter count when the
+/// real one cannot be read, so the request still covers the largest list the
+/// program permits.
+pub const MAX_SUPPORTERS_LIMIT: u32 = 2_000;
+
 /// Compute-unit limit to request for a support/retally against a proposal that
 /// currently has `num_supporters` supporters.
 pub fn support_compute_unit_limit(num_supporters: u32) -> u32 {
@@ -89,6 +94,18 @@ mod tests {
         // supportComputeUnitLimit test.
         assert_eq!(support_compute_unit_limit(0), 58_075);
         assert_eq!(support_compute_unit_limit(2_000), 361_675);
+    }
+
+    #[test]
+    fn the_fallback_supporter_count_covers_the_worst_case() {
+        // When the supporter count cannot be read, callers pass
+        // MAX_SUPPORTERS_LIMIT, which must request at least as much as any
+        // real list could need.
+        let fallback = support_compute_unit_limit(MAX_SUPPORTERS_LIMIT);
+        assert!(fallback > MEASURED_AT_CAP);
+        for n in [0u32, 1, 500, 1_999, MAX_SUPPORTERS_LIMIT] {
+            assert!(support_compute_unit_limit(n) <= fallback);
+        }
     }
 
     #[test]

--- a/svmgov/cli/src/constants.rs
+++ b/svmgov/cli/src/constants.rs
@@ -30,10 +30,12 @@ pub const SUPPORT_CU_PER_SUPPORTER: u32 = 132;
 
 /// Extra units for the call that crosses the support threshold: it activates
 /// voting and, unless the ballot box already exists, creates it through the
-/// `init_ballot_box` CPI. Measured at ~21-25k above a non-activating call in
-/// `tests/ncn_flow.rs`, which exercises the real CPI. Always included — a
-/// caller cannot know whether its own call will be the one that crosses.
-pub const SUPPORT_CU_ACTIVATION: u32 = 25_000;
+/// `init_ballot_box` CPI. Measured at ~26.8k above a non-activating call, at
+/// the 64-operator whitelist maximum — `init_ballot_box` clones the whitelist
+/// into the ballot box, so a longer list costs more. `tests/ncn_flow.rs`
+/// exercises the real CPI and asserts this covers it. Always included: a caller
+/// cannot know whether its own call will be the one that crosses.
+pub const SUPPORT_CU_ACTIVATION: u32 = 28_000;
 
 /// Margin over the modelled cost. Chiefly covers supporters that land between
 /// reading `num_supporters` and the transaction executing, at ~132 CU each.
@@ -67,7 +69,7 @@ mod tests {
     fn covers_measured_cost_with_headroom() {
         // No supporters yet, and this call could be the one that activates:
         // ncn_flow measured 43,817-47,610 CU for that path.
-        assert!(support_compute_unit_limit(0) > 47_610);
+        assert!(support_compute_unit_limit(0) > 49_473);
         assert!(support_compute_unit_limit(2_000) > MEASURED_AT_CAP);
     }
 
@@ -85,8 +87,8 @@ mod tests {
         // Both clients must request the same budget for the same state; these
         // values are pinned identically in the frontend's
         // supportComputeUnitLimit test.
-        assert_eq!(support_compute_unit_limit(0), 54_625);
-        assert_eq!(support_compute_unit_limit(2_000), 358_225);
+        assert_eq!(support_compute_unit_limit(0), 58_075);
+        assert_eq!(support_compute_unit_limit(2_000), 361_675);
     }
 
     #[test]

--- a/svmgov/cli/src/instructions/retally_support.rs
+++ b/svmgov/cli/src/instructions/retally_support.rs
@@ -1,11 +1,15 @@
 use std::str::FromStr;
 
-use anchor_client::solana_sdk::{pubkey::Pubkey, signer::Signer, transaction::Transaction};
+use anchor_client::solana_sdk::{
+    compute_budget::ComputeBudgetInstruction, pubkey::Pubkey, signer::Signer,
+    transaction::Transaction,
+};
 use anchor_lang::system_program;
 use anyhow::{Result, anyhow};
 use ncn_snapshot::ID as SNAPSHOT_PROGRAM_ID;
 
 use crate::{
+    constants::SUPPORT_COMPUTE_UNIT_LIMIT,
     svmgov_program::client::{accounts, args},
     utils::utils::{
         create_spinner, derive_global_config_pda, derive_program_config_pda, fetch_global_config,
@@ -47,8 +51,13 @@ pub async fn retally_support(
     let program_config_pda = derive_program_config_pda(&SNAPSHOT_PROGRAM_ID);
     let global_config_pda = derive_global_config_pda(&program.id());
 
+    // Same full-supporter re-tally as support_proposal; see
+    // SUPPORT_COMPUTE_UNIT_LIMIT.
     let retally_support_ixs = program
         .request()
+        .instruction(ComputeBudgetInstruction::set_compute_unit_limit(
+            SUPPORT_COMPUTE_UNIT_LIMIT,
+        ))
         .args(args::RetallySupport {})
         .accounts(accounts::RetallySupport {
             signer: payer.pubkey(),

--- a/svmgov/cli/src/instructions/retally_support.rs
+++ b/svmgov/cli/src/instructions/retally_support.rs
@@ -9,7 +9,7 @@ use anyhow::{Result, anyhow};
 use ncn_snapshot::ID as SNAPSHOT_PROGRAM_ID;
 
 use crate::{
-    constants::support_compute_unit_limit,
+    constants::{support_compute_unit_limit, MAX_SUPPORTERS_LIMIT},
     svmgov_program::accounts::Proposal,
     svmgov_program::client::{accounts, args},
     utils::utils::{
@@ -32,13 +32,21 @@ pub async fn retally_support(
 
     let global_config = fetch_global_config(&program).await?;
 
-    // Same full-supporter re-tally as support_proposal, so the budget is sized
-    // from the current list length.
-    let proposal = program
-        .account::<Proposal>(proposal_pubkey)
-        .await
-        .map_err(|e| anyhow!("Failed to fetch proposal: {}", e))?;
-    let compute_unit_limit = support_compute_unit_limit(proposal.num_supporters);
+    // The handler re-tallies every existing supporter, so the compute budget is
+    // sized from the current list length rather than a flat worst case. If the
+    // read fails the instruction itself may still succeed, so fall back to the
+    // program's supporter cap rather than aborting on a budgeting detail.
+    let num_supporters = match program.account::<Proposal>(proposal_pubkey).await {
+        Ok(proposal) => proposal.num_supporters,
+        Err(e) => {
+            log::warn!(
+                "Could not read the supporter count for {proposal_pubkey}: {e}. Requesting the \
+                 compute budget for a full {MAX_SUPPORTERS_LIMIT}-supporter list."
+            );
+            MAX_SUPPORTERS_LIMIT
+        }
+    };
+    let compute_unit_limit = support_compute_unit_limit(num_supporters);
 
     let spinner = create_spinner("Re-tallying proposal support...");
 

--- a/svmgov/cli/src/instructions/retally_support.rs
+++ b/svmgov/cli/src/instructions/retally_support.rs
@@ -9,7 +9,8 @@ use anyhow::{Result, anyhow};
 use ncn_snapshot::ID as SNAPSHOT_PROGRAM_ID;
 
 use crate::{
-    constants::SUPPORT_COMPUTE_UNIT_LIMIT,
+    constants::support_compute_unit_limit,
+    svmgov_program::accounts::Proposal,
     svmgov_program::client::{accounts, args},
     utils::utils::{
         create_spinner, derive_global_config_pda, derive_program_config_pda, fetch_global_config,
@@ -31,6 +32,14 @@ pub async fn retally_support(
 
     let global_config = fetch_global_config(&program).await?;
 
+    // Same full-supporter re-tally as support_proposal, so the budget is sized
+    // from the current list length.
+    let proposal = program
+        .account::<Proposal>(proposal_pubkey)
+        .await
+        .map_err(|e| anyhow!("Failed to fetch proposal: {}", e))?;
+    let compute_unit_limit = support_compute_unit_limit(proposal.num_supporters);
+
     let spinner = create_spinner("Re-tallying proposal support...");
 
     // Same prospective snapshot slot as support_proposal: if this retally
@@ -51,12 +60,10 @@ pub async fn retally_support(
     let program_config_pda = derive_program_config_pda(&SNAPSHOT_PROGRAM_ID);
     let global_config_pda = derive_global_config_pda(&program.id());
 
-    // Same full-supporter re-tally as support_proposal; see
-    // SUPPORT_COMPUTE_UNIT_LIMIT.
     let retally_support_ixs = program
         .request()
         .instruction(ComputeBudgetInstruction::set_compute_unit_limit(
-            SUPPORT_COMPUTE_UNIT_LIMIT,
+            compute_unit_limit,
         ))
         .args(args::RetallySupport {})
         .accounts(accounts::RetallySupport {

--- a/svmgov/cli/src/instructions/support_proposal.rs
+++ b/svmgov/cli/src/instructions/support_proposal.rs
@@ -1,11 +1,15 @@
 use std::str::FromStr;
 
-use anchor_client::solana_sdk::{pubkey::Pubkey, signer::Signer, transaction::Transaction};
+use anchor_client::solana_sdk::{
+    compute_budget::ComputeBudgetInstruction, pubkey::Pubkey, signer::Signer,
+    transaction::Transaction,
+};
 use anchor_lang::system_program;
 use anyhow::{Result, anyhow};
 use ncn_snapshot::ID as SNAPSHOT_PROGRAM_ID;
 
 use crate::{
+    constants::SUPPORT_COMPUTE_UNIT_LIMIT,
     svmgov_program::client::{accounts, args},
     utils::utils::{
         create_spinner, derive_global_config_pda, derive_program_config_pda, derive_support_pda,
@@ -46,8 +50,13 @@ pub async fn support_proposal(
     let program_config_pda = derive_program_config_pda(&SNAPSHOT_PROGRAM_ID);
     let global_config_pda = derive_global_config_pda(&program.id());
 
+    // Covers the supporter re-tally past the 200k default; see
+    // SUPPORT_COMPUTE_UNIT_LIMIT.
     let support_proposal_ixs = program
         .request()
+        .instruction(ComputeBudgetInstruction::set_compute_unit_limit(
+            SUPPORT_COMPUTE_UNIT_LIMIT,
+        ))
         .args(args::SupportProposal {})
         .accounts(accounts::SupportProposal {
             signer: payer.pubkey(),

--- a/svmgov/cli/src/instructions/support_proposal.rs
+++ b/svmgov/cli/src/instructions/support_proposal.rs
@@ -9,7 +9,7 @@ use anyhow::{Result, anyhow};
 use ncn_snapshot::ID as SNAPSHOT_PROGRAM_ID;
 
 use crate::{
-    constants::support_compute_unit_limit,
+    constants::{support_compute_unit_limit, MAX_SUPPORTERS_LIMIT},
     svmgov_program::accounts::Proposal,
     svmgov_program::client::{accounts, args},
     utils::utils::{
@@ -35,12 +35,20 @@ pub async fn support_proposal(
     let global_config = fetch_global_config(&program).await?;
 
     // The handler re-tallies every existing supporter, so the compute budget is
-    // sized from the current list length rather than a flat worst case.
-    let proposal = program
-        .account::<Proposal>(proposal_pubkey)
-        .await
-        .map_err(|e| anyhow!("Failed to fetch proposal: {}", e))?;
-    let compute_unit_limit = support_compute_unit_limit(proposal.num_supporters);
+    // sized from the current list length rather than a flat worst case. If the
+    // read fails the instruction itself may still succeed, so fall back to the
+    // program's supporter cap rather than aborting on a budgeting detail.
+    let num_supporters = match program.account::<Proposal>(proposal_pubkey).await {
+        Ok(proposal) => proposal.num_supporters,
+        Err(e) => {
+            log::warn!(
+                "Could not read the supporter count for {proposal_pubkey}: {e}. Requesting the \
+                 compute budget for a full {MAX_SUPPORTERS_LIMIT}-supporter list."
+            );
+            MAX_SUPPORTERS_LIMIT
+        }
+    };
+    let compute_unit_limit = support_compute_unit_limit(num_supporters);
 
     let spinner = create_spinner("Supporting proposal...");
 

--- a/svmgov/cli/src/instructions/support_proposal.rs
+++ b/svmgov/cli/src/instructions/support_proposal.rs
@@ -9,7 +9,8 @@ use anyhow::{Result, anyhow};
 use ncn_snapshot::ID as SNAPSHOT_PROGRAM_ID;
 
 use crate::{
-    constants::SUPPORT_COMPUTE_UNIT_LIMIT,
+    constants::support_compute_unit_limit,
+    svmgov_program::accounts::Proposal,
     svmgov_program::client::{accounts, args},
     utils::utils::{
         create_spinner, derive_global_config_pda, derive_program_config_pda, derive_support_pda,
@@ -33,6 +34,14 @@ pub async fn support_proposal(
 
     let global_config = fetch_global_config(&program).await?;
 
+    // The handler re-tallies every existing supporter, so the compute budget is
+    // sized from the current list length rather than a flat worst case.
+    let proposal = program
+        .account::<Proposal>(proposal_pubkey)
+        .await
+        .map_err(|e| anyhow!("Failed to fetch proposal: {}", e))?;
+    let compute_unit_limit = support_compute_unit_limit(proposal.num_supporters);
+
     let spinner = create_spinner("Supporting proposal...");
 
     let clock = program.rpc().get_epoch_info().await?;
@@ -50,12 +59,10 @@ pub async fn support_proposal(
     let program_config_pda = derive_program_config_pda(&SNAPSHOT_PROGRAM_ID);
     let global_config_pda = derive_global_config_pda(&program.id());
 
-    // Covers the supporter re-tally past the 200k default; see
-    // SUPPORT_COMPUTE_UNIT_LIMIT.
     let support_proposal_ixs = program
         .request()
         .instruction(ComputeBudgetInstruction::set_compute_unit_limit(
-            SUPPORT_COMPUTE_UNIT_LIMIT,
+            compute_unit_limit,
         ))
         .args(args::SupportProposal {})
         .accounts(accounts::SupportProposal {

--- a/svmgov/program/programs/svmgov_program/tests/common/mod.rs
+++ b/svmgov/program/programs/svmgov_program/tests/common/mod.rs
@@ -43,6 +43,23 @@ pub const MAX_SUPPORT_EPOCHS: u64 = 10;
 pub const VOTING_EPOCHS: u64 = 3;
 /// Mirrors `constants::MAX_SUPPORTERS_LIMIT` (not exported from the crate).
 pub const MAX_SUPPORTERS: u32 = 2_000;
+
+// Mirror of `support_compute_unit_limit` in svmgov/cli/src/constants.rs and
+// `supportComputeUnitLimit` in frontend/src/chain/instructions/types.ts. The
+// clients size their compute request from the supporter count; these suites are
+// what justify the model, so the constants must move together.
+pub const SUPPORT_CU_BASE: u32 = 22_500;
+pub const SUPPORT_CU_PER_SUPPORTER: u32 = 132;
+pub const SUPPORT_CU_ACTIVATION: u32 = 28_000;
+pub const SUPPORT_CU_HEADROOM_PERCENT: u32 = 15;
+
+/// Compute units the clients request for a support/retally at `num_supporters`.
+pub fn modelled_support_limit(num_supporters: u32) -> u64 {
+    let modelled = SUPPORT_CU_BASE
+        .saturating_add(SUPPORT_CU_PER_SUPPORTER.saturating_mul(num_supporters))
+        .saturating_add(SUPPORT_CU_ACTIVATION);
+    (u64::from(modelled) * u64::from(100 + SUPPORT_CU_HEADROOM_PERCENT)).div_ceil(100)
+}
 /// Anchor `#[error_code]` offset (`anchor_lang::error::ERROR_CODE_OFFSET`).
 pub const ANCHOR_ERROR_CODE_OFFSET: u32 = 6000;
 

--- a/svmgov/program/programs/svmgov_program/tests/ncn_flow.rs
+++ b/svmgov/program/programs/svmgov_program/tests/ncn_flow.rs
@@ -102,6 +102,9 @@ fn assert_anchor_err(
 }
 
 /// A ballot box created through the real svmgov `support_proposal` CPI,
+/// Mirrors `ncn_snapshot::MAX_OPERATOR_WHITELIST`.
+const MAX_OPERATOR_WHITELIST: usize = 64;
+
 /// governed by a real `ProgramConfig`.
 struct FlowCtx {
     admin: Keypair,
@@ -112,6 +115,9 @@ struct FlowCtx {
     /// Clock values at ballot-box creation (activation of the proposal).
     activation_slot: u64,
     activation_timestamp: i64,
+    /// Compute units burned by the support that crossed the threshold — the
+    /// call that runs the real `init_ballot_box` CPI.
+    activation_compute_units: u64,
     nonce: u32,
 }
 
@@ -177,8 +183,11 @@ fn setup_flow(operator_count: usize, vote_duration: i64) -> (Harness, FlowCtx) {
     let snapshot_slot = expected_snapshot_slot(CREATION_EPOCH);
     let ballot_box = ballot_box_pda(snapshot_slot);
     let clock = h.svm.get_sysvar::<Clock>();
+    let mut activation_compute_units = 0u64;
     for i in 0..h.supporter_count {
-        support_one(&mut h, proposal, i, ballot_box);
+        let meta = try_support_one(&mut h, proposal, i, ballot_box)
+            .unwrap_or_else(|e| panic!("support #{i} failed: {:?}", e.err));
+        activation_compute_units = meta.compute_units_consumed;
     }
     assert!(
         fetch_proposal(&h.svm, &proposal).voting,
@@ -193,6 +202,7 @@ fn setup_flow(operator_count: usize, vote_duration: i64) -> (Harness, FlowCtx) {
         snapshot_slot,
         activation_slot: clock.slot,
         activation_timestamp: clock.unix_timestamp,
+        activation_compute_units,
         nonce,
     };
     (h, ctx)
@@ -975,5 +985,31 @@ fn direct_init_ballot_box_without_proposal_pda_rejected() {
     assert_anchor_err(
         try_send(&mut h, &admin, &mut ctx.nonce, &[ix]),
         anchor_lang::error::ErrorCode::ConstraintSeeds,
+    );
+}
+
+/// The support that crosses the threshold runs the real `init_ballot_box` CPI,
+/// which the `support_compute_budget` suite cannot measure (it pre-seeds the
+/// ballot box to short-circuit that path). It is the most expensive call the
+/// clients' compute model has to cover, so measure it here — at the maximum
+/// operator whitelist, since `init_ballot_box` clones the whitelist into the
+/// ballot box and a longer list costs more to serialize.
+#[test_log::test]
+fn activation_cpi_fits_within_the_modelled_compute_limit() {
+    let (_h, ctx) = setup_flow(MAX_OPERATOR_WHITELIST, 100_000);
+
+    // Three supporters in the flow harness, so the activating call re-tallies
+    // two prior entries.
+    let requested = modelled_support_limit(2);
+    println!(
+        "activating support at {MAX_OPERATOR_WHITELIST} operators: {} CU; clients request {requested}",
+        ctx.activation_compute_units
+    );
+    assert!(
+        ctx.activation_compute_units < requested,
+        "the activating support consumed {} CU but the clients' model requests only {requested}. \
+         Raise SUPPORT_CU_ACTIVATION in tests/common/mod.rs, svmgov/cli/src/constants.rs AND \
+         frontend/src/chain/instructions/types.ts.",
+        ctx.activation_compute_units
     );
 }

--- a/svmgov/program/programs/svmgov_program/tests/support_compute_budget.rs
+++ b/svmgov/program/programs/svmgov_program/tests/support_compute_budget.rs
@@ -11,12 +11,21 @@ use {
     solana_signer::Signer, solana_transaction_error::TransactionError,
 };
 
-/// Keep in sync with `SUPPORT_COMPUTE_UNIT_LIMIT` in svmgov/cli/src/constants.rs
-/// and frontend/src/chain/instructions/types.ts.
-const SUPPORT_COMPUTE_UNIT_LIMIT: u32 = 600_000;
-/// Minimum multiple of the measured worst case the request must cover, so cost
-/// drift trips CI well before it trips a caller.
-const REQUIRED_HEADROOM_FACTOR: u64 = 2;
+/// Mirrors `support_compute_unit_limit` in svmgov/cli/src/constants.rs and
+/// `supportComputeUnitLimit` in frontend/src/chain/instructions/types.ts. The
+/// clients scale their request with the supporter count; this suite is what
+/// justifies the model, so keep the constants in step.
+const SUPPORT_CU_BASE: u32 = 22_500;
+const SUPPORT_CU_PER_SUPPORTER: u32 = 132;
+const SUPPORT_CU_ACTIVATION: u32 = 25_000;
+const SUPPORT_CU_HEADROOM_PERCENT: u32 = 15;
+
+fn modelled_limit(num_supporters: u32) -> u64 {
+    let modelled =
+        SUPPORT_CU_BASE + SUPPORT_CU_PER_SUPPORTER * num_supporters + SUPPORT_CU_ACTIVATION;
+    (u64::from(modelled) * u64::from(100 + SUPPORT_CU_HEADROOM_PERCENT)).div_ceil(100)
+}
+
 const DEFAULT_COMPUTE_UNITS_PER_IX: u32 = 200_000;
 
 /// Tracks the supporter cap, so raising `MAX_SUPPORTERS_LIMIT` re-measures the
@@ -98,7 +107,9 @@ fn support_without_compute_budget_request_exhausts_default_limit() {
         &mut h.svm,
         &signer,
         &[
-            ComputeBudgetInstruction::set_compute_unit_limit(SUPPORT_COMPUTE_UNIT_LIMIT),
+            ComputeBudgetInstruction::set_compute_unit_limit(
+                modelled_limit(failed_at as u32) as u32
+            ),
             ix,
         ],
     );
@@ -136,13 +147,13 @@ fn support_at_max_supporters_fits_within_requested_limit() {
     assert_eq!(state.num_supporters as usize, VALIDATOR_COUNT);
     assert!(state.voting, "threshold should have activated voting");
 
-    println!("peak at {VALIDATOR_COUNT} supporters: {peak_cu} CU of {SUPPORT_COMPUTE_UNIT_LIMIT}");
+    let requested = modelled_limit(VALIDATOR_COUNT as u32);
+    println!("peak at {VALIDATOR_COUNT} supporters: {peak_cu} CU; clients request {requested}");
     assert!(
-        peak_cu * REQUIRED_HEADROOM_FACTOR < SUPPORT_COMPUTE_UNIT_LIMIT as u64,
-        "support at the cap consumed {peak_cu} CU, under {REQUIRED_HEADROOM_FACTOR}x headroom of \
-         the {SUPPORT_COMPUTE_UNIT_LIMIT} clients request. Raise SUPPORT_COMPUTE_UNIT_LIMIT in \
-         svmgov/cli/src/constants.rs AND frontend/src/chain/instructions/types.ts (ceiling is \
-         1_400_000), or make the re-tally cheaper."
+        peak_cu < requested,
+        "support at the cap consumed {peak_cu} CU but the clients' model requests only \
+         {requested}. Adjust the constants in svmgov/cli/src/constants.rs AND \
+         frontend/src/chain/instructions/types.ts (and the mirrors above)."
     );
 }
 
@@ -167,10 +178,10 @@ fn retally_at_max_supporters_fits_within_requested_limit() {
         VALIDATOR_COUNT - 1,
         meta.compute_units_consumed
     );
+    let requested = modelled_limit((VALIDATOR_COUNT - 1) as u32);
     assert!(
-        meta.compute_units_consumed * REQUIRED_HEADROOM_FACTOR < SUPPORT_COMPUTE_UNIT_LIMIT as u64,
-        "retally consumed {} CU, under {REQUIRED_HEADROOM_FACTOR}x headroom of the \
-         {SUPPORT_COMPUTE_UNIT_LIMIT} clients request",
+        meta.compute_units_consumed < requested,
+        "retally consumed {} CU but the clients' model requests only {requested}",
         meta.compute_units_consumed
     );
 }

--- a/svmgov/program/programs/svmgov_program/tests/support_compute_budget.rs
+++ b/svmgov/program/programs/svmgov_program/tests/support_compute_budget.rs
@@ -19,9 +19,11 @@ const SUPPORT_COMPUTE_UNIT_LIMIT: u32 = 600_000;
 const REQUIRED_HEADROOM_FACTOR: u64 = 2;
 const DEFAULT_COMPUTE_UNITS_PER_IX: u32 = 200_000;
 
-/// Threshold lands at 100%, so the list can be filled without activating voting
-/// until the very last support.
-const VALIDATOR_COUNT: usize = 2_000;
+/// Tracks the supporter cap, so raising `MAX_SUPPORTERS_LIMIT` re-measures the
+/// new worst case instead of silently testing the old one. Equal to the
+/// supporter count, so the threshold lands at 100% and the list can be filled
+/// without activating voting until the very last support.
+const VALIDATOR_COUNT: usize = MAX_SUPPORTERS as usize;
 
 fn support_ix_for(h: &Harness, proposal: Address, idx: usize, ballot_box: Address) -> Instruction {
     let vote = h.validators[idx].vote.pubkey();
@@ -85,7 +87,9 @@ fn support_without_compute_budget_request_exhausts_default_limit() {
 
     let failed_at = first_failing_count
         .expect("default budget never ran out — the raised client limit may be unnecessary");
-    println!("default {DEFAULT_COMPUTE_UNITS_PER_IX} CU budget exhausted at {failed_at} supporters");
+    println!(
+        "default {DEFAULT_COMPUTE_UNITS_PER_IX} CU budget exhausted at {failed_at} supporters"
+    );
 
     // Same call, same state, with the limit clients request.
     let signer = h.validators[failed_at].identity.insecure_clone();
@@ -115,11 +119,16 @@ fn support_at_max_supporters_fits_within_requested_limit() {
 
     let mut peak_cu = 0u64;
     for i in 0..VALIDATOR_COUNT {
-        let meta = try_support_one(&mut h, proposal, i, ballot_box)
-            .unwrap_or_else(|e| panic!("support #{i} failed: {:?}\nlogs: {:#?}", e.err, e.meta.logs));
+        let meta = try_support_one(&mut h, proposal, i, ballot_box).unwrap_or_else(|e| {
+            panic!("support #{i} failed: {:?}\nlogs: {:#?}", e.err, e.meta.logs)
+        });
         peak_cu = peak_cu.max(meta.compute_units_consumed);
         if (i + 1) % 500 == 0 {
-            println!("supported {}/{VALIDATOR_COUNT} — {} CU", i + 1, meta.compute_units_consumed);
+            println!(
+                "supported {}/{VALIDATOR_COUNT} — {} CU",
+                i + 1,
+                meta.compute_units_consumed
+            );
         }
     }
 

--- a/svmgov/program/programs/svmgov_program/tests/support_compute_budget.rs
+++ b/svmgov/program/programs/svmgov_program/tests/support_compute_budget.rs
@@ -1,0 +1,167 @@
+//! Compute cost of the full supporter re-tally in `support_proposal` /
+//! `retally_support`, which scales with `num_supporters` (capped at
+//! `MAX_SUPPORTERS`) and outgrows the 200k CU default a single-instruction
+//! transaction gets. Pins the limit the CLI and frontend request.
+
+mod common;
+
+use {
+    common::*, solana_address::Address, solana_compute_budget_interface::ComputeBudgetInstruction,
+    solana_instruction::Instruction, solana_instruction_error::InstructionError,
+    solana_signer::Signer, solana_transaction_error::TransactionError,
+};
+
+/// Keep in sync with `SUPPORT_COMPUTE_UNIT_LIMIT` in svmgov/cli/src/constants.rs
+/// and frontend/src/chain/instructions/types.ts.
+const SUPPORT_COMPUTE_UNIT_LIMIT: u32 = 600_000;
+/// Minimum multiple of the measured worst case the request must cover, so cost
+/// drift trips CI well before it trips a caller.
+const REQUIRED_HEADROOM_FACTOR: u64 = 2;
+const DEFAULT_COMPUTE_UNITS_PER_IX: u32 = 200_000;
+
+/// Threshold lands at 100%, so the list can be filled without activating voting
+/// until the very last support.
+const VALIDATOR_COUNT: usize = 2_000;
+
+fn support_ix_for(h: &Harness, proposal: Address, idx: usize, ballot_box: Address) -> Instruction {
+    let vote = h.validators[idx].vote.pubkey();
+    let (support, _) = Address::find_program_address(
+        &[b"support", proposal.as_ref(), vote.as_ref()],
+        &SVMGOV_PROGRAM_ID,
+    );
+    support_proposal_ix(
+        &h.validators[idx].identity.pubkey(),
+        proposal,
+        support,
+        vote,
+        ballot_box,
+        h.program_config,
+        h.global_config,
+    )
+}
+
+/// The default budget really does run out, so the client-side request is
+/// load-bearing. If this ever fails to find a cliff, the re-tally got cheap
+/// enough that the request is unnecessary — confirm that deliberately.
+#[test_log::test]
+fn support_without_compute_budget_request_exhausts_default_limit() {
+    const CREATION_EPOCH: u64 = 10;
+    let mut h = setup_harness(CREATION_EPOCH, VALIDATOR_COUNT, VALIDATOR_COUNT);
+    let ballot_box = seed_ballot_box(&mut h.svm, expected_snapshot_slot(CREATION_EPOCH));
+    let proposal = create_proposal(&mut h, 1, "default compute budget");
+
+    let mut first_failing_count: Option<usize> = None;
+    for i in 0..VALIDATOR_COUNT {
+        let signer = h.validators[i].identity.insecure_clone();
+        let ix = support_ix_for(&h, proposal, i, ballot_box);
+        match try_send_ix(&mut h.svm, &signer, &[ix]) {
+            Ok(_) => continue,
+            Err(e) => {
+                // Exhausting the meter inside the program surfaces as
+                // ProgramFailedToComplete, not ComputationalBudgetExceeded.
+                assert!(
+                    matches!(
+                        e.err,
+                        TransactionError::InstructionError(
+                            0,
+                            InstructionError::ProgramFailedToComplete
+                                | InstructionError::ComputationalBudgetExceeded
+                        )
+                    ) && e.meta.logs.iter().any(|l| {
+                        l.contains(&format!(
+                            "consumed {DEFAULT_COMPUTE_UNITS_PER_IX} of \
+                             {DEFAULT_COMPUTE_UNITS_PER_IX} compute units"
+                        ))
+                    }),
+                    "expected compute-budget exhaustion, got {:?}\nlogs: {:#?}",
+                    e.err,
+                    e.meta.logs
+                );
+                first_failing_count = Some(i);
+                break;
+            }
+        }
+    }
+
+    let failed_at = first_failing_count
+        .expect("default budget never ran out — the raised client limit may be unnecessary");
+    println!("default {DEFAULT_COMPUTE_UNITS_PER_IX} CU budget exhausted at {failed_at} supporters");
+
+    // Same call, same state, with the limit clients request.
+    let signer = h.validators[failed_at].identity.insecure_clone();
+    let ix = support_ix_for(&h, proposal, failed_at, ballot_box);
+    send_ix(
+        &mut h.svm,
+        &signer,
+        &[
+            ComputeBudgetInstruction::set_compute_unit_limit(SUPPORT_COMPUTE_UNIT_LIMIT),
+            ix,
+        ],
+    );
+    assert_eq!(
+        fetch_proposal(&h.svm, &proposal).num_supporters as usize,
+        failed_at + 1
+    );
+}
+
+/// The requested limit covers the worst case: the last support at the cap,
+/// which re-tallies every prior supporter and activates voting.
+#[test_log::test]
+fn support_at_max_supporters_fits_within_requested_limit() {
+    const CREATION_EPOCH: u64 = 10;
+    let mut h = setup_harness(CREATION_EPOCH, VALIDATOR_COUNT, VALIDATOR_COUNT);
+    let ballot_box = seed_ballot_box(&mut h.svm, expected_snapshot_slot(CREATION_EPOCH));
+    let proposal = create_proposal(&mut h, 2, "max supporters compute budget");
+
+    let mut peak_cu = 0u64;
+    for i in 0..VALIDATOR_COUNT {
+        let meta = try_support_one(&mut h, proposal, i, ballot_box)
+            .unwrap_or_else(|e| panic!("support #{i} failed: {:?}\nlogs: {:#?}", e.err, e.meta.logs));
+        peak_cu = peak_cu.max(meta.compute_units_consumed);
+        if (i + 1) % 500 == 0 {
+            println!("supported {}/{VALIDATOR_COUNT} — {} CU", i + 1, meta.compute_units_consumed);
+        }
+    }
+
+    let state = fetch_proposal(&h.svm, &proposal);
+    assert_eq!(state.num_supporters as usize, VALIDATOR_COUNT);
+    assert!(state.voting, "threshold should have activated voting");
+
+    println!("peak at {VALIDATOR_COUNT} supporters: {peak_cu} CU of {SUPPORT_COMPUTE_UNIT_LIMIT}");
+    assert!(
+        peak_cu * REQUIRED_HEADROOM_FACTOR < SUPPORT_COMPUTE_UNIT_LIMIT as u64,
+        "support at the cap consumed {peak_cu} CU, under {REQUIRED_HEADROOM_FACTOR}x headroom of \
+         the {SUPPORT_COMPUTE_UNIT_LIMIT} clients request. Raise SUPPORT_COMPUTE_UNIT_LIMIT in \
+         svmgov/cli/src/constants.rs AND frontend/src/chain/instructions/types.ts (ceiling is \
+         1_400_000), or make the re-tally cheaper."
+    );
+}
+
+/// `retally_support` walks the same list, so it carries the same requirement.
+#[test_log::test]
+fn retally_at_max_supporters_fits_within_requested_limit() {
+    const CREATION_EPOCH: u64 = 10;
+    let mut h = setup_harness(CREATION_EPOCH, VALIDATOR_COUNT, VALIDATOR_COUNT);
+    let ballot_box = seed_ballot_box(&mut h.svm, expected_snapshot_slot(CREATION_EPOCH));
+    let proposal = create_proposal(&mut h, 3, "max supporters retally budget");
+
+    // One short of the cap, so the retally measures a full list without
+    // activating voting.
+    for i in 0..VALIDATOR_COUNT - 1 {
+        support_one(&mut h, proposal, i, ballot_box);
+    }
+
+    let meta = try_retally_one(&mut h, proposal, 0, ballot_box)
+        .unwrap_or_else(|e| panic!("retally failed: {:?}\nlogs: {:#?}", e.err, e.meta.logs));
+    println!(
+        "retally over {} supporters: {} CU",
+        VALIDATOR_COUNT - 1,
+        meta.compute_units_consumed
+    );
+    assert!(
+        meta.compute_units_consumed * REQUIRED_HEADROOM_FACTOR < SUPPORT_COMPUTE_UNIT_LIMIT as u64,
+        "retally consumed {} CU, under {REQUIRED_HEADROOM_FACTOR}x headroom of the \
+         {SUPPORT_COMPUTE_UNIT_LIMIT} clients request",
+        meta.compute_units_consumed
+    );
+}

--- a/svmgov/program/programs/svmgov_program/tests/support_compute_budget.rs
+++ b/svmgov/program/programs/svmgov_program/tests/support_compute_budget.rs
@@ -11,21 +11,6 @@ use {
     solana_signer::Signer, solana_transaction_error::TransactionError,
 };
 
-/// Mirrors `support_compute_unit_limit` in svmgov/cli/src/constants.rs and
-/// `supportComputeUnitLimit` in frontend/src/chain/instructions/types.ts. The
-/// clients scale their request with the supporter count; this suite is what
-/// justifies the model, so keep the constants in step.
-const SUPPORT_CU_BASE: u32 = 22_500;
-const SUPPORT_CU_PER_SUPPORTER: u32 = 132;
-const SUPPORT_CU_ACTIVATION: u32 = 25_000;
-const SUPPORT_CU_HEADROOM_PERCENT: u32 = 15;
-
-fn modelled_limit(num_supporters: u32) -> u64 {
-    let modelled =
-        SUPPORT_CU_BASE + SUPPORT_CU_PER_SUPPORTER * num_supporters + SUPPORT_CU_ACTIVATION;
-    (u64::from(modelled) * u64::from(100 + SUPPORT_CU_HEADROOM_PERCENT)).div_ceil(100)
-}
-
 const DEFAULT_COMPUTE_UNITS_PER_IX: u32 = 200_000;
 
 /// Tracks the supporter cap, so raising `MAX_SUPPORTERS_LIMIT` re-measures the
@@ -107,9 +92,9 @@ fn support_without_compute_budget_request_exhausts_default_limit() {
         &mut h.svm,
         &signer,
         &[
-            ComputeBudgetInstruction::set_compute_unit_limit(
-                modelled_limit(failed_at as u32) as u32
-            ),
+            ComputeBudgetInstruction::set_compute_unit_limit(modelled_support_limit(
+                failed_at as u32,
+            ) as u32),
             ix,
         ],
     );
@@ -147,7 +132,7 @@ fn support_at_max_supporters_fits_within_requested_limit() {
     assert_eq!(state.num_supporters as usize, VALIDATOR_COUNT);
     assert!(state.voting, "threshold should have activated voting");
 
-    let requested = modelled_limit(VALIDATOR_COUNT as u32);
+    let requested = modelled_support_limit(VALIDATOR_COUNT as u32);
     println!("peak at {VALIDATOR_COUNT} supporters: {peak_cu} CU; clients request {requested}");
     assert!(
         peak_cu < requested,
@@ -178,7 +163,7 @@ fn retally_at_max_supporters_fits_within_requested_limit() {
         VALIDATOR_COUNT - 1,
         meta.compute_units_consumed
     );
-    let requested = modelled_limit((VALIDATOR_COUNT - 1) as u32);
+    let requested = modelled_support_limit((VALIDATOR_COUNT - 1) as u32);
     assert!(
         meta.compute_units_consumed < requested,
         "retally consumed {} CU but the clients' model requests only {requested}",


### PR DESCRIPTION
## TLDR

`support_proposal` and `retally_support` re-tally the whole supporter list on every call, so their cost is linear in `num_supporters`, but neither client requested a compute budget at all, leaving them on the 200k default. This sizes the request from the actual supporter count instead of a flat worst case

## Background

Both handlers rebuild the entire supporter tally on every call: one `sol_get_epoch_stake` syscall per existing supporter, up to the `MAX_SUPPORTERS_LIMIT` of 2000. A transaction carrying only the governance instruction is allotted 200k CU, which does not cover that range. The program's own LiteSVM harness has always requested 1.4M for these two instructions; neither client requested anything

Measured: the 200k default runs out at 1,316 supporters. Mainnet has ~700 validators, so this is headroom rather than a live failure, but the clients could not service the supporter range the program advertises

## The model

Per review feedback, the request now scales with the supporter:

```
(22_500 + 132 × num_supporters + 28_000) × 1.15,  capped at 1_400_000
```

| supporters | requested | measured | headroom |
|---|---|---|---|
| 0 (activating, 64 operators) | 58,075 | 49,473 | 17% |
| 100 | 73,255 | — | — |
| 500 | 133,975 | 86,440 | 55% |
| 2,000 (cap) | 361,675 | 287,953 | 26% |

Both clients read `num_supporters` from the proposal account before building the transaction. The 15% margin chiefly covers supporters landing between that read and execution, at ~132 CU each, roughly 100+ supporters of slack even at the cap, so the race is not realistic

## The activation term

The `28_000` is the interesting part. The original measurement pre-seeded the ballot box, so `init_ballot_box` never ran, but that CPI fires on the threshold-crossing call, which is precisely the call the budget exists to protect. `ncn_flow` exercises the real path:

- support with no prior supporters, no activation: **22,434 CU**
- support that activates and creates the ballot box: **49,473 CU**

So activation adds ~26.8k. It is measured at the 64-operator whitelist maximum, because `init_ballot_box` clones the whitelist into the ballot box and a longer list costs more to serialize; an earlier draft used 25,000 from measurements at ≤8 operators, which quietly eroded the stated 15% margin to ~10%

The term is always included: a caller cannot know in advance whether its own call will be the one that crosses

## Changes

- `svmgov/cli/src/constants.rs` — the model plus `support_compute_unit_limit()`
- `svmgov/cli/src/instructions/{support_proposal,retally_support}.rs` — fetch the proposal, request the modelled limit
- `frontend/src/chain/instructions/types.ts` — `supportComputeUnitLimit()` mirror
- `frontend/src/chain/instructions/supportProposal.ts` — same, via a proposal fetch

`cast_vote` / `cast_vote_override` are deliberately unchanged: they verify a single merkle leaf rather than walking the list, and the harness correspondingly does not raise their limit. The frontend has no retally flow

## Tests

The model lives in three places (Rust CLI, TypeScript, and a test mirror in `tests/common/mod.rs` shared by both program suites). Cross-pinned values keep them honest: both client suites assert `supportComputeUnitLimit(0) == 58_075` and `(2_000) == 361_675`, so drift on either side fails CI

- **`tests/support_compute_budget.rs`** — proves the 200k default really is insufficient at the cap (so the request is load-bearing), then fills the list to 2000 and asserts the measured peak fits under what the clients request. It recomputes the clients' formula rather than comparing against a constant the same suite justifies
- **`tests/ncn_flow.rs`** — new `activation_cpi_fits_within_the_modelled_compute_limit` measures the activating support through the real CPI at the 64-operator maximum and asserts the model covers it. This is what keeps `28_000` from being an unexplained magic number
- **`svmgov/cli`** — unit tests for the formula: covers measured cost, scales with the count, clamps at 1.4M, matches the TypeScript mirror

Full program suite green (12 targets), CLI 11 unit + 3 integration, frontend 80 tests, `tsc` and eslint clean, touched Rust files rustfmt-clean