### PR TITLE
fix(ncn-router): Drop Verifiers That Have Fallen Behind The Fleet

### DIFF
--- a/ncn-router/README.md
+++ b/ncn-router/README.md
@@ -35,6 +35,7 @@
   - `SOLANA_RPC_URL` (optional): Solana RPC endpoint (defaults to mainnet/testnet public RPCs)
   - `NCN_PROGRAM_ID` (required): NCN program ID on Solana
   - `NCN_WHITELIST_MAINNET_PATH` / `NCN_WHITELIST_TESTNET_PATH` (optional): Output paths for whitelist JSON (defaults to `ncn_whitelist.mainnet.json` / `ncn_whitelist.testnet.json`)
+  - `NCN_MAX_VERIFIER_SLOT_LAG` (optional): How many slots a verifier's snapshot may trail the freshest whitelisted verifier before it is marked `stale` and dropped from routing (default: `432000`, one epoch / ~2 days). A verifier that stopped uploading still matches the on-chain ballot for its own old slot, so it stays `ok` without this bound and 404s every current proof request.
 
 ### Usage
 

--- a/ncn-router/src/cron_job.rs
+++ b/ncn-router/src/cron_job.rs
@@ -22,6 +22,13 @@ const CRON_EVERY_2_HOURS: &str = "0 0 0,2,4,6,8,10,12,14,16,18,20,22 * * *";
 // Anchor discriminator for the BallotBox account, from the IDL.
 const BALLOT_BOX_DISCRIMINATOR: [u8; 8] = [155, 169, 156, 8, 92, 14, 24, 101];
 
+/// How far a verifier's latest snapshot may trail the freshest whitelisted
+/// verifier before it is dropped from routing. One epoch (432,000 slots, ~2
+/// days) absorbs the normal spread in upload times while rejecting operators
+/// that have stopped producing snapshots altogether. Override with
+/// `NCN_MAX_VERIFIER_SLOT_LAG`.
+const DEFAULT_MAX_VERIFIER_SLOT_LAG: u64 = 432_000;
+
 #[derive(Debug, Deserialize)]
 struct Config {
     verifiers: Vec<Verifier>,
@@ -59,6 +66,10 @@ struct LogEntry {
 struct WhitelistVerifier {
     name: String,
     domain: String,
+    /// Slot of the snapshot this verifier last reported. Recorded so staleness
+    /// can be judged against the rest of the fleet, and so an operator that has
+    /// fallen behind is visible in the whitelist file without re-polling.
+    slot: u64,
     status: String,
     reason: Option<String>,
 }
@@ -256,6 +267,7 @@ fn compare_with_chain(
             whitelist_verifiers.push(WhitelistVerifier {
                 name: entry.name.clone(),
                 domain: entry.domain.clone(),
+                slot: entry.slot,
                 status: "error".to_string(),
                 reason: entry.error.clone(),
             });
@@ -300,6 +312,7 @@ fn compare_with_chain(
                 whitelist_verifiers.push(WhitelistVerifier {
                     name: entry.name.clone(),
                     domain: entry.domain.clone(),
+                    slot: entry.slot,
                     status,
                     reason,
                 });
@@ -316,6 +329,7 @@ fn compare_with_chain(
                 whitelist_verifiers.push(WhitelistVerifier {
                     name: entry.name.clone(),
                     domain: entry.domain.clone(),
+                    slot: entry.slot,
                     status: "error".to_string(),
                     reason: Some(e),
                 });
@@ -334,6 +348,17 @@ fn compare_with_chain(
             .max()
             .unwrap_or_default()
     };
+
+    // Drop verifiers that verify cleanly against their own stale slot but have
+    // fallen behind the fleet — they would otherwise stay in rotation and 404
+    // every proof request for a current snapshot. Runs before de-duplication so
+    // an origin that is stale on one row cannot be preferred as `ok` on another.
+    let mut whitelist_verifiers = whitelist_verifiers;
+    demote_stale_verifiers(
+        &mut whitelist_verifiers,
+        chosen_slot,
+        max_verifier_slot_lag(),
+    );
 
     // Collapse to one canonical record per verifier origin before persisting.
     // `ncn-router` samples whitelist rows uniformly, so duplicate rows for the
@@ -369,6 +394,51 @@ fn compare_with_chain(
     }
 
     Ok(())
+}
+
+fn max_verifier_slot_lag() -> u64 {
+    env::var("NCN_MAX_VERIFIER_SLOT_LAG")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(DEFAULT_MAX_VERIFIER_SLOT_LAG)
+}
+
+/// Demote `ok` verifiers whose latest snapshot trails `freshest_slot` by more
+/// than `max_lag`, so the router stops sampling them.
+///
+/// `status == "ok"` only means a verifier's merkle root and snapshot hash match
+/// the on-chain ballot *at the slot that verifier itself reported*. An operator
+/// that stopped uploading months ago still satisfies that: its stale data is
+/// perfectly self-consistent, so it stays `ok` indefinitely while answering
+/// every proof request for a current snapshot with a 404.
+///
+/// Freshness is measured against the freshest peer rather than the chain tip on
+/// purpose. Snapshots are only produced when a proposal needs one, so between
+/// proposals the whole fleet legitimately sits at the same older slot — against
+/// the tip that would demote everyone, against the fleet it demotes nobody.
+///
+/// `freshest_slot` is the maximum over verifiers that are already `ok`, so the
+/// verifier holding that slot has zero lag and always survives: this can narrow
+/// the routing pool but never empty it. When no verifier is `ok`,
+/// `freshest_slot` is 0 and every lag saturates to 0, so nothing is demoted.
+fn demote_stale_verifiers(verifiers: &mut [WhitelistVerifier], freshest_slot: u64, max_lag: u64) {
+    for verifier in verifiers.iter_mut() {
+        if verifier.status != "ok" {
+            continue;
+        }
+        let lag = freshest_slot.saturating_sub(verifier.slot);
+        if lag > max_lag {
+            eprintln!(
+                "[ncn-meta-cron] dropping stale verifier '{}' ({}): slot {} is {} slots behind the freshest verifier ({}), limit {}",
+                verifier.name, verifier.domain, verifier.slot, lag, freshest_slot, max_lag
+            );
+            verifier.status = "stale".to_string();
+            verifier.reason = Some(format!(
+                "snapshot slot {} is {} slots behind freshest verifier ({}); limit {}",
+                verifier.slot, lag, freshest_slot, max_lag
+            ));
+        }
+    }
 }
 
 /// Canonical routing identity for a verifier origin. `ncn-router` redirects to
@@ -621,12 +691,21 @@ mod tests {
     }
 
     fn verifier(name: &str, domain: &str, status: &str) -> WhitelistVerifier {
+        verifier_at(name, domain, status, 0)
+    }
+
+    fn verifier_at(name: &str, domain: &str, status: &str, slot: u64) -> WhitelistVerifier {
         WhitelistVerifier {
             name: name.to_string(),
             domain: domain.to_string(),
+            slot,
             status: status.to_string(),
             reason: None,
         }
+    }
+
+    fn statuses(verifiers: &[WhitelistVerifier]) -> Vec<&str> {
+        verifiers.iter().map(|v| v.status.as_str()).collect()
     }
 
     #[test]
@@ -703,6 +782,103 @@ mod tests {
         assert_eq!(dup.status, "ok");
         assert_eq!(dup.name, "succeeded");
         assert_eq!(deduped[0].domain, "http://dup");
+    }
+
+    #[test]
+    fn stale_ok_verifier_is_demoted() {
+        // The reported failure mode: a verifier stopped uploading months ago, so
+        // its data still matches the on-chain ballot for its own old slot and it
+        // stays "ok" — while 404ing every request for a current snapshot.
+        let mut verifiers = vec![
+            verifier_at("fresh", "http://fresh", "ok", 436_919_878),
+            verifier_at("frozen", "http://frozen", "ok", 422_497_000),
+        ];
+        demote_stale_verifiers(&mut verifiers, 436_919_878, DEFAULT_MAX_VERIFIER_SLOT_LAG);
+        assert_eq!(statuses(&verifiers), vec!["ok", "stale"]);
+        assert!(verifiers[1]
+            .reason
+            .as_deref()
+            .unwrap()
+            .contains("behind freshest verifier"));
+    }
+
+    #[test]
+    fn verifier_within_lag_budget_stays_ok() {
+        // Operators do not upload in lockstep; a verifier still inside the lag
+        // budget must keep its routing ticket.
+        let mut verifiers = vec![
+            verifier_at("fresh", "http://fresh", "ok", 436_941_951),
+            verifier_at("slightly-behind", "http://behind", "ok", 436_919_878),
+        ];
+        demote_stale_verifiers(&mut verifiers, 436_941_951, DEFAULT_MAX_VERIFIER_SLOT_LAG);
+        assert_eq!(statuses(&verifiers), vec!["ok", "ok"]);
+    }
+
+    #[test]
+    fn fleet_at_a_common_older_slot_is_not_demoted() {
+        // Snapshots are only produced when a proposal needs one, so between
+        // proposals the whole fleet legitimately sits at the same older slot.
+        // Measuring against the freshest peer (not the chain tip) keeps everyone.
+        let mut verifiers = vec![
+            verifier_at("a", "http://a", "ok", 100_000),
+            verifier_at("b", "http://b", "ok", 100_000),
+            verifier_at("c", "http://c", "ok", 100_000),
+        ];
+        demote_stale_verifiers(&mut verifiers, 100_000, DEFAULT_MAX_VERIFIER_SLOT_LAG);
+        assert_eq!(statuses(&verifiers), vec!["ok", "ok", "ok"]);
+    }
+
+    #[test]
+    fn demotion_never_empties_the_routing_pool() {
+        // `freshest_slot` is the max over ok verifiers, so its holder has zero lag
+        // and always survives. Narrowing the pool is fine; emptying it is not.
+        let mut verifiers = vec![
+            verifier_at("frozen-1", "http://f1", "ok", 1),
+            verifier_at("freshest", "http://f2", "ok", 10_000_000),
+            verifier_at("frozen-2", "http://f3", "ok", 2),
+        ];
+        demote_stale_verifiers(&mut verifiers, 10_000_000, DEFAULT_MAX_VERIFIER_SLOT_LAG);
+        assert_eq!(verifiers.iter().filter(|v| v.status == "ok").count(), 1);
+        assert_eq!(verifiers[1].status, "ok");
+    }
+
+    #[test]
+    fn non_ok_verifiers_keep_their_original_status() {
+        // A verifier that failed the on-chain root comparison must stay
+        // "mismatch"/"error" — staleness must not overwrite the real reason.
+        let mut verifiers = vec![
+            verifier_at("fresh", "http://fresh", "ok", 436_919_878),
+            verifier_at("bad-root", "http://bad", "mismatch", 1),
+            verifier_at("unreachable", "http://down", "error", 0),
+        ];
+        demote_stale_verifiers(&mut verifiers, 436_919_878, DEFAULT_MAX_VERIFIER_SLOT_LAG);
+        assert_eq!(statuses(&verifiers), vec!["ok", "mismatch", "error"]);
+    }
+
+    #[test]
+    fn no_ok_verifiers_demotes_nothing() {
+        // `chosen_slot` stays 0 when nothing verified; every lag saturates to 0.
+        let mut verifiers = vec![
+            verifier_at("a", "http://a", "error", 500),
+            verifier_at("b", "http://b", "mismatch", 600),
+        ];
+        demote_stale_verifiers(&mut verifiers, 0, DEFAULT_MAX_VERIFIER_SLOT_LAG);
+        assert_eq!(statuses(&verifiers), vec!["error", "mismatch"]);
+    }
+
+    #[test]
+    fn lag_exactly_at_the_limit_is_allowed() {
+        // The bound is inclusive: only a verifier strictly past the budget drops.
+        let mut verifiers = vec![
+            verifier_at("fresh", "http://fresh", "ok", DEFAULT_MAX_VERIFIER_SLOT_LAG),
+            verifier_at("edge", "http://edge", "ok", 0),
+        ];
+        demote_stale_verifiers(
+            &mut verifiers,
+            DEFAULT_MAX_VERIFIER_SLOT_LAG,
+            DEFAULT_MAX_VERIFIER_SLOT_LAG,
+        );
+        assert_eq!(statuses(&verifiers), vec!["ok", "ok"]);
     }
 
     #[test]

--- a/ncn-router/src/cron_job.rs
+++ b/ncn-router/src/cron_job.rs
@@ -349,10 +349,8 @@ fn compare_with_chain(
             .unwrap_or_default()
     };
 
-    // Drop verifiers that verify cleanly against their own stale slot but have
-    // fallen behind the fleet — they would otherwise stay in rotation and 404
-    // every proof request for a current snapshot. Runs before de-duplication so
-    // an origin that is stale on one row cannot be preferred as `ok` on another.
+    // Before de-duplication, so an origin that is stale on one row cannot be
+    // preferred as `ok` on another.
     let mut whitelist_verifiers = whitelist_verifiers;
     demote_stale_verifiers(
         &mut whitelist_verifiers,
@@ -397,30 +395,38 @@ fn compare_with_chain(
 }
 
 fn max_verifier_slot_lag() -> u64 {
-    env::var("NCN_MAX_VERIFIER_SLOT_LAG")
-        .ok()
-        .and_then(|s| s.parse().ok())
-        .unwrap_or(DEFAULT_MAX_VERIFIER_SLOT_LAG)
+    parse_max_verifier_slot_lag(env::var("NCN_MAX_VERIFIER_SLOT_LAG").ok().as_deref())
 }
 
-/// Demote `ok` verifiers whose latest snapshot trails `freshest_slot` by more
-/// than `max_lag`, so the router stops sampling them.
+/// A malformed override falls back to the default but says so: silently widening
+/// the budget would keep verifiers in rotation that the configured policy meant
+/// to drop, which is the failure this whole check exists to prevent.
+fn parse_max_verifier_slot_lag(raw: Option<&str>) -> u64 {
+    let Some(value) = raw else {
+        return DEFAULT_MAX_VERIFIER_SLOT_LAG;
+    };
+    value.trim().parse().unwrap_or_else(|_| {
+        eprintln!(
+            "[ncn-meta-cron] ignoring NCN_MAX_VERIFIER_SLOT_LAG={value:?}: not a slot count; \
+             using {DEFAULT_MAX_VERIFIER_SLOT_LAG}. Verifiers the configured value would have \
+             dropped stay in rotation until this is corrected."
+        );
+        DEFAULT_MAX_VERIFIER_SLOT_LAG
+    })
+}
+
+/// Demote `ok` verifiers whose snapshot trails `freshest_slot` by more than
+/// `max_lag`, so the router stops sampling them.
 ///
-/// `status == "ok"` only means a verifier's merkle root and snapshot hash match
-/// the on-chain ballot *at the slot that verifier itself reported*. An operator
-/// that stopped uploading months ago still satisfies that: its stale data is
-/// perfectly self-consistent, so it stays `ok` indefinitely while answering
-/// every proof request for a current snapshot with a 404.
+/// `status == "ok"` only checks a verifier's root against the on-chain ballot at
+/// the slot *it* reported, which an operator that stopped uploading months ago
+/// still satisfies — it stays `ok` while 404ing every current proof request.
 ///
-/// Freshness is measured against the freshest peer rather than the chain tip on
-/// purpose. Snapshots are only produced when a proposal needs one, so between
-/// proposals the whole fleet legitimately sits at the same older slot — against
-/// the tip that would demote everyone, against the fleet it demotes nobody.
-///
-/// `freshest_slot` is the maximum over verifiers that are already `ok`, so the
-/// verifier holding that slot has zero lag and always survives: this can narrow
-/// the routing pool but never empty it. When no verifier is `ok`,
-/// `freshest_slot` is 0 and every lag saturates to 0, so nothing is demoted.
+/// Measured against the freshest peer, not the chain tip: snapshots are only
+/// produced when a proposal needs one, so between proposals the whole fleet
+/// legitimately sits at the same older slot. `freshest_slot` is the max over
+/// already-`ok` verifiers, so its holder has zero lag and always survives —
+/// this narrows the routing pool but never empties it.
 fn demote_stale_verifiers(verifiers: &mut [WhitelistVerifier], freshest_slot: u64, max_lag: u64) {
     for verifier in verifiers.iter_mut() {
         if verifier.status != "ok" {
@@ -864,6 +870,28 @@ mod tests {
         ];
         demote_stale_verifiers(&mut verifiers, 0, DEFAULT_MAX_VERIFIER_SLOT_LAG);
         assert_eq!(statuses(&verifiers), vec!["error", "mismatch"]);
+    }
+
+    #[test]
+    fn lag_override_is_parsed_and_falls_back_loudly() {
+        assert_eq!(parse_max_verifier_slot_lag(Some("1000")), 1_000);
+        assert_eq!(parse_max_verifier_slot_lag(Some("  1000  ")), 1_000);
+        // 0 is a legitimate "any lag is stale" policy, not a parse failure.
+        assert_eq!(parse_max_verifier_slot_lag(Some("0")), 0);
+        assert_eq!(
+            parse_max_verifier_slot_lag(None),
+            DEFAULT_MAX_VERIFIER_SLOT_LAG
+        );
+        // Malformed values fall back rather than taking the cron down, but the
+        // fallback is announced — silently widening the budget would keep stale
+        // verifiers routable against the operator's intent.
+        for bad in ["", "abc", "-1", "1.5", "1_000"] {
+            assert_eq!(
+                parse_max_verifier_slot_lag(Some(bad)),
+                DEFAULT_MAX_VERIFIER_SLOT_LAG,
+                "unexpected parse of {bad:?}"
+            );
+        }
     }
 
     #[test]

--- a/ncn-router/src/router.rs
+++ b/ncn-router/src/router.rs
@@ -585,10 +585,35 @@ mod tests {
             verifier("a", "http://a", "ok"),
             verifier("b", "http://b", "error"),
             verifier("c", "http://c", "mismatch"),
+            verifier("d", "http://d", "stale"),
         ];
         let routable = select_routable_verifiers(&verifiers);
         assert_eq!(routable.len(), 1);
         assert_eq!(routable[0].domain, "http://a");
+    }
+
+    #[test]
+    fn whitelist_parses_the_per_verifier_slot_field() {
+        // The cron writes this file and the router reads it, so the two structs
+        // are a cross-binary contract. `slot` exists only on the writer side; if
+        // this struct ever gained `deny_unknown_fields`, the router would fail to
+        // parse the whole whitelist and stop routing entirely.
+        let json = r#"{
+            "network": "mainnet",
+            "slot": 436919878,
+            "updated_at": "2026-08-03T10:04:10Z",
+            "verifiers": [
+                {"name":"fresh","domain":"http://fresh","slot":436919878,"status":"ok","reason":null},
+                {"name":"frozen","domain":"http://frozen","slot":422497000,"status":"stale",
+                 "reason":"snapshot slot 422497000 is 14422878 slots behind freshest verifier"}
+            ]
+        }"#;
+        let snapshot: WhitelistSnapshot =
+            serde_json::from_str(json).expect("router must parse the cron's whitelist format");
+        assert_eq!(snapshot.verifiers.len(), 2);
+        let routable = select_routable_verifiers(&snapshot.verifiers);
+        assert_eq!(routable.len(), 1);
+        assert_eq!(routable[0].domain, "http://fresh");
     }
 
     #[test]


### PR DESCRIPTION
## TLDR

This PR drops verifiers that have fallen behind the rest of the fleet

## Problem

`ncn-router` picks a verifier uniformly at random from those with `status == "ok"`. That status is set by the cron comparing each verifier's merkle root and snapshot hash against the on-chain ballot at the slot that verifier itself reported

An operator that stopped uploading months ago still passes: its stale data is perfectly self-consistent with the onchain ballot for its own old slot. So it stays `"ok"` forever, keeps its routing ticket, and 404s every proof request for a current snapshot. Staleness is never evaluated anywhere

## Measured Impact

Polled all 11 configured verifiers on 2026-08-03 (chain slot 437,011,715):

| Verifier | Slot | Behind |
|---|---|---|
| ncn-verifier.chainflow.io | 436941951 | current |
| verifier.promptlogic.systems | 436924558 | current |
| gov.lantern.one | 436919878 | current |
| verifier.titananalytics.io | 435942000 | ~5 days |
| verifier.nops.blocksize.dev | 422497000 | **~67 days** |
| ncn-verifier.digital-energy.io | 422497000 | **~67 days** |
| ncn.stakeware.xyz:3000 | 422497000 | **~67 days** |
| ncn.brewlabs.so | 422497000 | **~67 days** |
| ncn.ha1iad3.com | — | expired TLS cert |
| solgov.com | — | redirects https → http |
| ncn-verifier.exotechnologies.xyz:3000 | — | timeout |

Six samples of the public router endpoint returned digital-energy, brewlabs, stakeware, blocksize, and two timeouts; no current operator in six tries. A validator using the CLI's default `operator_api_url` has roughly a 1-in-4 chance
of reaching an operator that holds the slot they need

## Fix

1. Record each verifier's reported `slot` in the whitelist file. Also makes a lagging operator visible without re-polling
2. After the on-chain comparison, demote any `"ok"` verifier trailing the freshest whitelisted peer by more than `NCN_MAX_VERIFIER_SLOT_LAG` (default to one epoch) to `"stale"`, with the lag in `reason`

Applied to the fleet above: chainflow becomes `chosen_slot`; titan (999,951 behind) and the four frozen operators (14,444,951 behind) are demoted. The pool goes from 8 to 3, all of which can serve current proofs

## Tests
- `cargo test` in `ncn-router` → 27 passed (13 cron + 14 router), up from 19.
- Eight new cron tests cover the reported failure mode, the lag budget, the common-older-slot case, pool-never-empty, non-`ok` statuses being preserved, the no-`ok`-verifiers case, the inclusive boundary, and lag-override parsing (valid, whitespace, `0`-as-strict-policy, absent, and five malformed inputs)
- One new router test deserializes a whitelist containing the new `slot` field. The cron writes that file and the router reads it, so the two structs are a cross-binary contract; if the reader ever gained `deny_unknown_fields`, adding a field would make it fail to parse the whole whitelist and stop routing entirely. The test pins that
