### PR TITLE
fix(frontend): The view detail button is no longer blocked

### DIFF
--- a/frontend/src/components/proposals/ProposalCard.tsx
+++ b/frontend/src/components/proposals/ProposalCard.tsx
@@ -28,9 +28,8 @@ interface VotingDetailsProps {
 interface ActionButtonsProps {
   layout: "mobile" | "tablet";
   showModifyButton: boolean;
-  showActionButton: boolean;
-  actionButtonText: string | null;
-  onButtonClick?: MouseEventHandler<HTMLButtonElement>;
+  actionConfig: ProposalActionConfig | null;
+  onAction: (action: ProposalAction) => void;
   disabled?: boolean;
   disabledErrorMessage?: string;
 }
@@ -54,21 +53,39 @@ const getVotingStatusValue = (
   return "Not Started Yet";
 };
 
-const getActionButtonText = (status: ProposalStatus) => {
+/**
+ * Explicit identifier for what a card button does. Dispatching on this —
+ * rather than on the button's rendered text — keeps behavior stable if
+ * labels change, and lets read-only actions skip the wallet gate.
+ */
+type ProposalAction = "cast-vote" | "modify-vote" | "support" | "view-details";
+
+interface ProposalActionConfig {
+  action: ProposalAction;
+  label: string;
+}
+
+const getProposalAction = (
+  status: ProposalStatus,
+): ProposalActionConfig | null => {
   if (status === "voting") {
-    return "Cast Vote";
+    return { action: "cast-vote", label: "Cast Vote" };
   }
 
   if (status === "supporting") {
-    return "Support";
+    return { action: "support", label: "Support" };
   }
 
   if (status === "discussion") {
-    return "View Details";
+    return { action: "view-details", label: "View Details" };
   }
 
   return null;
 };
+
+/** Do not gate navigation actions on the wallet status */
+const actionRequiresWallet = (action: ProposalAction) =>
+  action !== "view-details";
 
 const shouldShowModifyButton = (status: ProposalStatus) => status === "voting";
 
@@ -113,12 +130,12 @@ const VotingDetails = ({ items, layout }: VotingDetailsProps) => {
 const ActionButtons = ({
   layout,
   showModifyButton,
-  showActionButton,
-  actionButtonText,
-  onButtonClick,
+  actionConfig,
+  onAction,
   disabled,
   disabledErrorMessage,
 }: ActionButtonsProps) => {
+  const showActionButton = actionConfig !== null;
   if (!showModifyButton && !showActionButton) {
     return null;
   }
@@ -138,6 +155,13 @@ const ActionButtons = ({
     }
   };
 
+  const makeClickHandler =
+    (action: ProposalAction): MouseEventHandler<HTMLButtonElement> =>
+    (event) => {
+      event.stopPropagation();
+      onAction(action);
+    };
+
   return (
     <div className={containerClassName} onClick={handleDisabledClick}>
       {showModifyButton && (
@@ -146,18 +170,20 @@ const ActionButtons = ({
           variant="outline"
           size="default"
           className={buttonClassName}
-          onClick={onButtonClick}
+          onClick={makeClickHandler("modify-vote")}
           disabled={disabled}
         />
       )}
-      {showActionButton && actionButtonText && (
+      {actionConfig && (
         <AppButton
-          text={actionButtonText}
-          variant={actionButtonText === "View Details" ? "outline" : "gradient"}
+          text={actionConfig.label}
+          variant={
+            actionConfig.action === "view-details" ? "outline" : "gradient"
+          }
           size="default"
           className={buttonClassName}
-          onClick={onButtonClick}
-          disabled={disabled}
+          onClick={makeClickHandler(actionConfig.action)}
+          disabled={disabled && actionRequiresWallet(actionConfig.action)}
         />
       )}
     </div>
@@ -186,8 +212,7 @@ export default function ProposalCard({ proposal }: ProposalCardProps) {
   } = proposal;
 
   const votingStatusValue = getVotingStatusValue(status, endEpoch.toString());
-  const actionButtonText = getActionButtonText(status);
-  const showActionButton = Boolean(actionButtonText);
+  const actionConfig = getProposalAction(status);
   const showModifyButton = shouldShowModifyButton(status);
 
   const detailItems: VotingDetailItem[] = [
@@ -204,9 +229,13 @@ export default function ProposalCard({ proposal }: ProposalCardProps) {
     router.push(getProposalDetailPagePath(publicKey));
   };
 
-  const handleButtonClick: MouseEventHandler<HTMLButtonElement> = (event) => {
-    event.stopPropagation();
-    const buttonText = (event.target as HTMLButtonElement).innerText;
+  const handleAction = (action: ProposalAction) => {
+    const proposalId = publicKey.toBase58();
+
+    if (action === "view-details") {
+      router.push(getProposalDetailPagePath(proposalId));
+      return;
+    }
 
     if (!connected) {
       toast.error(
@@ -223,40 +252,47 @@ export default function ProposalCard({ proposal }: ProposalCardProps) {
       toast.error("Only validators are allowed to support");
       return;
     }
-    const proposalId = publicKey.toBase58();
-    if (buttonText === "Modify Vote" && consensusResult) {
+
+    if (action === "modify-vote" && consensusResult) {
       openModal(modifyModalName, {
         proposalId,
         consensusResult,
       });
-    } else if (buttonText === "Cast Vote" && consensusResult) {
+    } else if (action === "cast-vote" && consensusResult) {
       openModal(castModalName, {
         proposalId,
         consensusResult,
       });
-    } else if (buttonText === "Support") {
+    } else if (action === "support") {
       openModal("support-proposal", { proposalId });
-    } else if (buttonText === "View Details") {
-      router.push(getProposalDetailPagePath(proposalId));
     }
   };
 
+  // Wallet gates only apply to buttons that end in a transaction; a card
+  // whose only action is "View Details" is never disabled.
+  const hasWalletGatedButton =
+    showModifyButton ||
+    (actionConfig !== null && actionRequiresWallet(actionConfig.action));
+
   const disabledActionButtons =
-    !connected ||
-    isLoadingVoteIdentity ||
-    (walletRole === WalletRole.STAKER && proposal.status === "supporting");
+    hasWalletGatedButton &&
+    (!connected ||
+      isLoadingVoteIdentity ||
+      (walletRole === WalletRole.STAKER && proposal.status === "supporting"));
 
   let disabledErrorMessage = "";
-  if (!connected) {
-    disabledErrorMessage =
-      "Wallet not connected, please connect your wallet to be able to perform these actions";
-  } else if (isLoadingVoteIdentity) {
-    disabledErrorMessage = "Loading wallet voting identity";
-  } else if (
-    walletRole === WalletRole.STAKER &&
-    proposal.status === "supporting"
-  ) {
-    disabledErrorMessage = "Only validators are allowed to support";
+  if (disabledActionButtons) {
+    if (!connected) {
+      disabledErrorMessage =
+        "Wallet not connected, please connect your wallet to be able to perform these actions";
+    } else if (isLoadingVoteIdentity) {
+      disabledErrorMessage = "Loading wallet voting identity";
+    } else if (
+      walletRole === WalletRole.STAKER &&
+      proposal.status === "supporting"
+    ) {
+      disabledErrorMessage = "Only validators are allowed to support";
+    }
   }
 
   return (
@@ -294,9 +330,8 @@ export default function ProposalCard({ proposal }: ProposalCardProps) {
         <ActionButtons
           layout="mobile"
           showModifyButton={showModifyButton}
-          showActionButton={showActionButton}
-          actionButtonText={actionButtonText}
-          onButtonClick={handleButtonClick}
+          actionConfig={actionConfig}
+          onAction={handleAction}
           disabled={disabledActionButtons}
           disabledErrorMessage={disabledErrorMessage}
         />
@@ -326,9 +361,8 @@ export default function ProposalCard({ proposal }: ProposalCardProps) {
           <ActionButtons
             layout="tablet"
             showModifyButton={showModifyButton}
-            showActionButton={showActionButton}
-            actionButtonText={actionButtonText}
-            onButtonClick={handleButtonClick}
+            actionConfig={actionConfig}
+            onAction={handleAction}
             disabled={disabledActionButtons}
             disabledErrorMessage={disabledErrorMessage}
           />

--- a/frontend/src/components/proposals/proposals-table/ExternalProposalPanel.tsx
+++ b/frontend/src/components/proposals/proposals-table/ExternalProposalPanel.tsx
@@ -218,25 +218,25 @@ function VotingPanel({ proposal }: { proposal: ProposalRecord }) {
         </div>
       </header>
 
-      {connected ? (
-        <>
-          {isDiscussion && (
-            <DiscussionMessage proposalId={proposal.publicKey.toBase58()} />
-          )}
-          {(isSupporting || isVoting) && (
-            <VoteActions
-              state={proposal.status}
-              proposalId={proposal.publicKey.toBase58()}
-              consensusResult={proposal.consensusResult}
-            />
-          )}
-        </>
+      {/* Discussion is read-only (View Details navigation) — always shown,
+          wallet or not. Only transaction actions are wallet-gated. */}
+      {isDiscussion ? (
+        <DiscussionMessage proposalId={proposal.publicKey.toBase58()} />
+      ) : connected ? (
+        (isSupporting || isVoting) && (
+          <VoteActions
+            state={proposal.status}
+            proposalId={proposal.publicKey.toBase58()}
+            consensusResult={proposal.consensusResult}
+          />
+        )
       ) : (
         <Tooltip>
           <TooltipTrigger asChild>
             <span>
-              {isSupporting ||
-                (isVoting && <VoteActions state={proposal.status} disabled />)}
+              {(isSupporting || isVoting) && (
+                <VoteActions state={proposal.status} disabled />
+              )}
             </span>
           </TooltipTrigger>
           <TooltipContent side="bottom">


### PR DESCRIPTION
The view details button was not rendered on desktop and was not allowed on mobile if the user had not added a wallet. This change allows the view details button to be clicked and show the view details button on desktop