### PR TITLE
docs(svmgov): add clone + release tag steps to quick setup

### DIFF
--- a/docs/src/content/svmgov/stakers/index.mdx
+++ b/docs/src/content/svmgov/stakers/index.mdx
@@ -45,7 +45,12 @@ The Merkle proof system ensures that:
 ## Quick Setup
 
 ```bash
-# Install svmgov
+# Clone the repo and check out the latest release tag
+git clone https://github.com/solana-foundation/solana-governance.git
+cd solana-governance
+git checkout "$(git describe --tags --abbrev=0 --match 'v*')"
+
+# Build and install svmgov
 cd svmgov/cli && ./install.sh
 
 # Run interactive setup
@@ -55,6 +60,10 @@ svmgov init
 # Optional: override the default operator API URL
 svmgov config set operator-api-url https://your-operator-api.example.com
 ```
+
+<Callout type="info">
+  Release tags are named `v<version>` (for example `v0.4.0-40100`) and match the `svmgov` crate version. The `git checkout` above resolves the newest one for you, leaving you on a detached HEAD — expected, and fine for building. To build a specific version instead, pick its tag from <a href="https://github.com/solana-foundation/solana-governance/releases">Releases</a> and check that out by name. `main` is the development branch and can sit ahead of the latest release, so prefer a tag unless you need an unreleased change.
+</Callout>
 
 ## Commands
 

--- a/docs/src/content/svmgov/validators/index.mdx
+++ b/docs/src/content/svmgov/validators/index.mdx
@@ -19,7 +19,12 @@ The `svmgov` CLI provides validators with commands to create and manage governan
 ## Quick Setup
 
 ```bash
-# Install svmgov
+# Clone the repo and check out the latest release tag
+git clone https://github.com/solana-foundation/solana-governance.git
+cd solana-governance
+git checkout "$(git describe --tags --abbrev=0 --match 'v*')"
+
+# Build and install svmgov
 cd svmgov/cli && ./install.sh
 
 # Run interactive setup
@@ -28,6 +33,10 @@ svmgov init
 # Optional: override the default operator API URL
 svmgov config set operator-api-url https://your-operator-api.example.com
 ```
+
+<Callout type="info">
+  Release tags are named `v<version>` (for example `v0.4.0-40100`) and match the `svmgov` crate version. The `git checkout` above resolves the newest one for you, leaving you on a detached HEAD — expected, and fine for building. To build a specific version instead, pick its tag from <a href="https://github.com/solana-foundation/solana-governance/releases">Releases</a> and check that out by name. `main` is the development branch and can sit ahead of the latest release, so prefer a tag unless you need an unreleased change.
+</Callout>
 
 ## Available Commands
 


### PR DESCRIPTION
This PR implements a change based on [validator feedback](https://discord.com/channels/428295358100013066/673718028323782674/1534123634808066081) in the Solana Tech Discord mb-planning channel


Both Quick Setups started at `cd svmgov/cli && ./install.sh`, which assumes a repo that's already cloned and says nothing about which ref to build. Add the clone and checkout steps to the validator and staker pages, and explain the tag convention.

The checkout resolves the newest release tag at run time rather than naming a version, so the pages can't go stale as releases land:

    git checkout "$(git describe --tags --abbrev=0 --match 'v*')"

`--match 'v*'` skips the stray non-release `list` tag. Tags are `v<version>`, match the version in svmgov/cli/Cargo.toml and the program crate, and pushing one triggers .github/workflows/release.yaml, so they're real releases rather than bookmarks. main routinely sits ahead of the latest tag, so "just build main" would silently drift.