### PR TITLE
feat(svmgov): add support threshold on proposal acc for frontend support

### DIFF
--- a/svmgov/program/programs/svmgov_program/src/instructions/create_proposal.rs
+++ b/svmgov/program/programs/svmgov_program/src/instructions/create_proposal.rs
@@ -15,7 +15,7 @@ use crate::{
     events::ProposalCreated,
     stake_weight_bp,
     state::{GlobalConfig, Proposal, ProposalIndex},
-    utils::is_valid_github_link,
+    utils::{is_valid_github_link, min_stake_threshold},
 };
 
 #[derive(Accounts)]
@@ -107,6 +107,11 @@ impl<'info> CreateProposal<'info> {
             GovernanceError::NotEnoughStake
         );
 
+        let cluster_min_stake = min_stake_threshold(
+            cluster_stake,
+            self.global_config.cluster_support_pct_min_bps,
+        )?;
+
         // Initialize proposal account
         self.proposal.set_inner(Proposal {
             author: self.signer.key(),
@@ -121,6 +126,8 @@ impl<'info> CreateProposal<'info> {
             index: self.proposal_index.current_index + 1,
             proposal_seed: seed,
             vote_account_pubkey: self.spl_vote_account.key(),
+            support_threshold: cluster_min_stake,
+            last_support_epoch: clock.epoch,
             ..Proposal::default()
         });
         self.proposal_index.current_index += 1;

--- a/svmgov/program/programs/svmgov_program/src/instructions/retally_support.rs
+++ b/svmgov/program/programs/svmgov_program/src/instructions/retally_support.rs
@@ -95,6 +95,8 @@ impl<'info> RetallySupport<'info> {
             get_epoch_total_stake(),
             self.global_config.cluster_support_pct_min_bps,
         )?;
+        self.proposal.support_threshold = cluster_min_stake;
+        self.proposal.last_support_epoch = clock.epoch;
 
         let mut snapshot_slot = 0;
         if total >= cluster_min_stake {

--- a/svmgov/program/programs/svmgov_program/src/instructions/support_proposal.rs
+++ b/svmgov/program/programs/svmgov_program/src/instructions/support_proposal.rs
@@ -83,7 +83,7 @@ pub struct SupportProposal<'info> {
 impl<'info> SupportProposal<'info> {
     pub fn support_proposal(&mut self, bumps: &SupportProposalBumps) -> Result<()> {
         let clock = Clock::get()?;
-
+        let current_epoch = clock.epoch;
         // Ensure proposal is eligible for support
         require!(
             self.proposal.voting == false && self.proposal.finalized == false,
@@ -126,18 +126,28 @@ impl<'info> SupportProposal<'info> {
         );
         drop(vote_account_data);
 
-        // Support may span multiple epochs, so stake readings recorded in
-        // earlier epochs are no longer valid: rebuild the ENTIRE tally from
-        // every prior supporter's stake at the *current* epoch (via the
-        // sol_get_epoch_stake syscall — needs only the pubkey, not the
-        // account), then add the new supporter measured at the same epoch.
-        // The supporter list is read zero-copy from the account data.
         let proposal_info = self.proposal.to_account_info();
-        let prior_stake = {
-            let proposal_data = proposal_info.try_borrow_data()?;
-            let supporters = self.proposal.supporters(&proposal_data)?;
-            tally_supporter_stakes(supporters, |pk| get_epoch_stake_for_vote_account(pk))?
-        };
+
+        if current_epoch > self.proposal.last_support_epoch {
+            // update last support epoch to current epoch and epoch stake
+            self.proposal.last_support_epoch = current_epoch;
+            let cluster_min_stake = min_stake_threshold(
+                get_epoch_total_stake(),
+                self.global_config.cluster_support_pct_min_bps,
+            )?;
+            self.proposal.support_threshold = cluster_min_stake;
+
+            // retally only if current epoch != last support epoch
+            // active stake is not supposed to change during the epoch
+            let prior_stake = {
+                let proposal_data = proposal_info.try_borrow_data()?;
+                let supporters = self.proposal.supporters(&proposal_data)?;
+                tally_supporter_stakes(supporters, |pk| get_epoch_stake_for_vote_account(pk))?
+            };
+            self.proposal.cluster_support_lamports = prior_stake;
+        }
+
+
         let supporter_stake = get_epoch_stake_for_vote_account(self.spl_vote_account.key);
         // A supporter must clear the same stake floor as a proposal author.
         // This blocks a zero-/dust-stake spam attack that would otherwise let
@@ -147,7 +157,9 @@ impl<'info> SupportProposal<'info> {
             supporter_stake >= self.global_config.min_proposal_stake_lamports,
             GovernanceError::NotEnoughStake
         );
-        let new_support_stake = prior_stake
+        let new_support_stake = self
+            .proposal
+            .cluster_support_lamports
             .checked_add(supporter_stake)
             .ok_or(GovernanceError::ArithmeticOverflow)?;
 
@@ -172,13 +184,9 @@ impl<'info> SupportProposal<'info> {
         // Threshold is measured against the current epoch's total stake — the
         // same epoch every supporter above was just re-measured at, so
         // numerator and denominator can never mix epochs.
-        let cluster_min_stake = min_stake_threshold(
-            get_epoch_total_stake(),
-            self.global_config.cluster_support_pct_min_bps,
-        )?;
 
         let mut snapshot_slot = 0;
-        if new_support_stake >= cluster_min_stake {
+        if new_support_stake >= self.proposal.support_threshold {
             snapshot_slot = activate_voting(
                 &mut self.proposal,
                 &self.global_config,
@@ -234,11 +242,8 @@ pub(crate) fn activate_voting<'info>(
     // state. The init_ballot_box CPI below is skipped whenever `ballot_box`
     // already exists, so this re-check prevents a proposal from being bound
     // onto an already-finalized ConsensusResult for a past slot.
-    let snapshot_slot = compute_future_snapshot_slot(
-        target_epoch,
-        global_config.snapshot_slot_offset,
-        clock.slot,
-    )?;
+    let snapshot_slot =
+        compute_future_snapshot_slot(target_epoch, global_config.snapshot_slot_offset, clock.slot)?;
 
     // SECURITY: bind `ballot_box` to the exact PDA implied by the snapshot
     // slot so a caller cannot pass an arbitrary non-empty account to skip

--- a/svmgov/program/programs/svmgov_program/src/state/proposal.rs
+++ b/svmgov/program/programs/svmgov_program/src/state/proposal.rs
@@ -33,6 +33,10 @@ pub struct Proposal {
     // Seeds for CPI
     pub proposal_seed: u64,
     pub vote_account_pubkey: Pubkey,
+    // if the `cluster_support_pct_min_bps` changes throughout a support phase
+    // retally should correct the expected support_threshold
+    pub support_threshold: u64,
+    pub last_support_epoch: u64,
     /// Number of supporter entries stored in the account data at the fixed
     /// offset [`Proposal::SUPPORTERS_OFFSET`].
     ///
@@ -109,6 +113,8 @@ impl Default for Proposal {
             proposal_seed: 0,
             vote_account_pubkey: Pubkey::default(),
             num_supporters: 0,
+            last_support_epoch: 0,
+            support_threshold: 0,
         }
     }
 }

--- a/svmgov/program/programs/svmgov_program/tests/common/mod.rs
+++ b/svmgov/program/programs/svmgov_program/tests/common/mod.rs
@@ -146,6 +146,8 @@ pub struct ProposalAccount {
     pub snapshot_slot: u64,
     pub proposal_seed: u64,
     pub vote_account_pubkey: [u8; 32],
+    pub support_threshold: u64,
+    pub last_support_epoch: u64,
     pub num_supporters: u32,
     /// Not part of the Borsh payload: the entries live at the fixed offset
     /// `Proposal::SUPPORTERS_OFFSET` (= 8 + INIT_SPACE, past any slack left


### PR DESCRIPTION
## Problem

There is a slight drift between onchain `get_epoch_total_stake` and offchain sum of all active stake. `get_epoch_total_stake` reports active stake at the end of epoch without rewards, as the offchain calculations report the reward values as well.

## Solution

Track the threshold and epoch for each proposal support for proper front end reporting.

## Changes

- Add `support_threshold` on proposal account, tracks expected threshold for the support phase 
- Add `last_support_epoch` on proposal account, tracks epoch boundaries to support recalculating `support_threshold`
- Retally on support only happens if we cross a epoch boundary from last vote

## Todo

Need to discuss right migration path, or if its even worth the effort.