### PR TITLE
feat(frontend): split proposal tables by phase and improve stage UX

### DIFF
--- a/frontend/src/components/proposals/proposals-table/Columns.tsx
+++ b/frontend/src/components/proposals/proposals-table/Columns.tsx
@@ -1,99 +1,205 @@
 "use client";
 
-import type {} from "@/components/proposals/proposals-table/ProposalsTable";
 import { ColumnDef } from "@tanstack/react-table";
 import { ChevronDown } from "lucide-react";
 import StatusBadge from "@/components/ui/StatusBadge";
 import LifecycleIndicator from "@/components/ui/LifecycleIndicator";
 import { SortableHeaderButton } from "@/components/SortableHeaderButton";
 import { ProposalRecord } from "@/types";
+import { useGovernanceConfigContext } from "@/contexts/GovernanceConfigContext";
+import {
+  epochConstantsFromGovernanceConfig,
+  getProposalPhaseEpochs,
+} from "@/lib/proposals";
+import {
+  useEpochToDate,
+  useMounted,
+  useValidatorsTotalStakedLamports,
+} from "@/hooks";
+import { calculateVotingEndsIn } from "@/helpers";
 
-// function VotingEndsInCell({ votingEndsIn }: { votingEndsIn: string }) {
-//   const mounted = useMounted();
+function getPhaseEndEpoch(
+  proposal: ProposalRecord,
+  supportEndEpoch: number | undefined,
+  discussionEndEpoch: number | undefined,
+): number | undefined {
+  switch (proposal.status) {
+    case "supporting":
+      return supportEndEpoch;
+    case "discussion":
+      return discussionEndEpoch;
+    case "voting":
+      return proposal.endEpoch || undefined;
+    default:
+      return undefined;
+  }
+}
 
-//   if (!mounted) {
-//     return <span className="text-sm font-medium text-white/60">-</span>;
-//   }
+function RemainingTimeCell({ proposal }: { proposal: ProposalRecord }) {
+  const mounted = useMounted();
+  const governanceConfigQuery = useGovernanceConfigContext();
+  const epochConstants = governanceConfigQuery.data
+    ? epochConstantsFromGovernanceConfig(governanceConfigQuery.data)
+    : undefined;
+  const phaseEpochs =
+    epochConstants !== undefined
+      ? getProposalPhaseEpochs(proposal.creationEpoch, epochConstants)
+      : undefined;
 
-//   const value = calculateVotingEndsIn(votingEndsIn);
-//   return (
-//     <span className="text-sm font-medium text-white/60">{value || "-"}</span>
-//   );
-// }
+  const endEpoch = getPhaseEndEpoch(
+    proposal,
+    phaseEpochs?.supportEndEpoch,
+    phaseEpochs?.discussionEndEpoch,
+  );
 
-export const columns: ColumnDef<ProposalRecord>[] = [
-  {
-    accessorKey: "simd",
-    header: "Proposal SIMD",
-    cell: ({ row }) => (
-      <div className="text-sm font-medium text-white/90">
-        {row.original.simd || "-"}
+  const { data: endsAt, isLoading } = useEpochToDate(endEpoch);
+
+  if (
+    proposal.status === "finalized" ||
+    proposal.status === "failed" ||
+    endEpoch === undefined
+  ) {
+    return <span className="text-sm font-medium text-white/60">-</span>;
+  }
+
+  if (!mounted || isLoading || !endsAt) {
+    return <span className="text-sm font-medium text-white/60">-</span>;
+  }
+
+  const value = calculateVotingEndsIn(endsAt.toISOString());
+  return (
+    <span className="text-sm font-medium text-white/60">{value || "-"}</span>
+  );
+}
+
+function SupportPercentCell({ proposal }: { proposal: ProposalRecord }) {
+  const { totalStakedLamports, isLoading } =
+    useValidatorsTotalStakedLamports();
+
+  if (isLoading || totalStakedLamports <= 0) {
+    return <span className="text-sm font-medium text-white/60">-</span>;
+  }
+
+  const supportPercent =
+    (proposal.clusterSupportLamports / totalStakedLamports) * 100;
+
+  return (
+    <span className="text-sm font-medium text-white/60">
+      {supportPercent.toFixed(1)}%
+    </span>
+  );
+}
+
+const proposalColumn: ColumnDef<ProposalRecord> = {
+  id: "proposal",
+  accessorKey: "title",
+  header: "Proposal",
+  cell: ({ row }) => (
+    <div className="min-w-0 max-w-[18rem] text-left">
+      <div className="truncate text-sm font-medium text-white/90">
+        {row.original.title || "-"}
       </div>
-    ),
-  },
+      {row.original.simd ? (
+        <div className="truncate text-xs text-white/45">
+          SIMD {row.original.simd}
+        </div>
+      ) : null}
+    </div>
+  ),
+};
+
+const lifecycleColumn: ColumnDef<ProposalRecord> = {
+  id: "lifecycleStage",
+  accessorKey: "status",
+  header: ({ column }) => (
+    <SortableHeaderButton column={column} label="Lifecycle Stage" />
+  ),
+  cell: ({ row }) => <LifecycleIndicator status={row.original.status} />,
+};
+
+const remainingTimeColumn: ColumnDef<ProposalRecord> = {
+  id: "remainingTime",
+  header: "Remaining Time",
+  cell: ({ row }) => <RemainingTimeCell proposal={row.original} />,
+};
+
+const statusColumn: ColumnDef<ProposalRecord> = {
+  accessorKey: "status",
+  header: "Status",
+  cell: ({ row }) => <StatusBadge status={row.original.status} />,
+};
+
+const toggleColumn: ColumnDef<ProposalRecord> = {
+  id: "toggle",
+  header: () => null,
+  cell: ({ row }) => (
+    <div className="flex justify-end">
+      <ChevronDown
+        className={`size-4 text-white/60 transition-transform ${
+          row.getIsExpanded() ? "rotate-180" : "rotate-0"
+        }`}
+        aria-hidden
+      />
+    </div>
+  ),
+  size: 56,
+};
+
+export const supportColumns: ColumnDef<ProposalRecord>[] = [
+  proposalColumn,
+  lifecycleColumn,
   {
-    id: "lifecycleStage",
-    accessorKey: "status",
-    header: ({ column }) => (
-      <SortableHeaderButton column={column} label="Lifecycle Stage" />
-    ),
-    cell: ({ row }) => <LifecycleIndicator status={row.original.status} />,
+    id: "supportPercent",
+    accessorFn: (row) => row.clusterSupportLamports,
+    header: "Support (%)",
+    cell: ({ row }) => <SupportPercentCell proposal={row.original} />,
   },
+  remainingTimeColumn,
+  statusColumn,
+  toggleColumn,
+];
+
+export const votingColumns: ColumnDef<ProposalRecord>[] = [
+  proposalColumn,
+  lifecycleColumn,
   {
+    id: "quorumPercent",
     accessorKey: "quorumPercent",
     header: "Quorum (%)",
-    cell: ({ getValue }) => (
+    cell: ({ row }) => (
       <span className="text-sm font-medium text-white/60">
-        {getValue<number>()}
+        {row.original.quorumPercent}
       </span>
     ),
   },
+  remainingTimeColumn,
   {
+    id: "startEpoch",
     accessorKey: "startEpoch",
     header: ({ column }) => (
       <SortableHeaderButton column={column} label="Voting Start" />
     ),
-    cell: ({ row }) => {
-      const value = row.original.startEpoch;
-      return (
-        <span className="text-sm font-medium text-white/60">
-          {value || "-"}
-        </span>
-      );
-    },
+    cell: ({ row }) => (
+      <span className="text-sm font-medium text-white/60">
+        {row.original.startEpoch || "-"}
+      </span>
+    ),
   },
   {
+    id: "endEpoch",
     accessorKey: "endEpoch",
     header: ({ column }) => (
       <SortableHeaderButton column={column} label="Voting End" />
     ),
-    cell: ({ row }) => {
-      const value = row.original.endEpoch;
-      return (
-        <span className="text-sm font-medium text-white/60">
-          {value || "-"}
-        </span>
-      );
-    },
-  },
-  {
-    accessorKey: "status",
-    header: "Status",
-    cell: ({ row }) => <StatusBadge status={row.original.status} />,
-  },
-  {
-    id: "toggle",
-    header: () => null,
     cell: ({ row }) => (
-      <div className="flex justify-end">
-        <ChevronDown
-          className={`size-4 text-white/60 transition-transform ${
-            row.getIsExpanded() ? "rotate-180" : "rotate-0"
-          }`}
-          aria-hidden
-        />
-      </div>
+      <span className="text-sm font-medium text-white/60">
+        {row.original.endEpoch || "-"}
+      </span>
     ),
-    size: 56,
   },
+  statusColumn,
+  toggleColumn,
 ];
+
+/** @deprecated Prefer supportColumns / votingColumns */
+export const columns = supportColumns;

--- a/frontend/src/components/proposals/proposals-table/Columns.tsx
+++ b/frontend/src/components/proposals/proposals-table/Columns.tsx
@@ -75,6 +75,16 @@ function RemainingTimeCell({ proposal }: { proposal: ProposalRecord }) {
   }
 
   const value = calculateVotingEndsIn(endsAt.toISOString());
+  // After startEpoch, status can stay "discussion" until consensusResult
+  // lands. Don't report the phase as ended while the proposal is still active.
+  if (value === "Ended" && proposal.status === "discussion") {
+    return (
+      <span className="text-sm font-medium text-white/60">
+        Awaiting snapshot
+      </span>
+    );
+  }
+
   return (
     <span className="text-sm font-medium text-white/60">{value || "-"}</span>
   );

--- a/frontend/src/components/proposals/proposals-table/Columns.tsx
+++ b/frontend/src/components/proposals/proposals-table/Columns.tsx
@@ -22,12 +22,19 @@ function getPhaseEndEpoch(
   proposal: ProposalRecord,
   supportEndEpoch: number | undefined,
   discussionEndEpoch: number | undefined,
+  snapshotEpoch: number | undefined,
 ): number | undefined {
   switch (proposal.status) {
     case "supporting":
       return supportEndEpoch;
     case "discussion":
-      return discussionEndEpoch;
+      // Discussion lasts until voting starts. When support already succeeded,
+      // that boundary is on-chain startEpoch (includes snapshot epochs after
+      // discussionEndEpoch). Fall back to snapshot/discussion bounds otherwise.
+      if (proposal.startEpoch > 0) {
+        return proposal.startEpoch;
+      }
+      return snapshotEpoch ?? discussionEndEpoch;
     case "voting":
       return proposal.endEpoch || undefined;
     default:
@@ -50,6 +57,7 @@ function RemainingTimeCell({ proposal }: { proposal: ProposalRecord }) {
     proposal,
     phaseEpochs?.supportEndEpoch,
     phaseEpochs?.discussionEndEpoch,
+    phaseEpochs?.snapshotEpoch,
   );
 
   const { data: endsAt, isLoading } = useEpochToDate(endEpoch);

--- a/frontend/src/components/proposals/proposals-table/ExternalProposalPanel.tsx
+++ b/frontend/src/components/proposals/proposals-table/ExternalProposalPanel.tsx
@@ -3,7 +3,7 @@
 import Link from "next/link";
 import { AppButton } from "@/components/ui/AppButton";
 import { GitHubIcon } from "@/components/icons/SvgIcons";
-import { Spade } from "lucide-react";
+import { Circle, Loader, X } from "lucide-react";
 import { useModal } from "@/contexts/ModalContext";
 import {
   Tooltip,
@@ -19,6 +19,12 @@ import { PublicKey } from "@solana/web3.js";
 import { toast } from "sonner";
 import { getProposalDetailPagePath } from "@/helpers/proposalPage";
 import { getVoteModalNames } from "@/lib/governance/role-detection";
+import { useGovernanceConfigContext } from "@/contexts/GovernanceConfigContext";
+import {
+  supportPhaseRequirementCopy,
+  supportThresholdPercentFromConfig,
+} from "@/lib/proposals";
+import { FAILED_PHASE_DETAIL } from "../detail/phase-timeline/constants";
 
 const VOTE_STATE_LABEL: Record<ProposalRecord["status"], string> = {
   supporting: "Supporting",
@@ -26,6 +32,30 @@ const VOTE_STATE_LABEL: Record<ProposalRecord["status"], string> = {
   voting: "In Progress",
   finalized: "Finished",
   failed: "Failed",
+};
+
+const STAGE_ORDER: ProposalStatus[] = [
+  "supporting",
+  "discussion",
+  "voting",
+  "finalized",
+];
+
+const STAGE_LABEL: Record<(typeof STAGE_ORDER)[number], string> = {
+  supporting: "Supporting",
+  discussion: "Discussion",
+  voting: "Voting",
+  finalized: "Finished",
+};
+
+const STAGE_DESCRIPTION: Record<(typeof STAGE_ORDER)[number], string> = {
+  supporting: "",
+  discussion:
+    "The discussion phase covers the 4-5 epoch period while the NCN is created. Voting begins only after this process completes.",
+  voting:
+    "Validators vote on active governance proposals. Delegators can override their validator's vote using stake account verification.",
+  finalized:
+    "Voting period has ended and all votes have been counted. The proposal is finalized and ready for on-chain execution.",
 };
 
 const getVoteStateLabel = (proposal: ProposalRecord): string => {
@@ -77,23 +107,68 @@ function ProposalInfo({ proposal }: { proposal: ProposalRecord }) {
 }
 
 function LifecycleStageBar({ stage }: { stage: ProposalStatus }) {
-  const stages: ProposalStatus[] = [
-    "supporting",
-    "discussion",
-    "voting",
-    "finalized",
-  ];
-  const activeIndex = stages.indexOf(stage);
+  const isFailed = stage === "failed";
+  const activeIndex = isFailed ? 0 : Math.max(STAGE_ORDER.indexOf(stage), 0);
+  const governanceConfigQuery = useGovernanceConfigContext();
+  const thresholdPercent = supportThresholdPercentFromConfig(
+    governanceConfigQuery.data,
+  );
+
+  const getDescription = (value: (typeof STAGE_ORDER)[number]) => {
+    if (isFailed && value === "supporting") {
+      return FAILED_PHASE_DETAIL.body;
+    }
+    if (value === "supporting") {
+      return `${supportPhaseRequirementCopy(thresholdPercent)}.`;
+    }
+    return STAGE_DESCRIPTION[value];
+  };
+
+  // Match LifecycleIndicator: Loader for in-progress stages, Circle for
+  // finalized, X for failed support.
+  const getStageIcon = (value: (typeof STAGE_ORDER)[number]) => {
+    if (isFailed && value === "supporting") {
+      return <X className="size-4 text-white" strokeWidth={2.5} />;
+    }
+    if (value === "finalized") {
+      return <Circle className="size-3 fill-white text-white" />;
+    }
+    return <Loader className="size-4 animate-spin text-white" />;
+  };
 
   return (
-    <div className="flex items-center gap-2">
-      {stages.map((s, index) => (
-        <div
-          key={s}
-          className={`h-1.5 flex-1 rounded-full transition-colors ${
-            index <= activeIndex ? "bg-green-600" : "bg-white/10"
-          }`}
-        />
+    <div className="flex w-full items-center gap-2">
+      {STAGE_ORDER.map((value, index) => (
+        <Tooltip key={value}>
+          <TooltipTrigger asChild>
+            <button
+              type="button"
+              aria-label={`${STAGE_LABEL[value]} stage`}
+              className={`h-2 flex-1 rounded-full transition-transform duration-200 ease-out will-change-transform hover:scale-120 focus-visible:scale-110 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 ${
+                index <= activeIndex
+                  ? "bg-green-600 hover:bg-green-500"
+                  : "bg-white/10 hover:bg-white/30"
+              }`}
+            />
+          </TooltipTrigger>
+          <TooltipContent
+            side="top"
+            sideOffset={8}
+            className="w-[240px] rounded-xl border border-white/10 bg-white/10 px-4 py-3 text-left shadow-xl backdrop-blur-md"
+          >
+            <div className="flex flex-col gap-2">
+              <div className="flex items-center gap-2">
+                {getStageIcon(value)}
+                <p className="text-sm font-semibold text-white">
+                  {STAGE_LABEL[value]}
+                </p>
+              </div>
+              <p className="text-xs leading-[1.5] whitespace-pre-wrap text-white">
+                {getDescription(value)}
+              </p>
+            </div>
+          </TooltipContent>
+        </Tooltip>
       ))}
     </div>
   );
@@ -113,7 +188,7 @@ function VoteActions({
   const { openModal } = useModal();
   const { publicKey } = useWallet();
   const { isLoading: isLoadingWalletRole } = useWalletRole(
-    publicKey?.toBase58()
+    publicKey?.toBase58(),
   );
   const { data: chainVoteAccount, isLoading: isLoadingChainVoteAccount } =
     useChainVoteAccount(publicKey?.toBase58());
@@ -187,9 +262,7 @@ function DiscussionMessage({ proposalId }: { proposalId: string }) {
         variant="outline"
         className="w-full justify-center border-white/15 bg-white/10 text-sm font-medium text-white/75 hover:text-white"
       >
-        <Link href={getProposalDetailPagePath(proposalId)}>
-          View Details
-        </Link>
+        <Link href={getProposalDetailPagePath(proposalId)}>View Details</Link>
       </AppButton>
     </div>
   );
@@ -212,7 +285,7 @@ function VotingPanel({ proposal }: { proposal: ProposalRecord }) {
           <span className="text-lg font-semibold text-white">
             {getVoteStateLabel(proposal)}
           </span>
-          <div className="w-20">
+          <div className="min-w-28 max-w-36 flex-1">
             <LifecycleStageBar stage={proposal.status} />
           </div>
         </div>
@@ -251,7 +324,6 @@ function VotingPanel({ proposal }: { proposal: ProposalRecord }) {
   );
 }
 
-// Main component
 type ExternalProposalPanelProps = {
   proposal: ProposalRecord;
 };
@@ -261,9 +333,6 @@ export default function ExternalProposalPanel({
 }: ExternalProposalPanelProps) {
   return (
     <div className="flex flex-col gap-6 p-6 lg:flex-row lg:items-stretch xl:gap-8">
-      <div className="w-32 shrink-0 self-stretch flex items-center justify-center">
-        <Spade className="size-15 text-muted/70 animate-pulse" />
-      </div>
       <ProposalInfo proposal={proposal} />
       <div className="lg:ml-auto">
         <VotingPanel proposal={proposal} />

--- a/frontend/src/components/proposals/proposals-table/ProposalsTable.tsx
+++ b/frontend/src/components/proposals/proposals-table/ProposalsTable.tsx
@@ -2,6 +2,7 @@
 
 import { AnimatePresence, motion } from "framer-motion";
 import {
+  ColumnDef,
   ColumnFiltersState,
   ExpandedState,
   SortingState,
@@ -15,7 +16,7 @@ import {
 } from "@tanstack/react-table";
 import { Check, ChevronDown } from "lucide-react";
 
-import { columns } from "./Columns";
+import { supportColumns, votingColumns } from "./Columns";
 import {
   Table,
   TableBody,
@@ -34,11 +35,16 @@ import {
 import { Pagination } from "@/components/ui/AppPagniation";
 import { AppButton } from "@/components/ui/AppButton";
 import ExternalProposalPanel from "./ExternalProposalPanel";
-import { ProposalStatus } from "@/types";
+import { ProposalRecord, ProposalStatus } from "@/types";
 import { useProposals } from "@/hooks";
-import { Fragment, useCallback, useEffect, useMemo, useState } from "react";
-
-const TABLE_COLUMNS = columns;
+import {
+  Fragment,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 
 type StatusFilter = "all" | ProposalStatus;
 
@@ -51,11 +57,11 @@ const STATUS_FILTER_LABELS: Record<StatusFilter, string> = {
   failed: "Failed",
 };
 
-const filterOptions: StatusFilter[] = [
+const SUPPORT_FILTER_OPTIONS: StatusFilter[] = ["all", "supporting"];
+const VOTING_FILTER_OPTIONS: StatusFilter[] = [
   "all",
-  "supporting",
-  "discussion",
   "voting",
+  "discussion",
   "finalized",
   "failed",
 ];
@@ -63,16 +69,32 @@ const filterOptions: StatusFilter[] = [
 const getIsExpanded = (state: ExpandedState, rowId: string) =>
   Boolean((state as Record<string, boolean>)[rowId]);
 
-export default function ProposalsTable({ title }: { title: string }) {
+type PhaseTableProps = {
+  title: string;
+  data: ProposalRecord[];
+  columns: ColumnDef<ProposalRecord>[];
+  filterOptions: StatusFilter[];
+  isLoading: boolean;
+  showEligibleOnly: boolean;
+  onShowEligibleOnlyChange: (value: boolean) => void;
+  showEligibleToggle?: boolean;
+};
+
+function PhaseTable({
+  title,
+  data,
+  columns,
+  filterOptions,
+  isLoading,
+  showEligibleOnly,
+  onShowEligibleOnlyChange,
+  showEligibleToggle = false,
+}: PhaseTableProps) {
   const [sorting, setSorting] = useState<SortingState>([]);
   const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([]);
   const [expanded, setExpanded] = useState<ExpandedState>({});
   const [statusFilter, setStatusFilter] = useState<StatusFilter>("all");
-  const [showEligibleOnly, setShowEligibleOnly] = useState(false);
-
-  const { data: proposalsData, isLoading: isLoadingProposals } = useProposals();
-
-  const data = useMemo(() => proposalsData || [], [proposalsData]);
+  const hasInitializedExpand = useRef(false);
 
   const handleExpandedChange = useCallback<OnChangeFn<ExpandedState>>(
     (updater) => {
@@ -81,48 +103,45 @@ export default function ProposalsTable({ title }: { title: string }) {
           typeof updater === "function" ? updater(previous) : updater ?? {};
 
         const openEntries = Object.entries(nextState).filter(([, isOpen]) =>
-          Boolean(isOpen)
+          Boolean(isOpen),
         );
 
         if (openEntries.length === 0) return {};
 
         const newlyOpened = openEntries.find(
-          ([rowId]) => !getIsExpanded(previous, rowId)
+          ([rowId]) => !getIsExpanded(previous, rowId),
         );
         const [rowId] = newlyOpened ?? openEntries[0];
 
         return { [rowId]: true } satisfies ExpandedState;
       });
     },
-    []
+    [],
   );
 
   const handleRowToggle = useCallback((rowId: string) => {
     setExpanded((previous) =>
       getIsExpanded(previous, rowId)
         ? {}
-        : ({ [rowId]: true } satisfies ExpandedState)
+        : ({ [rowId]: true } satisfies ExpandedState),
     );
   }, []);
 
-  const getDefaultExpanded = useCallback((): ExpandedState => {
-    if (data.length === 0) {
-      return {};
-    }
-
-    return { [data[0].id]: true } satisfies ExpandedState;
+  useEffect(() => {
+    hasInitializedExpand.current = false;
+    setExpanded({});
   }, [data]);
 
   useEffect(() => {
-    // Only expand first row on client side after mount
-    if (data.length > 0 && Object.keys(expanded).length === 0) {
-      setExpanded(getDefaultExpanded());
+    if (!hasInitializedExpand.current && data.length > 0) {
+      hasInitializedExpand.current = true;
+      setExpanded({ [data[0].id]: true } satisfies ExpandedState);
     }
-  }, [data, expanded, getDefaultExpanded]);
+  }, [data]);
 
   const table = useReactTable({
     data,
-    columns: TABLE_COLUMNS,
+    columns,
     state: {
       sorting,
       columnFilters,
@@ -147,10 +166,10 @@ export default function ProposalsTable({ title }: { title: string }) {
     setSorting([]);
     setColumnFilters([]);
     setStatusFilter("all");
-    setShowEligibleOnly(false);
-    setExpanded(getDefaultExpanded());
+    onShowEligibleOnlyChange(false);
+    setExpanded({});
     table.setPageIndex(0);
-  }, [getDefaultExpanded, table]);
+  }, [onShowEligibleOnlyChange, table]);
 
   useEffect(() => {
     if (statusFilter !== "all") {
@@ -167,21 +186,23 @@ export default function ProposalsTable({ title }: { title: string }) {
       <div className="flex flex-wrap items-center justify-between gap-4">
         <div className="flex flex-wrap items-center gap-5 text-xs text-white/70">
           <h3 className="h3 font-semibold tracking-wide text-white">{title}</h3>
-          <label className="inline-flex items-center gap-2 font-medium text-sm">
-            <span className="relative flex size-4 items-center justify-center">
-              <input
-                type="checkbox"
-                checked={showEligibleOnly}
-                onChange={(e) => setShowEligibleOnly(e.target.checked)}
-                className="peer size-full appearance-none rounded border border-white/20 bg-transparent transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/50 checked:border-primary/80 checked:bg-primary/90"
-              />
-              <Check
-                strokeWidth={3}
-                className="pointer-events-none absolute size-3 text-black opacity-0 transition-opacity peer-checked:opacity-100"
-              />
-            </span>
-            My Eligible Proposals
-          </label>
+          {showEligibleToggle ? (
+            <label className="inline-flex items-center gap-2 font-medium text-sm">
+              <span className="relative flex size-4 items-center justify-center">
+                <input
+                  type="checkbox"
+                  checked={showEligibleOnly}
+                  onChange={(e) => onShowEligibleOnlyChange(e.target.checked)}
+                  className="peer size-full appearance-none rounded border border-white/20 bg-transparent transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/50 checked:border-primary/80 checked:bg-primary/90"
+                />
+                <Check
+                  strokeWidth={3}
+                  className="pointer-events-none absolute size-3 text-black opacity-0 transition-opacity peer-checked:opacity-100"
+                />
+              </span>
+              My Eligible Proposals
+            </label>
+          ) : null}
         </div>
         <div className="flex flex-wrap items-center gap-3 text-xs text-white/70">
           <div className="hidden sm:block">
@@ -247,7 +268,7 @@ export default function ProposalsTable({ title }: { title: string }) {
                       ? null
                       : flexRender(
                           header.column.columnDef.header,
-                          header.getContext()
+                          header.getContext(),
                         )}
                   </TableHead>
                 ))}
@@ -256,7 +277,7 @@ export default function ProposalsTable({ title }: { title: string }) {
           </TableHeader>
           <TableBody>
             {(() => {
-              if (isLoadingProposals) {
+              if (isLoading) {
                 return (
                   <>
                     {[...Array(4)].map((_, i) => (
@@ -309,14 +330,14 @@ export default function ProposalsTable({ title }: { title: string }) {
                       <TableCell
                         key={cell.id}
                         className={`py-5 px-6 ${
-                          cell.column.id === "simd"
+                          cell.column.id === "proposal"
                             ? "text-left"
                             : "text-center"
                         }`}
                       >
                         {flexRender(
                           cell.column.columnDef.cell,
-                          cell.getContext()
+                          cell.getContext(),
                         )}
                       </TableCell>
                     ))}
@@ -365,6 +386,52 @@ export default function ProposalsTable({ title }: { title: string }) {
           </TableBody>
         </Table>
       </div>
+    </div>
+  );
+}
+
+export default function ProposalsTable({ title: _title }: { title: string }) {
+  const [showEligibleOnly, setShowEligibleOnly] = useState(false);
+  const { data: proposalsData, isLoading: isLoadingProposals } = useProposals();
+
+  const data = useMemo(() => proposalsData || [], [proposalsData]);
+
+  const supportData = useMemo(
+    () => data.filter((proposal) => proposal.status === "supporting"),
+    [data],
+  );
+
+  const votingData = useMemo(
+    () =>
+      data.filter((proposal) =>
+        ["voting", "discussion", "finalized", "failed"].includes(
+          proposal.status,
+        ),
+      ),
+    [data],
+  );
+
+  return (
+    <div className="space-y-12">
+      <PhaseTable
+        title="Support Phase Proposals"
+        data={supportData}
+        columns={supportColumns}
+        filterOptions={SUPPORT_FILTER_OPTIONS}
+        isLoading={isLoadingProposals}
+        showEligibleOnly={showEligibleOnly}
+        onShowEligibleOnlyChange={setShowEligibleOnly}
+        showEligibleToggle
+      />
+      <PhaseTable
+        title="Voting Phase Proposals"
+        data={votingData}
+        columns={votingColumns}
+        filterOptions={VOTING_FILTER_OPTIONS}
+        isLoading={isLoadingProposals}
+        showEligibleOnly={showEligibleOnly}
+        onShowEligibleOnlyChange={setShowEligibleOnly}
+      />
     </div>
   );
 }

--- a/frontend/src/components/proposals/proposals-table/ProposalsTable.tsx
+++ b/frontend/src/components/proposals/proposals-table/ProposalsTable.tsx
@@ -127,17 +127,28 @@ function PhaseTable({
     );
   }, []);
 
-  useEffect(() => {
-    hasInitializedExpand.current = false;
-    setExpanded({});
-  }, [data]);
+  const dataIdsKey = useMemo(
+    () => data.map((proposal) => proposal.id).join(","),
+    [data],
+  );
 
   useEffect(() => {
+    // Expand the first row once when this phase table first has data.
     if (!hasInitializedExpand.current && data.length > 0) {
       hasInitializedExpand.current = true;
       setExpanded({ [data[0].id]: true } satisfies ExpandedState);
     }
   }, [data]);
+
+  useEffect(() => {
+    // Keep the open row across refetches; only clear if that row disappeared.
+    setExpanded((previous) => {
+      const openId = Object.entries(previous).find(([, isOpen]) => isOpen)?.[0];
+      if (!openId) return previous;
+      if (data.some((proposal) => proposal.id === openId)) return previous;
+      return {};
+    });
+  }, [data, dataIdsKey]);
 
   const table = useReactTable({
     data,

--- a/frontend/src/components/proposals/proposals-table/ProposalsTable.tsx
+++ b/frontend/src/components/proposals/proposals-table/ProposalsTable.tsx
@@ -128,7 +128,7 @@ function PhaseTable({
   }, []);
 
   const dataIdsKey = useMemo(
-    () => data.map((proposal) => proposal.id).join(","),
+    () => data.map((proposal) => proposal.publicKey.toBase58()).join(","),
     [data],
   );
 
@@ -136,7 +136,9 @@ function PhaseTable({
     // Expand the first row once when this phase table first has data.
     if (!hasInitializedExpand.current && data.length > 0) {
       hasInitializedExpand.current = true;
-      setExpanded({ [data[0].id]: true } satisfies ExpandedState);
+      setExpanded({
+        [data[0].publicKey.toBase58()]: true,
+      } satisfies ExpandedState);
     }
   }, [data]);
 
@@ -151,7 +153,11 @@ function PhaseTable({
     setExpanded((previous) => {
       const openId = Object.entries(previous).find(([, isOpen]) => isOpen)?.[0];
       if (!openId) return previous;
-      if (data.some((proposal) => proposal.id === openId)) return previous;
+      if (
+        data.some((proposal) => proposal.publicKey.toBase58() === openId)
+      ) {
+        return previous;
+      }
       return {};
     });
   }, [data, dataIdsKey, isLoading]);
@@ -171,7 +177,7 @@ function PhaseTable({
     onSortingChange: setSorting,
     onColumnFiltersChange: setColumnFilters,
     onExpandedChange: handleExpandedChange,
-    getRowId: (row) => row.id,
+    getRowId: (row) => row.publicKey.toBase58(),
     initialState: {
       pagination: {
         pageSize: 5,

--- a/frontend/src/components/proposals/proposals-table/ProposalsTable.tsx
+++ b/frontend/src/components/proposals/proposals-table/ProposalsTable.tsx
@@ -141,14 +141,20 @@ function PhaseTable({
   }, [data]);
 
   useEffect(() => {
-    // Keep the open row across refetches; only clear if that row disappeared.
+    // Ignore transient empty results during query-key transitions / loading.
+    // Only clear expansion when we have a real non-empty dataset that no
+    // longer contains the open row.
+    if (isLoading || data.length === 0) {
+      return;
+    }
+
     setExpanded((previous) => {
       const openId = Object.entries(previous).find(([, isOpen]) => isOpen)?.[0];
       if (!openId) return previous;
       if (data.some((proposal) => proposal.id === openId)) return previous;
       return {};
     });
-  }, [data, dataIdsKey]);
+  }, [data, dataIdsKey, isLoading]);
 
   const table = useReactTable({
     data,

--- a/frontend/src/data/getProposals.ts
+++ b/frontend/src/data/getProposals.ts
@@ -44,10 +44,9 @@ export const getProposals = async (
 
   const currentEpoch = epochInfo.epoch;
 
-  let data = proposalAccs.map((acc, index) =>
+  let data = proposalAccs.map((acc) =>
     mapProposalDto(
       acc,
-      index,
       currentEpoch,
       totalStakedLamports,
       epochConstants,
@@ -73,7 +72,6 @@ export const getProposals = async (
 
 export function mapProposalDto(
   rawAccount: RawProposalAccount,
-  index: number,
   currentEpoch: number,
   totalStakedLamports: number,
   epochConstants: EpochConstants,
@@ -102,10 +100,12 @@ export function mapProposalDto(
   });
 
   const simd = getSimd(raw.description);
+  const publicKey = rawAccount.publicKey;
 
   return {
-    publicKey: rawAccount.publicKey,
-    id: index.toString(),
+    publicKey,
+    // Stable across refetches/reorders — never use array index.
+    id: publicKey.toBase58(),
     simd,
     title: raw.title,
     description: raw.description,


### PR DESCRIPTION
Show support and voting proposals in stacked tables with phase-specific columns, and add stage tooltips with hover feedback in the expanded panel.