### PR TITLE
fix: correct ballot_tallies comment — operator votes are not stake-weighted

### DIFF
--- a/ncn/programs/ncn-snapshot/src/state/ballot_box.rs
+++ b/ncn/programs/ncn-snapshot/src/state/ballot_box.rs
@@ -23,7 +23,8 @@ pub struct BallotBox {
     /// Operator votes
     #[max_len(MAX_OPERATOR_VOTES)]
     pub operator_votes: Vec<OperatorVote>,
-    /// Mapping of ballots votes to stake weight
+    /// Vote counts per distinct ballot. Each whitelisted operator contributes
+    /// one vote; tallies are not stake-weighted.
     #[max_len(MAX_BALLOT_TALLIES)]
     pub ballot_tallies: Vec<BallotTally>,
     /// Timestamp when voting ends. Tie breaker admin will decide the results


### PR DESCRIPTION
The ballot_tallies field comment says "Mapping of ballots votes to stake weight," but tallies are not stake-weighted — and the struct it points to says so directly. BallotTally.tally is documented as "The number of votes for this ballot. Each vote is equally weighted," and is typed u8, which cannot hold a lamport-scale value. cast_vote increments it by one per operator with no stake lookup, and ncn-snapshot's README states that all whitelisted operators have equal voting weight.

Comment-only change; no behavior affected.

Noticed while correcting the same conflation in the root README (#30) and the architecture doc (#36).