### PR TITLE
fix(frontend): Don't Report Support Success Before Stake Loads

### DIFF
--- a/frontend/src/components/proposals/detail/support-phase-progress/SupportDonut.tsx
+++ b/frontend/src/components/proposals/detail/support-phase-progress/SupportDonut.tsx
@@ -5,32 +5,26 @@ import { useSpring, animated, to } from "@react-spring/web";
 import { formatSOL } from "@/lib/governance/formatters";
 import { DONUT_CONFIG, DonutChartBase } from "../shared/DonutChartBase";
 
+/**
+ * Presentational only. These figures come from `computeSupportStats` so the
+ * donut and its parent cannot disagree — the donut used to recompute
+ * `isThresholdMet` itself and reported success while stake was still loading.
+ */
 interface SupportDonutProps {
-  currentSupportLamports: number;
-  requiredThresholdLamports: number;
+  progressPercent: number;
+  isThresholdMet: boolean;
+  remainingLamports: number;
 }
 
 export function SupportDonut({
-  currentSupportLamports,
-  requiredThresholdLamports,
+  progressPercent,
+  isThresholdMet,
+  remainingLamports,
 }: SupportDonutProps) {
-  const { progressPercent, isThresholdMet, remainingSol } = useMemo(() => {
-    const progress =
-      requiredThresholdLamports > 0
-        ? (currentSupportLamports / requiredThresholdLamports) * 100
-        : 0;
-
-    const remaining = Math.max(
-      0,
-      requiredThresholdLamports - currentSupportLamports
-    );
-
-    return {
-      progressPercent: progress,
-      isThresholdMet: currentSupportLamports >= requiredThresholdLamports,
-      remainingSol: formatSOL(remaining),
-    };
-  }, [currentSupportLamports, requiredThresholdLamports]);
+  const remainingSol = useMemo(
+    () => formatSOL(remainingLamports),
+    [remainingLamports]
+  );
 
   // Clamp display to 100% for the arc (even if progress > 100%)
   const displayPercent = Math.min(progressPercent, 100) / 100;

--- a/frontend/src/components/proposals/detail/support-phase-progress/__tests__/stats.test.ts
+++ b/frontend/src/components/proposals/detail/support-phase-progress/__tests__/stats.test.ts
@@ -46,6 +46,31 @@ describe("computeSupportStats", () => {
     expect(stats.supportPercentOfTotal).toBe(0);
   });
 
+  it("treats a configured 0% threshold as met, matching the program", () => {
+    // The program permits 0..=10000 bps and its own check is
+    // `support >= cluster_min_stake`, which any support satisfies at 0 bps.
+    // Gating on stake rather than on the derived threshold keeps the two in
+    // agreement instead of reporting unmet for a legitimate config.
+    const stats = computeSupportStats({
+      ...base,
+      thresholdPercent: 0,
+      currentSupportLamports: 1,
+    });
+    expect(stats.requiredThresholdLamports).toBe(0);
+    expect(stats.isThresholdMet).toBe(true);
+  });
+
+  it("still withholds success at 0% while stake is unknown", () => {
+    // The two zero-threshold causes must not collapse into one another.
+    const stats = computeSupportStats({
+      ...base,
+      thresholdPercent: 0,
+      totalStakedLamports: 0,
+      currentSupportLamports: 1,
+    });
+    expect(stats.isThresholdMet).toBe(false);
+  });
+
   it("does not divide by a validator count of zero", () => {
     // Regression: participationPercent was NaN whenever the validator query had
     // not resolved, which rendered as "NaN%".

--- a/frontend/src/components/proposals/detail/support-phase-progress/__tests__/stats.test.ts
+++ b/frontend/src/components/proposals/detail/support-phase-progress/__tests__/stats.test.ts
@@ -1,0 +1,80 @@
+import { computeSupportStats } from "../stats";
+
+const TOTAL = 100_000_000_000;
+
+const base = {
+  currentSupportLamports: 0,
+  totalStakedLamports: TOTAL,
+  thresholdPercent: 15,
+  validatorCount: 0,
+  numOfValidators: 100,
+};
+
+describe("computeSupportStats", () => {
+  it("measures progress against the configured threshold", () => {
+    // 9% of stake against a 15% threshold is 60% of the way there.
+    const stats = computeSupportStats({
+      ...base,
+      currentSupportLamports: TOTAL * 0.09,
+    });
+    expect(stats.progressPercent).toBeCloseTo(60, 10);
+    expect(stats.supportPercentOfTotal).toBeCloseTo(9, 10);
+    expect(stats.isThresholdMet).toBe(false);
+    expect(stats.remainingLamports).toBeCloseTo(TOTAL * 0.06, 0);
+  });
+
+  it("meets the threshold exactly at the configured percentage", () => {
+    const stats = computeSupportStats({
+      ...base,
+      currentSupportLamports: TOTAL * 0.15,
+    });
+    expect(stats.isThresholdMet).toBe(true);
+    expect(stats.remainingLamports).toBe(0);
+  });
+
+  it("does not report success before validator stake is known", () => {
+    // Regression: validator stake arrives from a separate query, so the required
+    // threshold is 0 on first paint and `support >= 0` was true — the panel
+    // showed "Support threshold reached! Proposal advancing to next phase."
+    const stats = computeSupportStats({
+      ...base,
+      currentSupportLamports: TOTAL * 0.01,
+      totalStakedLamports: 0,
+    });
+    expect(stats.isThresholdMet).toBe(false);
+    expect(stats.progressPercent).toBe(0);
+    expect(stats.supportPercentOfTotal).toBe(0);
+  });
+
+  it("does not divide by a validator count of zero", () => {
+    // Regression: participationPercent was NaN whenever the validator query had
+    // not resolved, which rendered as "NaN%".
+    const stats = computeSupportStats({
+      ...base,
+      validatorCount: 0,
+      numOfValidators: 0,
+    });
+    expect(stats.participationPercent).toBe(0);
+    expect(stats.avgStakePerValidator).toBe(0);
+  });
+
+  it("reports participation against the validator count", () => {
+    const stats = computeSupportStats({
+      ...base,
+      currentSupportLamports: TOTAL * 0.2,
+      validatorCount: 25,
+      numOfValidators: 100,
+    });
+    expect(stats.participationPercent).toBe(25);
+    expect(stats.avgStakePerValidator).toBeCloseTo((TOTAL * 0.2) / 25, 0);
+  });
+
+  it("allows progress to exceed 100% once the threshold is passed", () => {
+    const stats = computeSupportStats({
+      ...base,
+      currentSupportLamports: TOTAL * 0.3,
+    });
+    expect(stats.progressPercent).toBeCloseTo(200, 10);
+    expect(stats.isThresholdMet).toBe(true);
+  });
+});

--- a/frontend/src/components/proposals/detail/support-phase-progress/index.tsx
+++ b/frontend/src/components/proposals/detail/support-phase-progress/index.tsx
@@ -20,6 +20,7 @@ import { PhaseStatusBadge } from "./PhaseStatusBadge";
 import { SupportDonut } from "./SupportDonut";
 import { StatBadge, StatCard } from "./StatCard";
 import { TimeRemainingCarousel } from "./TimeRemainingCarousel";
+import { computeSupportStats } from "./stats";
 
 /** Mock total active staked SOL across the network (in lamports) */
 // const MOCK_TOTAL_STAKED_LAMPORTS = 316_010_000 * LAMPORTS_PER_SOL; // 316.01M SOL
@@ -79,64 +80,25 @@ export function SupportPhaseProgress({ proposal }: SupportPhaseProgressProps) {
 
   const configData = governanceConfigQuery.data;
 
-  const stats = useMemo(() => {
-    // Use proposal's clusterSupportLamports as current support
-    const currentSupportLamports = proposal.clusterSupportLamports;
-    const totalStakedLamports = validatorsStake;
-    // Support threshold comes from the on-chain GlobalConfig; falls back to
-    // the current mainnet default until the config loads.
-    const thresholdPercent = supportThresholdPercentFromConfig(configData);
-
-    // Calculate required threshold in lamports
-    const requiredThresholdLamports =
-      totalStakedLamports * (thresholdPercent / 100);
-
-    // Progress toward threshold (can exceed 100%)
-    const progressPercent =
-      requiredThresholdLamports > 0
-        ? (currentSupportLamports / requiredThresholdLamports) * 100
-        : 0;
-
-    // Support as percent of total staked
-    const supportPercentOfTotal =
-      totalStakedLamports > 0
-        ? (currentSupportLamports / totalStakedLamports) * 100
-        : 0;
-
-    // Remaining SOL needed (0 if threshold met)
-    const remainingLamports = Math.max(
-      0,
-      requiredThresholdLamports - currentSupportLamports,
-    );
-
-    // Is threshold met?
-    const isThresholdMet = currentSupportLamports >= requiredThresholdLamports;
-
-    const validatorCount = supportAccounts.length;
-    const participationPercent = (validatorCount / numOfValidators) * 100;
-    const avgStakePerValidator =
-      validatorCount > 0 ? currentSupportLamports / validatorCount : 0;
-
-    return {
-      currentSupportLamports,
-      totalStakedLamports,
-      requiredThresholdLamports,
-      thresholdPercent,
-      progressPercent,
-      supportPercentOfTotal,
-      remainingLamports,
-      isThresholdMet,
-      validatorCount,
-      participationPercent,
-      avgStakePerValidator,
-    };
-  }, [
-    configData,
-    numOfValidators,
-    proposal.clusterSupportLamports,
-    supportAccounts.length,
-    validatorsStake,
-  ]);
+  const stats = useMemo(
+    () =>
+      computeSupportStats({
+        currentSupportLamports: proposal.clusterSupportLamports,
+        totalStakedLamports: validatorsStake,
+        // Support threshold comes from the on-chain GlobalConfig; falls back to
+        // the current mainnet default until the config loads.
+        thresholdPercent: supportThresholdPercentFromConfig(configData),
+        validatorCount: supportAccounts.length,
+        numOfValidators,
+      }),
+    [
+      configData,
+      numOfValidators,
+      proposal.clusterSupportLamports,
+      supportAccounts.length,
+      validatorsStake,
+    ],
+  );
 
   // Determine banner state
   const showBanner = stats.progressPercent >= 80 || stats.isThresholdMet;

--- a/frontend/src/components/proposals/detail/support-phase-progress/index.tsx
+++ b/frontend/src/components/proposals/detail/support-phase-progress/index.tsx
@@ -146,8 +146,9 @@ export function SupportPhaseProgress({ proposal }: SupportPhaseProgressProps) {
         {/* Donut Chart */}
         <div className="flex flex-1 items-center justify-center">
           <SupportDonut
-            currentSupportLamports={stats.currentSupportLamports}
-            requiredThresholdLamports={stats.requiredThresholdLamports}
+            progressPercent={stats.progressPercent}
+            isThresholdMet={stats.isThresholdMet}
+            remainingLamports={stats.remainingLamports}
           />
         </div>
 

--- a/frontend/src/components/proposals/detail/support-phase-progress/stats.ts
+++ b/frontend/src/components/proposals/detail/support-phase-progress/stats.ts
@@ -51,11 +51,13 @@ export function computeSupportStats({
     requiredThresholdLamports - currentSupportLamports,
   );
 
-  // A required threshold of 0 means validator stake has not loaded yet, not
-  // that the bar has been cleared. Without the guard any support satisfies
-  // `>= 0`, so the panel claims success on first paint.
+  // Gate on total stake, not on the derived threshold: a zero threshold has two
+  // very different causes. Stake not loaded yet means nothing is known, and
+  // `support >= 0` would claim success on first paint. A configured 0% (the
+  // program permits 0..=10000 bps) genuinely is satisfied by any support, which
+  // is what the on-chain check does, so it must still report met.
   const isThresholdMet =
-    requiredThresholdLamports > 0 &&
+    totalStakedLamports > 0 &&
     currentSupportLamports >= requiredThresholdLamports;
 
   const participationPercent =

--- a/frontend/src/components/proposals/detail/support-phase-progress/stats.ts
+++ b/frontend/src/components/proposals/detail/support-phase-progress/stats.ts
@@ -1,0 +1,79 @@
+export interface SupportStatsInput {
+  currentSupportLamports: number;
+  totalStakedLamports: number;
+  /** Already resolved via `supportThresholdPercentFromConfig`. */
+  thresholdPercent: number;
+  validatorCount: number;
+  numOfValidators: number;
+}
+
+export interface SupportStats {
+  currentSupportLamports: number;
+  totalStakedLamports: number;
+  requiredThresholdLamports: number;
+  thresholdPercent: number;
+  progressPercent: number;
+  supportPercentOfTotal: number;
+  remainingLamports: number;
+  isThresholdMet: boolean;
+  validatorCount: number;
+  participationPercent: number;
+  avgStakePerValidator: number;
+}
+
+/**
+ * Support-phase figures for the proposal detail page. Pure so the zero states
+ * are testable: validator stake and the supporter list arrive from separate
+ * queries, and either being absent must not read as progress.
+ */
+export function computeSupportStats({
+  currentSupportLamports,
+  totalStakedLamports,
+  thresholdPercent,
+  validatorCount,
+  numOfValidators,
+}: SupportStatsInput): SupportStats {
+  const requiredThresholdLamports =
+    totalStakedLamports * (thresholdPercent / 100);
+
+  const progressPercent =
+    requiredThresholdLamports > 0
+      ? (currentSupportLamports / requiredThresholdLamports) * 100
+      : 0;
+
+  const supportPercentOfTotal =
+    totalStakedLamports > 0
+      ? (currentSupportLamports / totalStakedLamports) * 100
+      : 0;
+
+  const remainingLamports = Math.max(
+    0,
+    requiredThresholdLamports - currentSupportLamports,
+  );
+
+  // A required threshold of 0 means validator stake has not loaded yet, not
+  // that the bar has been cleared. Without the guard any support satisfies
+  // `>= 0`, so the panel claims success on first paint.
+  const isThresholdMet =
+    requiredThresholdLamports > 0 &&
+    currentSupportLamports >= requiredThresholdLamports;
+
+  const participationPercent =
+    numOfValidators > 0 ? (validatorCount / numOfValidators) * 100 : 0;
+  const avgStakePerValidator =
+    validatorCount > 0 ? currentSupportLamports / validatorCount : 0;
+
+  return {
+    currentSupportLamports,
+    totalStakedLamports,
+    requiredThresholdLamports,
+    thresholdPercent,
+    progressPercent,
+    supportPercentOfTotal,
+    remainingLamports,
+    isThresholdMet,
+    validatorCount,
+    participationPercent,
+    avgStakePerValidator,
+  };
+}


### PR DESCRIPTION
## TLDR

This PR is a follow-up to #118. Two zero-state bugs survive in the same panel: the support page claims "Support threshold reached!" on every first paint, and participation renders `NaN%` until the validator query resolves

## Issues

#118 correctly sourced the threshold from the on-chain config with a 15% fallback, which closed the config route into the first bug. The validator-stake route is still open:

```ts
const isThresholdMet = currentSupportLamports >= requiredThresholdLamports;
```

Validator stake arrives from a separate query, so `requiredThresholdLamports` is `0` on first paint and any support satisfies `>= 0`. The banner is not gated by `isLoading`—that only gates individual stat elements—so every support-phase page load briefly displays "Support threshold reached! Proposal advancing to next phase."

```ts
const participationPercent = (validatorCount / numOfValidators) * 100;
```

`NaN` whenever `numOfValidators` is 0, rendered directly as "NaN%".

## Fix

Extract the panel's figures into a pure `computeSupportStats()` and guard both zero states. The extraction is a faithful move of the block #118 edited; it keeps `supportThresholdPercentFromConfig` and the `configData` memo dependency as introduced there. The only logic changes are the two guards

## Tests
- `pnpm test` → 82 passed, 1 skipped
- `tsc --noEmit` and eslint clean