### PR TITLE
fix: propagate get_bank_from_ledger errors instead of discarding them

### DIFF
--- a/ncn/cli/src/main.rs
+++ b/ncn/cli/src/main.rs
@@ -1199,7 +1199,7 @@ fn main() -> Result<()> {
                 backup_snapshots_dir,
             } = cli.get_snapshot_paths();
 
-            let _ = get_bank_from_ledger(
+            if let Err(e) = get_bank_from_ledger(
                 cli.operator_address,
                 &ledger_path,
                 account_paths,
@@ -1209,7 +1209,11 @@ fn main() -> Result<()> {
                 save_snapshot,
                 backup_snapshots_dir,
                 &cli.cluster,
-            );
+            ) {
+                return Err(anyhow!(
+                    "get_bank_from_ledger FAILED: {:?}", e
+                ));
+            }
         }
         Commands::GenerateMetaMerkle {
             slot,
@@ -1420,7 +1424,7 @@ fn main() -> Result<()> {
                         );
                         let save_snapshot = true;
                         let account_paths = vec![backup_ledger_dir.clone()];
-                        let _ = get_bank_from_ledger(
+                        if let Err(e) = get_bank_from_ledger(
                             cli.operator_address,
                             &backup_ledger_dir,
                             account_paths,
@@ -1430,7 +1434,11 @@ fn main() -> Result<()> {
                             save_snapshot,
                             backup_snapshots_dir.clone(),
                             &cli.cluster,
-                        );
+                        ) {
+                            return Err(anyhow!(
+                                "get_bank_from_ledger FAILED: {:?}", e
+                            ));
+                        }
 
                         if generate_meta_merkle {
                             info!("Generating MetaMerkleSnapshot for slot {}...", slot);


### PR DESCRIPTION
## Problem

Both call sites of `get_bank_from_ledger` in `ncn/cli/src/main.rs` discard the
result with `let _ =`:

- ~line 1202 — `SnapshotSlot` command flow
- ~line 1424 — `await-snapshot` flow

Execution then proceeds unconditionally to `get_bank_from_snapshot_at_slot`,
which raises `MissingSnapshotAtSlot` (`ncn/ledger/src/ledger_utils.rs:46`).
Every bank-load failure therefore surfaces as `Missing snapshot at slot X`,
pointing operators at snapshot discovery rather than the actual fault.

## Impact

Diagnosing this cost six failed runs. After patching both sites to propagate the error, the underlying causes appeared immediately:

1. `LoadBankForksError` → `failed to unpack "accounts/...": IO error: No space left on device (os error 28)` — the accounts unpack needs several hundred GB beyond the copied archives, and the volume exhausted mid-unpack.

2. `GenesisConfigError("Failed to load genesis config: unpack error: IO error:
   No such file or directory (os error 2)")` — `blockstore copy` transfers
   rocksdb column families only, so a fresh `--backup-ledger-dir` has no
   `genesis.bin` / `genesis.tar.bz2`.

Neither is a subtle failure.

## Change

Two sites converted from `let _ = ...` to `if let Err(e) = ... { return
Err(anyhow!(...)) }`. No behavioural change on the success path.

## Verification

Mainnet slot 437036500, CLI v0.4.0-40100, agave-ledger-tool 4.1.2:

- `snapshot-slot` completed in 47 min — bank hash
  `9aL3vC7TWooRaLp9o53bD3i5PXY8Us6zRXmPbmFZTS6K`
- `generate-meta-merkle` completed in 12.7 min — merkle root
  `2oMqHHMoQZdShkEhXhLA5NBy1Lsr68XmUJEohEwZUKEg`, 792 vote accounts,
  1,221,305 stake accounts
- Uploaded to the verifier and confirmed via `/meta` and
  `/proof/vote_account`