### PR TITLE
fix(frontend): Degrade Gracefully When Validator Metadata is Unavailable

### DIFF
--- a/frontend/src/components/governance/shared/DashboardStats.tsx
+++ b/frontend/src/components/governance/shared/DashboardStats.tsx
@@ -59,7 +59,9 @@ export function DashboardStats({
 
   const totalStaked =
     stakeAccounts?.reduce((acc, curr) => acc + curr.activeStake, 0) || 0;
-  const activeValidators = validators?.length || 0;
+  // Left undefined when the validator query has not resolved; formatOptionalCount
+  // renders "-" rather than a "0" that reads as a real count.
+  const activeValidators = validators?.length;
 
   // TODO: on mobile only show "custom" when the network is a custom URL, otherwise show the network name
 

--- a/frontend/src/components/proposals/StatsCard.tsx
+++ b/frontend/src/components/proposals/StatsCard.tsx
@@ -2,7 +2,8 @@ import { formatNumber } from "@/helpers";
 
 type StatsCardProps = {
   label: string;
-  value: number;
+  /** `undefined` when the value could not be loaded; renders "-". */
+  value: number | undefined;
   isLoading: boolean;
 };
 
@@ -16,7 +17,7 @@ export default function StatsCard({ label, value, isLoading }: StatsCardProps) {
             {isLoading ? (
               <span className="animate-pulse h-8 w-10 bg-white/10 rounded" />
             ) : (
-              formatNumber(value)
+              (value === undefined ? "-" : formatNumber(value))
             )}
           </div>
         </div>

--- a/frontend/src/components/proposals/detail/QuorumDonut.tsx
+++ b/frontend/src/components/proposals/detail/QuorumDonut.tsx
@@ -19,9 +19,13 @@ interface QuorumDonutProps {
   forLamports: number;
   againstLamports: number;
   abstainLamports: number;
-  totalLamports: number;
+  /** `undefined` when total network stake could not be loaded. */
+  totalLamports: number | undefined;
   quorumPercentage?: number;
 }
+
+/** Shown in the donut centre when total network stake could not be loaded. */
+const UNKNOWN_TOTAL = "—";
 
 export function QuorumDonutSkeleton() {
   return (
@@ -56,7 +60,10 @@ export default function QuorumDonut({
 
   // Memoize calculations to avoid re-computing on every render
   const { chartData, totalSol } = useMemo(() => {
-    const totalSol = formatSOL(totalLamports);
+    // Unknown must not render as "0.00 Total SOL" — that reads as a real
+    // figure, and would contradict the "—" the breakdown beside it shows.
+    const totalSol =
+      totalLamports === undefined ? UNKNOWN_TOTAL : formatSOL(totalLamports);
 
     const chartData = [
       { name: "For", value: forLamports },
@@ -75,11 +82,12 @@ export default function QuorumDonut({
   const strokeWidth = 7;
   const circumference = 2 * Math.PI * radius;
 
-  const forPercent = totalLamports > 0 ? chartData[0].value / totalLamports : 0;
-  const againstPercent =
-    totalLamports > 0 ? chartData[1].value / totalLamports : 0;
-  const abstainPercent =
-    totalLamports > 0 ? chartData[2].value / totalLamports : 0;
+  // No arcs when the denominator is unknown: an empty ring is the honest
+  // rendering, and it matches the "—" in the centre.
+  const hasTotal = totalLamports !== undefined && totalLamports > 0;
+  const forPercent = hasTotal ? chartData[0].value / totalLamports : 0;
+  const againstPercent = hasTotal ? chartData[1].value / totalLamports : 0;
+  const abstainPercent = hasTotal ? chartData[2].value / totalLamports : 0;
 
   // Animation spring for the percentages
   const { forP, againstP, abstainP } = useSpring({

--- a/frontend/src/components/proposals/detail/TopSupportersColumns.tsx
+++ b/frontend/src/components/proposals/detail/TopSupportersColumns.tsx
@@ -10,6 +10,10 @@ import {
 import { TopSupporterRecord } from "@/types";
 import { CopyableAddressIcon } from "@/components/governance/shared/CopyableAddressIcon";
 
+/** Shown when validator stake could not be loaded, so an unknown value is not
+ * rendered as a real-looking zero. */
+const UNKNOWN_VALUE = "—";
+
 export const topSupporterColumns: ColumnDef<TopSupporterRecord>[] = [
   {
     accessorKey: "validatorName",
@@ -57,7 +61,9 @@ export const topSupporterColumns: ColumnDef<TopSupporterRecord>[] = [
     ),
     cell: ({ row }) => (
       <div className="text-sm text-white/60">
-        {formatLamportsDisplay(row.original.stakedLamports).value}
+        {row.original.stakedLamports === undefined
+          ? UNKNOWN_VALUE
+          : formatLamportsDisplay(row.original.stakedLamports).value}
       </div>
     ),
     sortingFn: "basic",
@@ -69,7 +75,9 @@ export const topSupporterColumns: ColumnDef<TopSupporterRecord>[] = [
     ),
     cell: ({ row }) => (
       <span className="text-sm text-white/60">
-        {row.original.stakePercentage.toFixed(2)}%
+        {row.original.stakePercentage === undefined
+          ? UNKNOWN_VALUE
+          : `${row.original.stakePercentage.toFixed(2)}%`}
       </span>
     ),
     sortingFn: "basic",

--- a/frontend/src/components/proposals/detail/VoteBreakdown.tsx
+++ b/frontend/src/components/proposals/detail/VoteBreakdown.tsx
@@ -11,6 +11,9 @@ import {
 } from "@/lib/governance/formatters";
 import { useHasUserVoted, useValidatorsTotalStakedLamports } from "@/hooks";
 
+/** Shown in place of a percentage when total network stake could not be loaded. */
+const UNKNOWN_PERCENTAGE = "—";
+
 interface VoteBreakdownWrapperProps {
   proposal: ProposalRecord | undefined;
   isLoading: boolean;
@@ -39,13 +42,11 @@ const VoteBreakdown = ({
   const { totalStakedLamports, isLoading: isLoadingTotalStake } =
     useValidatorsTotalStakedLamports();
 
+  // `undefined` when the denominator is unknown, so the percentages render as
+  // "—" rather than a "0.00%" that looks like a real tally.
   const votePercentages = useMemo(() => {
-    if (!proposal || !totalStakedLamports || totalStakedLamports === 0) {
-      return {
-        forVotesPercentage: 0,
-        againstVotesPercentage: 0,
-        abstainVotesPercentage: 0,
-      };
+    if (!proposal || !totalStakedLamports) {
+      return undefined;
     }
 
     return {
@@ -75,7 +76,7 @@ const VoteBreakdown = ({
               forLamports={proposal.forVotesLamports}
               againstLamports={proposal.againstVotesLamports}
               abstainLamports={proposal.abstainVotesLamports}
-              totalLamports={totalStakedLamports}
+              totalLamports={totalStakedLamports ?? 0}
               quorumPercentage={proposal.quorumPercent / 100}
             />
           )}
@@ -105,10 +106,11 @@ const VoteBreakdown = ({
                   amount={
                     formatLamportsDisplay(proposal.forVotesLamports).value
                   }
-                  percentage={formatPercentage(
-                    votePercentages.forVotesPercentage,
-                    2,
-                  )}
+                  percentage={
+                    votePercentages
+                      ? formatPercentage(votePercentages.forVotesPercentage, 2)
+                      : UNKNOWN_PERCENTAGE
+                  }
                   color="bg-primary"
                 />
                 <VoteItem
@@ -116,10 +118,14 @@ const VoteBreakdown = ({
                   amount={
                     formatLamportsDisplay(proposal.againstVotesLamports).value
                   }
-                  percentage={formatPercentage(
-                    votePercentages.againstVotesPercentage,
-                    2,
-                  )}
+                  percentage={
+                    votePercentages
+                      ? formatPercentage(
+                          votePercentages.againstVotesPercentage,
+                          2,
+                        )
+                      : UNKNOWN_PERCENTAGE
+                  }
                   color="bg-destructive"
                 />
                 <VoteItem
@@ -127,10 +133,14 @@ const VoteBreakdown = ({
                   amount={
                     formatLamportsDisplay(proposal.abstainVotesLamports).value
                   }
-                  percentage={formatPercentage(
-                    votePercentages.abstainVotesPercentage,
-                    2,
-                  )}
+                  percentage={
+                    votePercentages
+                      ? formatPercentage(
+                          votePercentages.abstainVotesPercentage,
+                          2,
+                        )
+                      : UNKNOWN_PERCENTAGE
+                  }
                   color="bg-white/30"
                 />
               </>

--- a/frontend/src/components/proposals/detail/VoteBreakdown.tsx
+++ b/frontend/src/components/proposals/detail/VoteBreakdown.tsx
@@ -76,7 +76,7 @@ const VoteBreakdown = ({
               forLamports={proposal.forVotesLamports}
               againstLamports={proposal.againstVotesLamports}
               abstainLamports={proposal.abstainVotesLamports}
-              totalLamports={totalStakedLamports ?? 0}
+              totalLamports={totalStakedLamports}
               quorumPercentage={proposal.quorumPercent / 100}
             />
           )}

--- a/frontend/src/components/proposals/detail/__tests__/QuorumDonut.test.tsx
+++ b/frontend/src/components/proposals/detail/__tests__/QuorumDonut.test.tsx
@@ -1,0 +1,25 @@
+import { render, screen } from "@testing-library/react";
+import QuorumDonut from "../QuorumDonut";
+
+const props = {
+  forLamports: 30_000_000_000,
+  againstLamports: 10_000_000_000,
+  abstainLamports: 10_000_000_000,
+};
+
+describe("QuorumDonut", () => {
+  it("renders the total when network stake is known", () => {
+    render(<QuorumDonut {...props} totalLamports={100_000_000_000} />);
+    expect(screen.getByText("Total SOL")).toBeInTheDocument();
+    expect(screen.getByText("100.00")).toBeInTheDocument();
+  });
+
+  it("renders a dash, not 0.00, when network stake is unknown", () => {
+    // Regression (PR #121 review): the caller passed `?? 0`, so the donut
+    // showed "0.00 Total SOL" — a real-looking figure — while the vote
+    // breakdown beside it correctly showed "—".
+    render(<QuorumDonut {...props} totalLamports={undefined} />);
+    expect(screen.getByText("—")).toBeInTheDocument();
+    expect(screen.queryByText("0.00")).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/hooks/__tests__/useGetValidators.test.tsx
+++ b/frontend/src/hooks/__tests__/useGetValidators.test.tsx
@@ -1,0 +1,134 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import React from "react";
+
+// helpers/contexts pull in env.ts (ESM-only, untransformed by jest), so stub the
+// endpoint context the same way the instruction tests do.
+jest.mock("@/contexts/EndpointContext", () => ({
+  useEndpoint: () => ({ endpointUrl: "http://localhost:8899" }),
+  RPC_URLS: { testnet: "http://localhost:8899" },
+}));
+
+const mockGetStakeWizValidators = jest.fn();
+jest.mock("@/data", () => ({
+  getStakeWizValidators: () => mockGetStakeWizValidators(),
+}));
+
+const mockGetVoteAccounts = jest.fn();
+jest.mock("@solana/web3.js", () => ({
+  ...jest.requireActual("@solana/web3.js"),
+  Connection: jest.fn().mockImplementation(() => ({
+    getVoteAccounts: () => mockGetVoteAccounts(),
+  })),
+}));
+
+import { useGetValidators } from "../useGetValidators";
+
+const VOTE_ACCOUNT = "Vote111111111111111111111111111111111111111";
+const IDENTITY = "Node1111111111111111111111111111111111111111";
+
+/** RPC stake is an integer in lamports; StakeWiz reports SOL as a float. */
+const RPC_STAKE_LAMPORTS = 5_123_456_789_012_345;
+
+function voteAccounts() {
+  return {
+    current: [
+      {
+        votePubkey: VOTE_ACCOUNT,
+        nodePubkey: IDENTITY,
+        activatedStake: RPC_STAKE_LAMPORTS,
+        commission: 5,
+        epochCredits: [[123, 0, 0]],
+        lastVote: 999,
+      },
+    ],
+    delinquent: [],
+  };
+}
+
+function stakeWiz() {
+  return {
+    data: [
+      {
+        name: "Real Validator",
+        vote_identity: VOTE_ACCOUNT,
+        // Same stake expressed in SOL, as StakeWiz reports it.
+        activated_stake: RPC_STAKE_LAMPORTS / 1e9,
+        commission: 5,
+        epoch_credits: 123,
+        last_vote: 999,
+      },
+    ],
+  };
+}
+
+function wrapper({ children }: { children: React.ReactNode }) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 } },
+  });
+  return (
+    <QueryClientProvider client={client}>{children}</QueryClientProvider>
+  );
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe("useGetValidators", () => {
+  it("keeps correct stake when StakeWiz is down, losing only display metadata", async () => {
+    // The reported failure: a third-party outage used to blank the whole
+    // governance UI to zeros while reporting success, because the hook returned
+    // [] unless BOTH sources resolved.
+    mockGetStakeWizValidators.mockRejectedValue(new Error("stakewiz 503"));
+    mockGetVoteAccounts.mockResolvedValue(voteAccounts());
+
+    const { result } = renderHook(() => useGetValidators(), { wrapper });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data).toHaveLength(1);
+    expect(result.current.data?.[0].activated_stake).toBe(RPC_STAKE_LAMPORTS);
+    expect(result.current.data?.[0].name).toBe("Unknown validator #1");
+    expect(result.current.data?.[0].vote_identity).toBe(VOTE_ACCOUNT);
+  });
+
+  it("surfaces an RPC failure as a query error rather than an empty list", async () => {
+    // Returning [] made react-query record a success, so nothing retried and
+    // every consumer divided by a zero denominator.
+    mockGetStakeWizValidators.mockResolvedValue(stakeWiz());
+    mockGetVoteAccounts.mockRejectedValue(new Error("rpc down"));
+
+    const { result } = renderHook(() => useGetValidators(), { wrapper });
+    await waitFor(() => expect(result.current.isError).toBe(true));
+
+    expect(result.current.data).toBeUndefined();
+  });
+
+  it("takes stake from the RPC, not StakeWiz, when both resolve", async () => {
+    // StakeWiz samples stake independently of the RPC, so matched and unmatched
+    // validators used to carry differently-sourced numbers in the same array.
+    // Give the two sources different values and pin which one wins.
+    mockGetStakeWizValidators.mockResolvedValue({
+      data: [{ ...stakeWiz().data[0], activated_stake: 1 }], // 1 SOL, stale
+    });
+    mockGetVoteAccounts.mockResolvedValue(voteAccounts());
+
+    const { result } = renderHook(() => useGetValidators(), { wrapper });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data?.[0].name).toBe("Real Validator");
+    expect(result.current.data?.[0].activated_stake).toBe(RPC_STAKE_LAMPORTS);
+  });
+
+  it("fills in the identity from the RPC when metadata omits it", async () => {
+    // Governance votes key on validator identity; StakeWiz does not always
+    // carry it, and consumers index by both.
+    mockGetStakeWizValidators.mockResolvedValue(stakeWiz());
+    mockGetVoteAccounts.mockResolvedValue(voteAccounts());
+
+    const { result } = renderHook(() => useGetValidators(), { wrapper });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data?.[0].identity).toBe(IDENTITY);
+  });
+});

--- a/frontend/src/hooks/__tests__/useGetValidators.test.tsx
+++ b/frontend/src/hooks/__tests__/useGetValidators.test.tsx
@@ -23,6 +23,7 @@ jest.mock("@solana/web3.js", () => ({
 }));
 
 import { useGetValidators } from "../useGetValidators";
+import { useValidatorsTotalStakedLamports } from "../useValidatorsTotalStakedLamports";
 
 const VOTE_ACCOUNT = "Vote111111111111111111111111111111111111111";
 const IDENTITY = "Node1111111111111111111111111111111111111111";
@@ -130,5 +131,35 @@ describe("useGetValidators", () => {
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
     expect(result.current.data?.[0].identity).toBe(IDENTITY);
+  });
+});
+
+describe("useValidatorsTotalStakedLamports", () => {
+  it("reports an unknown denominator rather than zero when the RPC fails", async () => {
+    // Regression (PR #121 review): throwing surfaced the query error, but the
+    // derived hook still collapsed the undefined data into 0, so consumers
+    // divided by zero and rendered "0.00%" — indistinguishable from a real
+    // tally. Unknown must stay unknown all the way to the consumer.
+    mockGetStakeWizValidators.mockResolvedValue(stakeWiz());
+    mockGetVoteAccounts.mockRejectedValue(new Error("rpc down"));
+
+    const { result } = renderHook(() => useValidatorsTotalStakedLamports(), {
+      wrapper,
+    });
+    await waitFor(() => expect(result.current.isError).toBe(true));
+
+    expect(result.current.totalStakedLamports).toBeUndefined();
+  });
+
+  it("sums activated stake once the query resolves", async () => {
+    mockGetStakeWizValidators.mockResolvedValue(stakeWiz());
+    mockGetVoteAccounts.mockResolvedValue(voteAccounts());
+
+    const { result } = renderHook(() => useValidatorsTotalStakedLamports(), {
+      wrapper,
+    });
+    await waitFor(() =>
+      expect(result.current.totalStakedLamports).toBe(RPC_STAKE_LAMPORTS),
+    );
   });
 });

--- a/frontend/src/hooks/__tests__/useProposalSupporters.test.tsx
+++ b/frontend/src/hooks/__tests__/useProposalSupporters.test.tsx
@@ -1,0 +1,93 @@
+import { renderHook } from "@testing-library/react";
+import { PublicKey } from "@solana/web3.js";
+
+const mockUseSupportAccounts = jest.fn();
+const mockUseGetValidators = jest.fn();
+const mockUseValidatorsTotalStakedLamports = jest.fn();
+
+jest.mock("../useSupportAccounts", () => ({
+  buildSupportFilters: () => [{ memcmp: { offset: 8, bytes: "x" } }],
+  useSupportAccounts: () => mockUseSupportAccounts(),
+}));
+jest.mock("../useGetValidators", () => ({
+  useGetValidators: () => mockUseGetValidators(),
+}));
+jest.mock("../useValidatorsTotalStakedLamports", () => ({
+  useValidatorsTotalStakedLamports: () => mockUseValidatorsTotalStakedLamports(),
+}));
+
+import { useProposalSupporters } from "../useProposalSupporters";
+
+const PROPOSAL = new PublicKey("11111111111111111111111111111111");
+const SUPPORT = new PublicKey("SysvarC1ock11111111111111111111111111111111");
+const IDENTITY = new PublicKey("Vote111111111111111111111111111111111111111");
+
+const supportAccounts = [{ publicKey: SUPPORT, validator: IDENTITY }];
+
+const validators = [
+  {
+    name: "Real Validator",
+    vote_identity: IDENTITY.toBase58(),
+    identity: IDENTITY.toBase58(),
+    activated_stake: 25_000_000_000,
+    commission: 5,
+    epoch_credits: 1,
+    last_vote: 1,
+  },
+];
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockUseSupportAccounts.mockReturnValue({
+    data: supportAccounts,
+    isLoading: false,
+  });
+});
+
+describe("useProposalSupporters", () => {
+  it("computes a stake percentage when validator data is available", () => {
+    mockUseGetValidators.mockReturnValue({
+      data: validators,
+      isLoading: false,
+    });
+    mockUseValidatorsTotalStakedLamports.mockReturnValue({
+      totalStakedLamports: 100_000_000_000,
+    });
+
+    const { result } = renderHook(() => useProposalSupporters(PROPOSAL));
+
+    expect(result.current.data[0].validatorName).toBe("Real Validator");
+    expect(result.current.data[0].stakedLamports).toBe(25_000_000_000);
+    expect(result.current.data[0].stakePercentage).toBe(25);
+  });
+
+  it("leaves stake unknown rather than zero when validators fail to load", () => {
+    // A zero denominator used to render every supporter as "0 SOL / 0.00%",
+    // indistinguishable from a supporter that genuinely holds no stake.
+    mockUseGetValidators.mockReturnValue({ data: undefined, isLoading: false });
+    mockUseValidatorsTotalStakedLamports.mockReturnValue({
+      totalStakedLamports: undefined,
+    });
+
+    const { result } = renderHook(() => useProposalSupporters(PROPOSAL));
+
+    expect(result.current.data).toHaveLength(1);
+    expect(result.current.data[0].stakedLamports).toBeUndefined();
+    expect(result.current.data[0].stakePercentage).toBeUndefined();
+  });
+
+  it("still lists a supporter that is missing from validator metadata", () => {
+    // The supporter is real — it came from an on-chain Support account — so the
+    // row must stay, with its stake marked unknown.
+    mockUseGetValidators.mockReturnValue({ data: [], isLoading: false });
+    mockUseValidatorsTotalStakedLamports.mockReturnValue({
+      totalStakedLamports: 100_000_000_000,
+    });
+
+    const { result } = renderHook(() => useProposalSupporters(PROPOSAL));
+
+    expect(result.current.data).toHaveLength(1);
+    expect(result.current.data[0].validatorName).toBe("Unknown Validator");
+    expect(result.current.data[0].stakePercentage).toBeUndefined();
+  });
+});

--- a/frontend/src/hooks/useGetValidators.ts
+++ b/frontend/src/hooks/useGetValidators.ts
@@ -1,7 +1,7 @@
 import { useEndpoint } from "@/contexts/EndpointContext";
 import { getStakeWizValidators } from "@/data";
 import { Validator, Validators } from "@/types";
-import { Connection, LAMPORTS_PER_SOL } from "@solana/web3.js";
+import { Connection } from "@solana/web3.js";
 import { useQuery } from "@tanstack/react-query";
 
 export const useGetValidators = () => {
@@ -17,56 +17,73 @@ export const useGetValidators = () => {
 const getValidators = async (endpoint: string): Promise<Validators> => {
   const connection = new Connection(endpoint, "confirmed");
 
+  // The RPC is the source of truth for both the validator set and its stake, so
+  // a failure here has to surface as a query error — react-query then retries
+  // and consumers can render an error instead of a plausible-looking zero.
+  // StakeWiz only supplies display metadata (name, image, description), so it is
+  // allowed to fail: validators fall back to placeholder names with their stake
+  // still correct.
   const [stakeWizValidators, voteAccounts] = await Promise.allSettled([
     getStakeWizValidators(),
     connection.getVoteAccounts(),
   ]);
 
-  if (
-    stakeWizValidators.status === "fulfilled" &&
-    voteAccounts.status === "fulfilled"
-  ) {
-    const allVotes = [
-      ...voteAccounts.value.current,
-      ...voteAccounts.value.delinquent,
-    ];
-
-    // For each RPC vote account: votePubkey = vote account address, nodePubkey = validator identity.
-    // StakeWiz vote_identity is the vote account address — match to vote.votePubkey, not nodePubkey.
-    let unknownCount = 0;
-    const validators = allVotes.map((vote) => {
-      const voteAccountAddress = vote.votePubkey;
-      const matchedValidator = stakeWizValidators.value.data.find(
-        (v) => v.vote_identity === voteAccountAddress,
-      );
-
-      if (matchedValidator) {
-        // StakeWiz returns activated_stake in SOL; normalize to lamports.
-        const activatedStakeLamports = Math.round(
-          matchedValidator.activated_stake * LAMPORTS_PER_SOL,
-        );
-        return {
-          ...matchedValidator,
-          activated_stake: activatedStakeLamports,
-        };
-      }
-      unknownCount++;
-      const unknownValidator: Validator = {
-        name: `Unknown validator #${unknownCount}`,
-        activated_stake: vote.activatedStake,
-        version: "-",
-        description: "",
-        asn: "-",
-        vote_identity: voteAccountAddress,
-        identity: vote.nodePubkey,
-        commission: vote.commission,
-        epoch_credits: vote.epochCredits?.[0]?.[0] || 0,
-        last_vote: vote.lastVote,
-      };
-      return unknownValidator;
-    });
-    return validators;
+  if (voteAccounts.status === "rejected") {
+    throw new Error(
+      `Failed to fetch vote accounts from ${endpoint}: ${voteAccounts.reason}`,
+    );
   }
 
-  return [];
+  if (stakeWizValidators.status === "rejected") {
+    console.warn(
+      "StakeWiz metadata unavailable; falling back to placeholder validator names",
+      stakeWizValidators.reason,
+    );
+  }
+
+  const metadataByVoteAccount = new Map<string, Validator>();
+  if (stakeWizValidators.status === "fulfilled") {
+    for (const validator of stakeWizValidators.value.data) {
+      metadataByVoteAccount.set(validator.vote_identity, validator);
+    }
+  }
+
+  const allVotes = [
+    ...voteAccounts.value.current,
+    ...voteAccounts.value.delinquent,
+  ];
+
+  // For each RPC vote account: votePubkey = vote account address, nodePubkey =
+  // validator identity. StakeWiz vote_identity is the vote account address —
+  // match to vote.votePubkey, not nodePubkey.
+  let unknownCount = 0;
+  return allVotes.map((vote) => {
+    const metadata = metadataByVoteAccount.get(vote.votePubkey);
+
+    if (metadata) {
+      return {
+        ...metadata,
+        // Always take stake from the RPC. StakeWiz reports a separately-sampled
+        // SOL figure, so sourcing it here left one array holding two different
+        // measurements depending on whether a validator happened to match.
+        activated_stake: vote.activatedStake,
+        identity: metadata.identity ?? vote.nodePubkey,
+      };
+    }
+
+    unknownCount++;
+    const unknownValidator: Validator = {
+      name: `Unknown validator #${unknownCount}`,
+      activated_stake: vote.activatedStake,
+      version: "-",
+      description: "",
+      asn: "-",
+      vote_identity: vote.votePubkey,
+      identity: vote.nodePubkey,
+      commission: vote.commission,
+      epoch_credits: vote.epochCredits?.[0]?.[0] || 0,
+      last_vote: vote.lastVote,
+    };
+    return unknownValidator;
+  });
 };

--- a/frontend/src/hooks/useProposalOverviewStats.ts
+++ b/frontend/src/hooks/useProposalOverviewStats.ts
@@ -5,7 +5,8 @@ import { useGetValidators } from "./useGetValidators";
 export type Stat = {
   id: string;
   label: string;
-  value: number;
+  /** `undefined` when the value is not known — rendered as "-", not as 0. */
+  value: number | undefined;
 };
 
 export interface Stats {
@@ -30,7 +31,9 @@ export const useProposalOverviewStats = (): Stats => {
     [proposals]
   );
 
-  const numOfValidators = useMemo(() => validators?.length || 0, [validators]);
+  // Undefined rather than 0 when the validator query has not resolved, so the
+  // card can show "-" instead of a count that looks real.
+  const numOfValidators = useMemo(() => validators?.length, [validators]);
 
   return {
     isLoading,

--- a/frontend/src/hooks/useProposalSupporters.ts
+++ b/frontend/src/hooks/useProposalSupporters.ts
@@ -4,6 +4,7 @@ import { TopSupporterRecord, Validator } from "@/types";
 import { accentColors } from "@/types/topVoters";
 import { buildSupportFilters, useSupportAccounts } from "./useSupportAccounts";
 import { useGetValidators } from "./useGetValidators";
+import { useValidatorsTotalStakedLamports } from "./useValidatorsTotalStakedLamports";
 
 const getColorFromString = (str: string): string => {
   let hash = 0;
@@ -34,6 +35,10 @@ export const useProposalSupporters = (
   const { data: validators, isLoading: isLoadingValidators } =
     useGetValidators();
 
+  // Same query as above (react-query dedupes), but the denominator lives in one
+  // place so this pane cannot disagree with the rest of the UI about it.
+  const { totalStakedLamports } = useValidatorsTotalStakedLamports();
+
   const supporters = useMemo((): TopSupporterRecord[] => {
     if (!supportAccounts) {
       return [];
@@ -51,19 +56,15 @@ export const useProposalSupporters = (
       }
     }
 
-    const totalStakedLamports = validators
-      ? validators.reduce((sum, v) => sum + (v.activated_stake || 0), 0)
-      : 0;
-
     return supportAccounts.map((support) => {
       const identity = support.validator.toBase58();
       const validator = validatorMap[identity];
       const validatorName = validator?.name || "Unknown Validator";
-      const stakedLamports = validator?.activated_stake || 0;
+      const stakedLamports = validator?.activated_stake;
       const stakePercentage =
-        totalStakedLamports > 0 && stakedLamports > 0
+        totalStakedLamports && stakedLamports !== undefined
           ? (stakedLamports / totalStakedLamports) * 100
-          : 0;
+          : undefined;
 
       return {
         id: support.publicKey.toBase58(),
@@ -75,7 +76,7 @@ export const useProposalSupporters = (
         accentColor: getColorFromString(validatorName),
       };
     });
-  }, [supportAccounts, validators]);
+  }, [supportAccounts, totalStakedLamports, validators]);
 
   return {
     data: supporters,

--- a/frontend/src/hooks/useValidatorsTotalStakedLamports.ts
+++ b/frontend/src/hooks/useValidatorsTotalStakedLamports.ts
@@ -2,15 +2,19 @@ import { useMemo } from "react";
 import { useGetValidators } from "./useGetValidators";
 
 /**
- * Hook to get the total staked lamports from all validators
- * @returns The total staked lamports (sum of all validators' activated_stake)
+ * Total activated stake across all validators, or `undefined` when it is not
+ * known — the query is in flight, or it failed.
+ *
+ * Deliberately not `0` for the unknown case: callers divide by this to produce
+ * percentages, and a zero denominator renders as "0%", which is
+ * indistinguishable from a real result.
  */
 export const useValidatorsTotalStakedLamports = () => {
-  const { data: validators, isLoading, error } = useGetValidators();
+  const { data: validators, isLoading, isError, error } = useGetValidators();
 
   const totalStakedLamports = useMemo(() => {
     if (!validators) {
-      return 0;
+      return undefined;
     }
 
     return validators.reduce(
@@ -22,7 +26,7 @@ export const useValidatorsTotalStakedLamports = () => {
   return {
     totalStakedLamports,
     isLoading,
+    isError,
     error,
   };
 };
-

--- a/frontend/src/types/topVoters.ts
+++ b/frontend/src/types/topVoters.ts
@@ -24,8 +24,10 @@ export interface TopSupporterRecord {
   validatorName: string;
   validatorIdentity: string;
   validatorImage?: string | null;
-  stakedLamports: number;
-  stakePercentage: number;
+  /** `undefined` when validator metadata could not be loaded. */
+  stakedLamports: number | undefined;
+  /** `undefined` when total network stake is unknown, so it can render "—". */
+  stakePercentage: number | undefined;
   accentColor: string;
 }
 


### PR DESCRIPTION
## TLDR

This PR ensures we degrade gracefully whenever validator metadata is unavailable, so the governance UI doesn't silently zero out 

## Problem

`useGetValidators` fetched StakeWiz metadata and RPC vote accounts with `Promise.allSettled`, required **both** to resolve, and returned `[]` otherwise

`allSettled` never rejects, so react-query recorded a successful query returning an empty list. No error state, no retry, no signal, and every consumer computed a zero denominator from data that looked fine

Twelve files depend on this query. On a StakeWiz outage:

| Consumer | Renders |
|---|---|
| `VoteBreakdown` | every vote percentage **0%** |
| `support-phase-progress` | **0 SOL** total staked, threshold **0** |
| `DashboardStats` | **0 active validators** |
| `TopVotersTable` | every voter **0%** |
| `useValidatorsVoterSplits` | query disabled (gated on `length > 0`) |

During a live proposal that reads as "this proposal has no support," which is about the worst thing a governance UI can say incorrectly

## Fix

Separate the two sources by what each is actually for:

- RPC is the source of truth for the validator set and its stake, so a failure now throws. React-query retries, and consumers can distinguish "broken" from "zero"
- StakeWiz only supplies display metadata, so it is allowed to fail: validators fall back to placeholder names with correct stake numbers. This is the far more likely outage of the two, and it is now fully non-fatal

Note that all twelve consumers already guard against `undefined` (`?.length || 0`, gated `enabled`, or an explicit `undefined` throw), so the new error path breaks nothing

## Tests

Four new tests:
- StakeWiz down → stake stays correct, only names degrade
- RPC down → query error rather than an empty list
- Both resolve with conflicting stake → the RPC value wins
- Metadata omits `identity` → filled from the RPC's `nodePubkey`