### PR TITLE
fix(svmgov-cli): Derive Proposal Phase From Onchain State Instead of Creation Epoch

### DIFF
--- a/svmgov/cli/src/utils/commands.rs
+++ b/svmgov/cli/src/utils/commands.rs
@@ -15,6 +15,7 @@ use serde::{Deserialize, Serialize};
 use crate::{
     anchor_client_setup,
     svmgov_program::accounts::{GlobalConfig, Proposal},
+    utils::phase::{epochs_remaining, phase_timeline, proposal_phase, PhaseInputs},
     utils::utils::fetch_global_config,
 };
 
@@ -102,21 +103,10 @@ fn print_proposal_detail(proposal_id: &str, proposal: &Proposal, current_epoch: 
     let cluster_support_sol = proposal.cluster_support_lamports as f64 / 1_000_000_000.0;
     let proposer_stake_bp = proposal.proposer_stake_weight_bp as f64 / 100.0;
 
-    let status = get_proposal_status(proposal, current_epoch, config);
-    let status_display = match status {
-        "support" => "Support",
-        "discussion" => "Discussion",
-        "snapshot" => "Snapshot",
-        "voting" => "Voting",
-        "ended" => "Ended (awaiting finalization)",
-        "finalized" => "Finalized",
-        other => other,
-    };
-
-    // Compute phase boundaries
-    let support_end = proposal.creation_epoch + config.max_support_epochs;
-    let discussion_end = support_end + config.discussion_epochs;
-    let snapshot_end = discussion_end + config.snapshot_epoch_extension;
+    let inputs = phase_inputs(proposal, config);
+    let phase = proposal_phase(&inputs, current_epoch);
+    let status_display = phase.label();
+    let timeline = phase_timeline(&inputs);
 
     table.add_row(vec![Cell::new("Proposal ID"), Cell::new(proposal_id)]);
     table.add_row(vec![Cell::new("Title"), Cell::new(&proposal.title)]);
@@ -134,33 +124,19 @@ fn print_proposal_detail(proposal_id: &str, proposal: &Proposal, current_epoch: 
     table.add_row(vec![
         Cell::new("Phase Timeline"),
         Cell::new(format!(
-            "support: epoch {} | discussion: epochs {}-{} | snapshot: epochs {}-{} | voting: epochs {}-{}",
-            proposal.creation_epoch,
-            proposal.creation_epoch + 1, support_end + config.discussion_epochs,
-            discussion_end + 1, snapshot_end,
-            proposal.start_epoch, proposal.end_epoch,
+            "support: epochs {}-{} | discussion: epochs {}-{} | snapshot: epoch {} | voting: epochs {}-{}{}",
+            timeline.support.0, timeline.support.1,
+            timeline.discussion.0, timeline.discussion.1,
+            timeline.snapshot.0,
+            timeline.voting.0, timeline.voting.1,
+            if timeline.projected { " (projected — set once support crosses)" } else { "" },
         )),
     ]);
 
     // Show epochs remaining for current phase
-    let epochs_remaining = match status {
-        "support" => {
-            let remaining = support_end.saturating_sub(current_epoch);
-            format!("{} epoch(s) until discussion", remaining)
-        }
-        "discussion" => {
-            let remaining = discussion_end.saturating_sub(current_epoch);
-            format!("{} epoch(s) until snapshot", remaining)
-        }
-        "snapshot" => {
-            let remaining = snapshot_end.saturating_sub(current_epoch);
-            format!("{} epoch(s) until voting", remaining)
-        }
-        "voting" => {
-            let remaining = proposal.end_epoch.saturating_sub(current_epoch);
-            format!("{} epoch(s) until voting ends", remaining)
-        }
-        _ => "—".to_string(),
+    let epochs_remaining = match epochs_remaining(&inputs, current_epoch) {
+        Some((remaining, what)) => format!("{} epoch(s) {}", remaining, what),
+        None => "—".to_string(),
     };
     table.add_row(vec![
         Cell::new("Epochs Remaining"),
@@ -261,36 +237,23 @@ struct ProposalOutput {
     creation_timestamp: i64,
 }
 
+/// Bridges the generated account types into the pure phase logic.
+fn phase_inputs(proposal: &Proposal, config: &GlobalConfig) -> PhaseInputs {
+    PhaseInputs {
+        creation_epoch: proposal.creation_epoch,
+        start_epoch: proposal.start_epoch,
+        end_epoch: proposal.end_epoch,
+        voting: proposal.voting,
+        finalized: proposal.finalized,
+        max_support_epochs: config.max_support_epochs,
+        discussion_epochs: config.discussion_epochs,
+        snapshot_epoch_extension: config.snapshot_epoch_extension,
+        voting_epochs: config.voting_epochs,
+    }
+}
+
 fn get_proposal_status(proposal: &Proposal, current_epoch: u64, config: &GlobalConfig) -> &'static str {
-    if proposal.finalized {
-        return "finalized";
-    }
-
-    // Once start_epoch/end_epoch are set (voting flag raised during support),
-    // use those to determine voting/ended phases
-    if proposal.voting && current_epoch >= proposal.end_epoch {
-        return "ended";
-    }
-    if proposal.voting && current_epoch >= proposal.start_epoch {
-        return "voting";
-    }
-
-    // Pre-voting: compute phase boundaries from creation_epoch + config durations
-    let support_end = proposal.creation_epoch + config.max_support_epochs;
-    let discussion_end = support_end + config.discussion_epochs;
-    let snapshot_end = discussion_end + config.snapshot_epoch_extension;
-
-    if current_epoch <= support_end {
-        "support"
-    } else if current_epoch <= discussion_end {
-        "discussion"
-    } else if current_epoch <= snapshot_end {
-        "snapshot"
-    } else {
-        // Past all computed phases but voting hasn't started — still waiting
-        // This can happen if support threshold wasn't reached
-        "support"
-    }
+    proposal_phase(&phase_inputs(proposal, config), current_epoch).id()
 }
 
 pub async fn list_proposals(
@@ -437,15 +400,7 @@ fn print_proposals_table(proposals: &[(Pubkey, Proposal)], current_epoch: u64, c
     }
 
     for (pubkey, proposal) in proposals {
-        let status = match get_proposal_status(proposal, current_epoch, config) {
-            "support" => "Support",
-            "discussion" => "Discussion",
-            "snapshot" => "Snapshot",
-            "voting" => "Voting",
-            "ended" => "Ended",
-            "finalized" => "Finalized",
-            other => other,
-        };
+        let status = proposal_phase(&phase_inputs(proposal, config), current_epoch).label();
 
         // Truncate title if too long
         let title = if proposal.title.len() > 40 {

--- a/svmgov/cli/src/utils/commands.rs
+++ b/svmgov/cli/src/utils/commands.rs
@@ -15,7 +15,7 @@ use serde::{Deserialize, Serialize};
 use crate::{
     anchor_client_setup,
     svmgov_program::accounts::{GlobalConfig, Proposal},
-    utils::phase::{epochs_remaining, phase_timeline, proposal_phase, PhaseInputs},
+    utils::phase::{PhaseInputs, PhaseTimeline, ProposalPhase},
     utils::utils::fetch_global_config,
 };
 
@@ -103,10 +103,9 @@ fn print_proposal_detail(proposal_id: &str, proposal: &Proposal, current_epoch: 
     let cluster_support_sol = proposal.cluster_support_lamports as f64 / 1_000_000_000.0;
     let proposer_stake_bp = proposal.proposer_stake_weight_bp as f64 / 100.0;
 
-    let inputs = phase_inputs(proposal, config);
-    let phase = proposal_phase(&inputs, current_epoch);
-    let status_display = phase.label();
-    let timeline = phase_timeline(&inputs);
+    let inputs = PhaseInputs::new(proposal, config);
+    let status_display = ProposalPhase::new(&inputs, current_epoch).label();
+    let timeline = PhaseTimeline::new(&inputs);
 
     table.add_row(vec![Cell::new("Proposal ID"), Cell::new(proposal_id)]);
     table.add_row(vec![Cell::new("Title"), Cell::new(&proposal.title)]);
@@ -149,7 +148,7 @@ fn print_proposal_detail(proposal_id: &str, proposal: &Proposal, current_epoch: 
     ]);
 
     // Show epochs remaining for current phase
-    let epochs_remaining = match epochs_remaining(&inputs, current_epoch) {
+    let epochs_remaining = match inputs.epochs_remaining(current_epoch) {
         Some((remaining, what)) => format!("{} epoch(s) {}", remaining, what),
         None => "—".to_string(),
     };
@@ -252,23 +251,8 @@ struct ProposalOutput {
     creation_timestamp: i64,
 }
 
-/// Bridges the generated account types into the pure phase logic.
-fn phase_inputs(proposal: &Proposal, config: &GlobalConfig) -> PhaseInputs {
-    PhaseInputs {
-        creation_epoch: proposal.creation_epoch,
-        start_epoch: proposal.start_epoch,
-        end_epoch: proposal.end_epoch,
-        voting: proposal.voting,
-        finalized: proposal.finalized,
-        max_support_epochs: config.max_support_epochs,
-        discussion_epochs: config.discussion_epochs,
-        snapshot_epoch_extension: config.snapshot_epoch_extension,
-        voting_epochs: config.voting_epochs,
-    }
-}
-
 fn get_proposal_status(proposal: &Proposal, current_epoch: u64, config: &GlobalConfig) -> &'static str {
-    proposal_phase(&phase_inputs(proposal, config), current_epoch).id()
+    ProposalPhase::new(&PhaseInputs::new(proposal, config), current_epoch).id()
 }
 
 pub async fn list_proposals(
@@ -415,7 +399,7 @@ fn print_proposals_table(proposals: &[(Pubkey, Proposal)], current_epoch: u64, c
     }
 
     for (pubkey, proposal) in proposals {
-        let status = proposal_phase(&phase_inputs(proposal, config), current_epoch).label();
+        let status = ProposalPhase::new(&PhaseInputs::new(proposal, config), current_epoch).label();
 
         // Truncate title if too long
         let title = if proposal.title.len() > 40 {

--- a/svmgov/cli/src/utils/commands.rs
+++ b/svmgov/cli/src/utils/commands.rs
@@ -124,8 +124,12 @@ fn print_proposal_detail(proposal_id: &str, proposal: &Proposal, current_epoch: 
     table.add_row(vec![
         Cell::new("Phase Timeline"),
         Cell::new(format!(
-            "support: epochs {}-{} | discussion: epochs {}-{} | snapshot: epoch {} | voting: epochs {}-{}{}",
+            "support: epochs {}-{}{} | discussion: epochs {}-{} | snapshot: epoch {} | voting: epochs {}-{}{}",
             timeline.support.0, timeline.support.1,
+            // The crossing epoch belongs to both phases: support closed partway
+            // through it. Say so, rather than leaving what looks like an
+            // off-by-one between the two ranges.
+            if timeline.projected { String::new() } else { format!(" (crossed in {})", timeline.support.1) },
             timeline.discussion.0, timeline.discussion.1,
             timeline.snapshot.0,
             timeline.voting.0, timeline.voting.1,

--- a/svmgov/cli/src/utils/commands.rs
+++ b/svmgov/cli/src/utils/commands.rs
@@ -120,20 +120,31 @@ fn print_proposal_detail(proposal_id: &str, proposal: &Proposal, current_epoch: 
     ]);
     table.add_row(vec![Cell::new("Status"), Cell::new(status_display)]);
 
-    // Show phase timeline
+    // Show phase timeline. Once activated, the epoch support crossed is not
+    // recorded on-chain and cannot be recovered, so the support/discussion
+    // boundary is shown as unknown rather than guessed — see phase.rs.
+    let support_segment = match timeline.support {
+        Some((from, to)) => format!("support: epochs {}-{}", from, to),
+        None => format!("created: epoch {}", timeline.created),
+    };
+    let discussion_segment = match timeline.discussion.0 {
+        Some(from) => format!("discussion: epochs {}-{}", from, timeline.discussion.1),
+        None => format!("discussion: through epoch {}", timeline.discussion.1),
+    };
     table.add_row(vec![
         Cell::new("Phase Timeline"),
         Cell::new(format!(
-            "support: epochs {}-{}{} | discussion: epochs {}-{} | snapshot: epoch {} | voting: epochs {}-{}{}",
-            timeline.support.0, timeline.support.1,
-            // The crossing epoch belongs to both phases: support closed partway
-            // through it. Say so, rather than leaving what looks like an
-            // off-by-one between the two ranges.
-            if timeline.projected { String::new() } else { format!(" (crossed in {})", timeline.support.1) },
-            timeline.discussion.0, timeline.discussion.1,
-            timeline.snapshot.0,
-            timeline.voting.0, timeline.voting.1,
-            if timeline.projected { " (projected — set once support crosses)" } else { "" },
+            "{} | {} | snapshot: epoch {} | voting: epochs {}-{}{}",
+            support_segment,
+            discussion_segment,
+            timeline.snapshot,
+            timeline.voting.0,
+            timeline.voting.1,
+            if timeline.projected {
+                " (projected — set once support crosses)"
+            } else {
+                ""
+            },
         )),
     ]);
 

--- a/svmgov/cli/src/utils/mod.rs
+++ b/svmgov/cli/src/utils/mod.rs
@@ -2,6 +2,7 @@ pub mod api_helpers;
 pub mod commands;
 pub mod config_command;
 pub mod init;
+pub mod phase;
 pub mod proposal_link;
 pub mod squads;
 pub mod utils;

--- a/svmgov/cli/src/utils/phase.rs
+++ b/svmgov/cli/src/utils/phase.rs
@@ -1,19 +1,26 @@
-//! Proposal lifecycle phases, derived from on-chain state.
+//! Placing a proposal in its lifecycle, for display by the CLI.
 //!
-//! The program fixes a proposal's schedule at the moment support crosses the
-//! threshold: `activate_voting` sets `voting`, `start_epoch` and `end_epoch`
-//! from the epoch the crossing happened in, which can be any epoch inside the
-//! support window. A schedule recomputed from `creation_epoch` and the config
-//! durations therefore only matches reality for a proposal that crosses on the
-//! very last epoch of its window — for anything that crosses early it reports
-//! the proposal as still gathering support long after it has advanced.
+//! Answers two questions about a proposal: which phase it is in right now, and
+//! what the epoch boundaries of every phase are. Both are needed by the detail
+//! view, the list table, the `--status` filter and the JSON output, so they live
+//! here rather than being recomputed at each call site.
 //!
-//! So: once `voting` is set, the on-chain epochs are authoritative and the
-//! config model is not consulted. It is used only to project a schedule for a
-//! proposal that has not yet activated.
+//! The program commits a proposal's schedule on-chain the moment support
+//! crosses its threshold, writing `voting`, `start_epoch` and `end_epoch`. Those
+//! fields are the source of truth wherever they are set; the `GlobalConfig`
+//! durations are consulted only to project a schedule for a proposal that has
+//! not activated yet, and that projection is flagged so callers can label it.
+//!
+//! Input is a [`PhaseInputs`] built from the `Proposal` and `GlobalConfig`
+//! accounts — plain values, so the logic is unit-testable without an RPC.
+//! Output is a [`ProposalPhase`] (where it is now), a [`PhaseTimeline`] (the
+//! epoch windows, with anything the chain does not record left as `None`), and
+//! [`PhaseInputs::epochs_remaining`] (how long the current phase has left).
 
-/// Fields needed to place a proposal in its lifecycle. Plain values rather than
-/// the generated account types, so the logic is unit-testable.
+use crate::svmgov_program::accounts::{GlobalConfig, Proposal};
+
+/// Everything needed to place a proposal in its lifecycle, copied off the two
+/// accounts so the logic below does not depend on the generated types.
 #[derive(Debug, Clone, Copy)]
 pub struct PhaseInputs {
     pub creation_epoch: u64,
@@ -25,6 +32,50 @@ pub struct PhaseInputs {
     pub discussion_epochs: u64,
     pub snapshot_epoch_extension: u64,
     pub voting_epochs: u64,
+}
+
+impl PhaseInputs {
+    pub fn new(proposal: &Proposal, config: &GlobalConfig) -> Self {
+        Self {
+            creation_epoch: proposal.creation_epoch,
+            start_epoch: proposal.start_epoch,
+            end_epoch: proposal.end_epoch,
+            voting: proposal.voting,
+            finalized: proposal.finalized,
+            max_support_epochs: config.max_support_epochs,
+            discussion_epochs: config.discussion_epochs,
+            snapshot_epoch_extension: config.snapshot_epoch_extension,
+            voting_epochs: config.voting_epochs,
+        }
+    }
+
+    /// How many epochs until the current phase gives way to the next, with a
+    /// label for what comes after. `None` once the proposal has stopped moving.
+    pub fn epochs_remaining(&self, current_epoch: u64) -> Option<(u64, &'static str)> {
+        let timeline = PhaseTimeline::new(self);
+        match ProposalPhase::new(self, current_epoch) {
+            ProposalPhase::Support => Some((
+                timeline
+                    .support
+                    .map(|(_, end)| end.saturating_sub(current_epoch))
+                    .unwrap_or(0),
+                "until the support window closes",
+            )),
+            ProposalPhase::Discussion => Some((
+                timeline.snapshot.saturating_sub(current_epoch),
+                "until snapshot",
+            )),
+            ProposalPhase::Snapshot => Some((
+                timeline.voting.0.saturating_sub(current_epoch),
+                "until voting opens",
+            )),
+            ProposalPhase::Voting => Some((
+                self.end_epoch.saturating_sub(current_epoch),
+                "until voting ends",
+            )),
+            ProposalPhase::Ended | ProposalPhase::Finalized | ProposalPhase::Failed => None,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -39,6 +90,40 @@ pub enum ProposalPhase {
 }
 
 impl ProposalPhase {
+    /// The phase `p` is in at `current_epoch`.
+    pub fn new(p: &PhaseInputs, current_epoch: u64) -> Self {
+        if p.finalized {
+            return Self::Finalized;
+        }
+
+        if p.voting {
+            // Support succeeded and the program pinned the schedule, so the
+            // config model is not consulted from here on.
+            if current_epoch >= p.end_epoch {
+                return Self::Ended;
+            }
+            if current_epoch >= p.start_epoch {
+                return Self::Voting;
+            }
+            // The snapshot is taken in the epoch immediately before voting
+            // opens. Written as an addition so a start_epoch of 0 cannot
+            // underflow.
+            if current_epoch + 1 >= p.start_epoch {
+                return Self::Snapshot;
+            }
+            return Self::Discussion;
+        }
+
+        // Not activated. The program only accepts support inside
+        // [creation_epoch, creation_epoch + max_support_epochs]; past that with
+        // `voting` still unset, the proposal can never advance.
+        if current_epoch <= p.creation_epoch.saturating_add(p.max_support_epochs) {
+            Self::Support
+        } else {
+            Self::Failed
+        }
+    }
+
     pub fn label(self) -> &'static str {
         match self {
             Self::Support => "Support",
@@ -65,38 +150,6 @@ impl ProposalPhase {
     }
 }
 
-pub fn proposal_phase(p: &PhaseInputs, current_epoch: u64) -> ProposalPhase {
-    if p.finalized {
-        return ProposalPhase::Finalized;
-    }
-
-    if p.voting {
-        // Support succeeded and the program pinned the schedule. Nothing here
-        // may fall back to the config model.
-        if current_epoch >= p.end_epoch {
-            return ProposalPhase::Ended;
-        }
-        if current_epoch >= p.start_epoch {
-            return ProposalPhase::Voting;
-        }
-        // The snapshot is taken in the epoch immediately before voting opens.
-        // Written as an addition so a start_epoch of 0 cannot underflow.
-        if current_epoch + 1 >= p.start_epoch {
-            return ProposalPhase::Snapshot;
-        }
-        return ProposalPhase::Discussion;
-    }
-
-    // Not activated. The program only accepts support inside
-    // [creation_epoch, creation_epoch + max_support_epochs]; past that with
-    // `voting` still unset, the proposal can never advance.
-    if current_epoch <= p.creation_epoch.saturating_add(p.max_support_epochs) {
-        ProposalPhase::Support
-    } else {
-        ProposalPhase::Failed
-    }
-}
-
 /// Epoch ranges for each phase.
 ///
 /// The epoch support crossed the threshold is **not recorded on-chain** and
@@ -116,68 +169,44 @@ pub struct PhaseTimeline {
     pub discussion: (Option<u64>, u64),
     pub snapshot: u64,
     pub voting: (u64, u64),
+    /// The windows were projected from the config because the proposal has not
+    /// activated; they move if it crosses earlier than its window's last epoch.
     pub projected: bool,
 }
 
-pub fn phase_timeline(p: &PhaseInputs) -> PhaseTimeline {
-    if p.voting {
-        // Everything here comes straight from stored state. `start_epoch - 1`
-        // is the snapshot epoch by construction in *both* the activate_voting
-        // and flush_merkle_root paths, so it survives a re-anchor.
-        let snapshot = p.start_epoch.saturating_sub(1);
-        return PhaseTimeline {
+impl PhaseTimeline {
+    pub fn new(p: &PhaseInputs) -> Self {
+        if p.voting {
+            // Everything here comes straight from stored state. `start_epoch - 1`
+            // is the snapshot epoch by construction in *both* the activate_voting
+            // and flush_merkle_root paths, so it survives a re-anchor.
+            let snapshot = p.start_epoch.saturating_sub(1);
+            return Self {
+                created: p.creation_epoch,
+                support: None,
+                discussion: (None, snapshot.saturating_sub(1)),
+                snapshot,
+                voting: (p.start_epoch, p.end_epoch),
+                projected: false,
+            };
+        }
+
+        // Not activated: project from the config, assuming the latest epoch it
+        // could still cross.
+        let crossing = p.creation_epoch.saturating_add(p.max_support_epochs);
+        let snapshot = crossing
+            .saturating_add(p.discussion_epochs)
+            .saturating_add(p.snapshot_epoch_extension);
+        let voting_start = snapshot.saturating_add(1);
+
+        Self {
             created: p.creation_epoch,
-            support: None,
-            discussion: (None, snapshot.saturating_sub(1)),
+            support: Some((p.creation_epoch, crossing)),
+            discussion: (Some(crossing), snapshot.saturating_sub(1)),
             snapshot,
-            voting: (p.start_epoch, p.end_epoch),
-            projected: false,
-        };
-    }
-
-    // Not activated: project from the config, assuming the latest epoch it
-    // could still cross. Marked projected, and re-derived on every call, so a
-    // config change simply produces a new projection.
-    let crossing = p.creation_epoch.saturating_add(p.max_support_epochs);
-    let snapshot = crossing
-        .saturating_add(p.discussion_epochs)
-        .saturating_add(p.snapshot_epoch_extension);
-    let voting_start = snapshot.saturating_add(1);
-
-    PhaseTimeline {
-        created: p.creation_epoch,
-        support: Some((p.creation_epoch, crossing)),
-        discussion: (Some(crossing), snapshot.saturating_sub(1)),
-        snapshot,
-        voting: (voting_start, voting_start.saturating_add(p.voting_epochs)),
-        projected: true,
-    }
-}
-
-/// How many epochs until the current phase gives way to the next.
-pub fn epochs_remaining(p: &PhaseInputs, current_epoch: u64) -> Option<(u64, &'static str)> {
-    let timeline = phase_timeline(p);
-    match proposal_phase(p, current_epoch) {
-        ProposalPhase::Support => Some((
-            timeline
-                .support
-                .map(|(_, end)| end.saturating_sub(current_epoch))
-                .unwrap_or(0),
-            "until the support window closes",
-        )),
-        ProposalPhase::Discussion => Some((
-            timeline.snapshot.saturating_sub(current_epoch),
-            "until snapshot",
-        )),
-        ProposalPhase::Snapshot => Some((
-            timeline.voting.0.saturating_sub(current_epoch),
-            "until voting opens",
-        )),
-        ProposalPhase::Voting => Some((
-            p.end_epoch.saturating_sub(current_epoch),
-            "until voting ends",
-        )),
-        ProposalPhase::Ended | ProposalPhase::Finalized | ProposalPhase::Failed => None,
+            voting: (voting_start, voting_start.saturating_add(p.voting_epochs)),
+            projected: true,
+        }
     }
 }
 
@@ -208,16 +237,16 @@ mod tests {
         // discussion" for a proposal that had already advanced, because
         // current_epoch was still inside the config-derived support window.
         let p = double_disinflation();
-        assert_eq!(proposal_phase(&p, 1012), ProposalPhase::Discussion);
+        assert_eq!(ProposalPhase::new(&p, 1012), ProposalPhase::Discussion);
         assert_eq!(
-            epochs_remaining(&p, 1012).map(|(n, _)| n),
+            p.epochs_remaining(1012).map(|(n, _)| n),
             Some(8) // 1020 - 1012
         );
     }
 
     #[test]
     fn an_activated_timeline_uses_only_stored_state() {
-        let t = phase_timeline(&double_disinflation());
+        let t = PhaseTimeline::new(&double_disinflation());
         assert!(!t.projected);
         assert_eq!(t.created, 1011);
         // The epoch support crossed is not recorded on-chain, so it is not
@@ -241,7 +270,7 @@ mod tests {
             end_epoch: 1020,
             ..double_disinflation()
         };
-        let t = phase_timeline(&flushed);
+        let t = PhaseTimeline::new(&flushed);
         assert_eq!(t.support, None);
         assert_eq!(t.discussion.0, None);
         // What is printed stays correct across the re-anchor.
@@ -255,8 +284,8 @@ mod tests {
         // update_config can change durations after activation; the stored epochs
         // were computed with the old ones, so the timeline must not depend on
         // whatever the config says now.
-        let base = phase_timeline(&double_disinflation());
-        let reconfigured = phase_timeline(&PhaseInputs {
+        let base = PhaseTimeline::new(&double_disinflation());
+        let reconfigured = PhaseTimeline::new(&PhaseInputs {
             discussion_epochs: 2,
             snapshot_epoch_extension: 4,
             max_support_epochs: 1,
@@ -270,17 +299,17 @@ mod tests {
         // The bug this module exists to fix was a timeline that disagreed with
         // the reported status, so pin that they cannot drift apart.
         let p = double_disinflation();
-        let t = phase_timeline(&p);
+        let t = PhaseTimeline::new(&p);
         for epoch in t.discussion.0.unwrap_or(t.created)..=t.discussion.1 {
             assert_eq!(
-                proposal_phase(&p, epoch),
+                ProposalPhase::new(&p, epoch),
                 ProposalPhase::Discussion,
                 "epoch {epoch} is inside the discussion window"
             );
         }
-        assert_eq!(proposal_phase(&p, t.snapshot), ProposalPhase::Snapshot);
+        assert_eq!(ProposalPhase::new(&p, t.snapshot), ProposalPhase::Snapshot);
         for epoch in t.voting.0..t.voting.1 {
-            assert_eq!(proposal_phase(&p, epoch), ProposalPhase::Voting);
+            assert_eq!(ProposalPhase::new(&p, epoch), ProposalPhase::Voting);
         }
     }
 
@@ -297,7 +326,7 @@ mod tests {
                 ..double_disinflation()
             },
         ] {
-            let t = phase_timeline(&p);
+            let t = PhaseTimeline::new(&p);
             if let Some((from, to)) = t.support {
                 assert!(from <= to);
                 assert!(to <= t.discussion.0.unwrap_or(to));
@@ -312,12 +341,12 @@ mod tests {
     #[test]
     fn walks_the_whole_lifecycle() {
         let p = double_disinflation();
-        assert_eq!(proposal_phase(&p, 1011), ProposalPhase::Discussion);
-        assert_eq!(proposal_phase(&p, 1019), ProposalPhase::Discussion);
-        assert_eq!(proposal_phase(&p, 1020), ProposalPhase::Snapshot);
-        assert_eq!(proposal_phase(&p, 1021), ProposalPhase::Voting);
-        assert_eq!(proposal_phase(&p, 1023), ProposalPhase::Voting);
-        assert_eq!(proposal_phase(&p, 1024), ProposalPhase::Ended);
+        assert_eq!(ProposalPhase::new(&p, 1011), ProposalPhase::Discussion);
+        assert_eq!(ProposalPhase::new(&p, 1019), ProposalPhase::Discussion);
+        assert_eq!(ProposalPhase::new(&p, 1020), ProposalPhase::Snapshot);
+        assert_eq!(ProposalPhase::new(&p, 1021), ProposalPhase::Voting);
+        assert_eq!(ProposalPhase::new(&p, 1023), ProposalPhase::Voting);
+        assert_eq!(ProposalPhase::new(&p, 1024), ProposalPhase::Ended);
     }
 
     #[test]
@@ -328,8 +357,8 @@ mod tests {
             end_epoch: 0,
             ..double_disinflation()
         };
-        assert_eq!(proposal_phase(&p, 1011), ProposalPhase::Support);
-        assert_eq!(proposal_phase(&p, 1018), ProposalPhase::Support);
+        assert_eq!(ProposalPhase::new(&p, 1011), ProposalPhase::Support);
+        assert_eq!(ProposalPhase::new(&p, 1018), ProposalPhase::Support);
     }
 
     #[test]
@@ -343,8 +372,8 @@ mod tests {
             end_epoch: 0,
             ..double_disinflation()
         };
-        assert_eq!(proposal_phase(&p, 1019), ProposalPhase::Failed);
-        assert_eq!(epochs_remaining(&p, 1019), None);
+        assert_eq!(ProposalPhase::new(&p, 1019), ProposalPhase::Failed);
+        assert_eq!(p.epochs_remaining(1019), None);
     }
 
     #[test]
@@ -355,7 +384,7 @@ mod tests {
             end_epoch: 0,
             ..double_disinflation()
         };
-        let t = phase_timeline(&p);
+        let t = PhaseTimeline::new(&p);
         assert!(t.projected);
         // Latest possible crossing is the last epoch of the support window.
         assert_eq!(t.support, Some((1011, 1018)));
@@ -370,8 +399,8 @@ mod tests {
             finalized: true,
             ..double_disinflation()
         };
-        assert_eq!(proposal_phase(&p, 1012), ProposalPhase::Finalized);
-        assert_eq!(epochs_remaining(&p, 1012), None);
+        assert_eq!(ProposalPhase::new(&p, 1012), ProposalPhase::Finalized);
+        assert_eq!(p.epochs_remaining(1012), None);
     }
 
     #[test]
@@ -384,7 +413,7 @@ mod tests {
             ..double_disinflation()
         };
         // end_epoch 0 means current >= end, so this is Ended rather than a panic.
-        assert_eq!(proposal_phase(&p, 0), ProposalPhase::Ended);
-        let _ = phase_timeline(&p);
+        assert_eq!(ProposalPhase::new(&p, 0), ProposalPhase::Ended);
+        let _ = PhaseTimeline::new(&p);
     }
 }

--- a/svmgov/cli/src/utils/phase.rs
+++ b/svmgov/cli/src/utils/phase.rs
@@ -97,56 +97,60 @@ pub fn proposal_phase(p: &PhaseInputs, current_epoch: u64) -> ProposalPhase {
     }
 }
 
-/// Inclusive epoch ranges for each phase. `projected` marks a schedule inferred
-/// from the config because the proposal has not activated yet — those epochs
-/// will shift if it crosses the threshold earlier than the window's last epoch.
+/// Epoch ranges for each phase.
+///
+/// The epoch support crossed the threshold is **not recorded on-chain** and
+/// cannot be recovered from `start_epoch`: `flush_merkle_root` re-anchors with a
+/// different formula from `activate_voting` (it omits `discussion_epochs`), and
+/// `update_config` can change the durations after a proposal has activated.
+/// Inverting the activation formula against a flushed or reconfigured proposal
+/// produces a crossing epoch that can predate the proposal itself. So once
+/// activated, the support window's end and the discussion window's start are
+/// reported as unknown rather than guessed.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct PhaseTimeline {
-    pub support: (u64, u64),
-    pub discussion: (u64, u64),
-    pub snapshot: (u64, u64),
+    pub created: u64,
+    /// `None` once activated — see the note above.
+    pub support: Option<(u64, u64)>,
+    /// Start is `None` once activated; the end is always known.
+    pub discussion: (Option<u64>, u64),
+    pub snapshot: u64,
     pub voting: (u64, u64),
     pub projected: bool,
 }
 
 pub fn phase_timeline(p: &PhaseInputs) -> PhaseTimeline {
-    // The epoch support crossed the threshold. `activate_voting` computes
-    // start_epoch = crossing + discussion_epochs + snapshot_epoch_extension + 1,
-    // so inverting it recovers the crossing epoch from on-chain state alone.
-    let crossing = if p.voting {
-        p.start_epoch
-            .saturating_sub(1)
-            .saturating_sub(p.discussion_epochs)
-            .saturating_sub(p.snapshot_epoch_extension)
-    } else {
-        // Not activated: project the latest it could still cross.
-        p.creation_epoch.saturating_add(p.max_support_epochs)
-    };
+    if p.voting {
+        // Everything here comes straight from stored state. `start_epoch - 1`
+        // is the snapshot epoch by construction in *both* the activate_voting
+        // and flush_merkle_root paths, so it survives a re-anchor.
+        let snapshot = p.start_epoch.saturating_sub(1);
+        return PhaseTimeline {
+            created: p.creation_epoch,
+            support: None,
+            discussion: (None, snapshot.saturating_sub(1)),
+            snapshot,
+            voting: (p.start_epoch, p.end_epoch),
+            projected: false,
+        };
+    }
 
-    // Discussion begins in the crossing epoch itself: support closed partway
-    // through it, so that epoch is the tail of support and the head of
-    // discussion. `proposal_phase` reports Discussion there, and the timeline
-    // has to agree. Running discussion to the epoch before the snapshot keeps
-    // the two definitions in step for every epoch in between.
-    let snapshot_epoch = crossing
+    // Not activated: project from the config, assuming the latest epoch it
+    // could still cross. Marked projected, and re-derived on every call, so a
+    // config change simply produces a new projection.
+    let crossing = p.creation_epoch.saturating_add(p.max_support_epochs);
+    let snapshot = crossing
         .saturating_add(p.discussion_epochs)
         .saturating_add(p.snapshot_epoch_extension);
-    let discussion_start = crossing;
-    let discussion_end = snapshot_epoch.saturating_sub(1);
-
-    let (voting_start, voting_end) = if p.voting {
-        (p.start_epoch, p.end_epoch)
-    } else {
-        let start = snapshot_epoch.saturating_add(1);
-        (start, start.saturating_add(p.voting_epochs))
-    };
+    let voting_start = snapshot.saturating_add(1);
 
     PhaseTimeline {
-        support: (p.creation_epoch, crossing),
-        discussion: (discussion_start, discussion_end),
-        snapshot: (snapshot_epoch, snapshot_epoch),
-        voting: (voting_start, voting_end),
-        projected: !p.voting,
+        created: p.creation_epoch,
+        support: Some((p.creation_epoch, crossing)),
+        discussion: (Some(crossing), snapshot.saturating_sub(1)),
+        snapshot,
+        voting: (voting_start, voting_start.saturating_add(p.voting_epochs)),
+        projected: true,
     }
 }
 
@@ -155,11 +159,14 @@ pub fn epochs_remaining(p: &PhaseInputs, current_epoch: u64) -> Option<(u64, &'s
     let timeline = phase_timeline(p);
     match proposal_phase(p, current_epoch) {
         ProposalPhase::Support => Some((
-            timeline.support.1.saturating_sub(current_epoch),
+            timeline
+                .support
+                .map(|(_, end)| end.saturating_sub(current_epoch))
+                .unwrap_or(0),
             "until the support window closes",
         )),
         ProposalPhase::Discussion => Some((
-            timeline.snapshot.0.saturating_sub(current_epoch),
+            timeline.snapshot.saturating_sub(current_epoch),
             "until snapshot",
         )),
         ProposalPhase::Snapshot => Some((
@@ -209,35 +216,69 @@ mod tests {
     }
 
     #[test]
-    fn recovers_the_crossing_epoch_from_on_chain_state() {
-        // start_epoch inverts back to the epoch support actually crossed, so
-        // the printed timeline matches reality instead of the config model.
+    fn an_activated_timeline_uses_only_stored_state() {
         let t = phase_timeline(&double_disinflation());
         assert!(!t.projected);
-        assert_eq!(t.support, (1011, 1012));
-        // 1012 is shared: support closed partway through it and discussion
-        // began. Anything else would contradict proposal_phase(1012).
-        assert_eq!(t.discussion, (1012, 1019));
-        assert_eq!(t.snapshot, (1020, 1020)); // snapshot_slot 440_641_000 / 432_000
+        assert_eq!(t.created, 1011);
+        // The epoch support crossed is not recorded on-chain, so it is not
+        // claimed. `start_epoch - 1` gives the snapshot epoch in both the
+        // activate_voting and flush_merkle_root paths; 1020 matches the stored
+        // snapshot_slot of 440_641_000.
+        assert_eq!(t.support, None);
+        assert_eq!(t.discussion, (None, 1019));
+        assert_eq!(t.snapshot, 1020);
         assert_eq!(t.voting, (1021, 1024));
     }
 
     #[test]
+    fn a_flushed_proposal_does_not_get_a_fabricated_crossing_epoch() {
+        // flush_merkle_root re-anchors with target = current + snapshot_extension,
+        // omitting discussion_epochs. Inverting activate_voting's formula against
+        // it produced a crossing epoch before the proposal existed: a recovery at
+        // epoch 1015 sets start_epoch 1017, and 1017 - 1 - 7 - 1 = 1008 < 1011.
+        let flushed = PhaseInputs {
+            start_epoch: 1017,
+            end_epoch: 1020,
+            ..double_disinflation()
+        };
+        let t = phase_timeline(&flushed);
+        assert_eq!(t.support, None);
+        assert_eq!(t.discussion.0, None);
+        // What is printed stays correct across the re-anchor.
+        assert_eq!(t.snapshot, 1016);
+        assert_eq!(t.voting, (1017, 1020));
+        assert!(t.created <= t.snapshot);
+    }
+
+    #[test]
+    fn changing_the_config_durations_cannot_corrupt_an_activated_timeline() {
+        // update_config can change durations after activation; the stored epochs
+        // were computed with the old ones, so the timeline must not depend on
+        // whatever the config says now.
+        let base = phase_timeline(&double_disinflation());
+        let reconfigured = phase_timeline(&PhaseInputs {
+            discussion_epochs: 2,
+            snapshot_epoch_extension: 4,
+            max_support_epochs: 1,
+            ..double_disinflation()
+        });
+        assert_eq!(base, reconfigured);
+    }
+
+    #[test]
     fn the_timeline_agrees_with_the_phase_at_every_epoch() {
-        // The bug this whole module exists to fix was a timeline that disagreed
-        // with the reported status, so pin that they cannot drift apart.
+        // The bug this module exists to fix was a timeline that disagreed with
+        // the reported status, so pin that they cannot drift apart.
         let p = double_disinflation();
         let t = phase_timeline(&p);
-        for epoch in t.discussion.0..=t.discussion.1 {
+        for epoch in t.discussion.0.unwrap_or(t.created)..=t.discussion.1 {
             assert_eq!(
                 proposal_phase(&p, epoch),
                 ProposalPhase::Discussion,
                 "epoch {epoch} is inside the discussion window"
             );
         }
-        for epoch in t.snapshot.0..=t.snapshot.1 {
-            assert_eq!(proposal_phase(&p, epoch), ProposalPhase::Snapshot);
-        }
+        assert_eq!(proposal_phase(&p, t.snapshot), ProposalPhase::Snapshot);
         for epoch in t.voting.0..t.voting.1 {
             assert_eq!(proposal_phase(&p, epoch), ProposalPhase::Voting);
         }
@@ -247,14 +288,25 @@ mod tests {
     fn the_timeline_is_internally_ordered() {
         // The old output had voting (1021-1024) starting before the snapshot
         // (1026) and before discussion ended (1025).
-        let t = phase_timeline(&double_disinflation());
-        // Support and discussion share the crossing epoch; everything else is
-        // strictly ordered.
-        assert!(t.support.1 <= t.discussion.0);
-        assert!(t.discussion.0 <= t.discussion.1);
-        assert!(t.discussion.1 < t.snapshot.0);
-        assert!(t.snapshot.1 < t.voting.0);
-        assert!(t.voting.0 < t.voting.1);
+        for p in [
+            double_disinflation(),
+            PhaseInputs {
+                voting: false,
+                start_epoch: 0,
+                end_epoch: 0,
+                ..double_disinflation()
+            },
+        ] {
+            let t = phase_timeline(&p);
+            if let Some((from, to)) = t.support {
+                assert!(from <= to);
+                assert!(to <= t.discussion.0.unwrap_or(to));
+            }
+            assert!(t.discussion.0.unwrap_or(t.discussion.1) <= t.discussion.1);
+            assert!(t.discussion.1 < t.snapshot);
+            assert!(t.snapshot < t.voting.0);
+            assert!(t.voting.0 < t.voting.1);
+        }
     }
 
     #[test]
@@ -306,9 +358,9 @@ mod tests {
         let t = phase_timeline(&p);
         assert!(t.projected);
         // Latest possible crossing is the last epoch of the support window.
-        assert_eq!(t.support, (1011, 1018));
-        assert_eq!(t.discussion, (1018, 1025));
-        assert_eq!(t.snapshot, (1026, 1026));
+        assert_eq!(t.support, Some((1011, 1018)));
+        assert_eq!(t.discussion, (Some(1018), 1025));
+        assert_eq!(t.snapshot, 1026);
         assert_eq!(t.voting, (1027, 1030));
     }
 

--- a/svmgov/cli/src/utils/phase.rs
+++ b/svmgov/cli/src/utils/phase.rs
@@ -123,9 +123,16 @@ pub fn phase_timeline(p: &PhaseInputs) -> PhaseTimeline {
         p.creation_epoch.saturating_add(p.max_support_epochs)
     };
 
-    let discussion_start = crossing.saturating_add(1);
-    let discussion_end = crossing.saturating_add(p.discussion_epochs);
-    let snapshot_epoch = discussion_end.saturating_add(p.snapshot_epoch_extension);
+    // Discussion begins in the crossing epoch itself: support closed partway
+    // through it, so that epoch is the tail of support and the head of
+    // discussion. `proposal_phase` reports Discussion there, and the timeline
+    // has to agree. Running discussion to the epoch before the snapshot keeps
+    // the two definitions in step for every epoch in between.
+    let snapshot_epoch = crossing
+        .saturating_add(p.discussion_epochs)
+        .saturating_add(p.snapshot_epoch_extension);
+    let discussion_start = crossing;
+    let discussion_end = snapshot_epoch.saturating_sub(1);
 
     let (voting_start, voting_end) = if p.voting {
         (p.start_epoch, p.end_epoch)
@@ -208,9 +215,32 @@ mod tests {
         let t = phase_timeline(&double_disinflation());
         assert!(!t.projected);
         assert_eq!(t.support, (1011, 1012));
-        assert_eq!(t.discussion, (1013, 1019));
+        // 1012 is shared: support closed partway through it and discussion
+        // began. Anything else would contradict proposal_phase(1012).
+        assert_eq!(t.discussion, (1012, 1019));
         assert_eq!(t.snapshot, (1020, 1020)); // snapshot_slot 440_641_000 / 432_000
         assert_eq!(t.voting, (1021, 1024));
+    }
+
+    #[test]
+    fn the_timeline_agrees_with_the_phase_at_every_epoch() {
+        // The bug this whole module exists to fix was a timeline that disagreed
+        // with the reported status, so pin that they cannot drift apart.
+        let p = double_disinflation();
+        let t = phase_timeline(&p);
+        for epoch in t.discussion.0..=t.discussion.1 {
+            assert_eq!(
+                proposal_phase(&p, epoch),
+                ProposalPhase::Discussion,
+                "epoch {epoch} is inside the discussion window"
+            );
+        }
+        for epoch in t.snapshot.0..=t.snapshot.1 {
+            assert_eq!(proposal_phase(&p, epoch), ProposalPhase::Snapshot);
+        }
+        for epoch in t.voting.0..t.voting.1 {
+            assert_eq!(proposal_phase(&p, epoch), ProposalPhase::Voting);
+        }
     }
 
     #[test]
@@ -218,7 +248,10 @@ mod tests {
         // The old output had voting (1021-1024) starting before the snapshot
         // (1026) and before discussion ended (1025).
         let t = phase_timeline(&double_disinflation());
-        assert!(t.support.1 < t.discussion.0);
+        // Support and discussion share the crossing epoch; everything else is
+        // strictly ordered.
+        assert!(t.support.1 <= t.discussion.0);
+        assert!(t.discussion.0 <= t.discussion.1);
         assert!(t.discussion.1 < t.snapshot.0);
         assert!(t.snapshot.1 < t.voting.0);
         assert!(t.voting.0 < t.voting.1);
@@ -274,6 +307,8 @@ mod tests {
         assert!(t.projected);
         // Latest possible crossing is the last epoch of the support window.
         assert_eq!(t.support, (1011, 1018));
+        assert_eq!(t.discussion, (1018, 1025));
+        assert_eq!(t.snapshot, (1026, 1026));
         assert_eq!(t.voting, (1027, 1030));
     }
 

--- a/svmgov/cli/src/utils/phase.rs
+++ b/svmgov/cli/src/utils/phase.rs
@@ -1,0 +1,303 @@
+//! Proposal lifecycle phases, derived from on-chain state.
+//!
+//! The program fixes a proposal's schedule at the moment support crosses the
+//! threshold: `activate_voting` sets `voting`, `start_epoch` and `end_epoch`
+//! from the epoch the crossing happened in, which can be any epoch inside the
+//! support window. A schedule recomputed from `creation_epoch` and the config
+//! durations therefore only matches reality for a proposal that crosses on the
+//! very last epoch of its window — for anything that crosses early it reports
+//! the proposal as still gathering support long after it has advanced.
+//!
+//! So: once `voting` is set, the on-chain epochs are authoritative and the
+//! config model is not consulted. It is used only to project a schedule for a
+//! proposal that has not yet activated.
+
+/// Fields needed to place a proposal in its lifecycle. Plain values rather than
+/// the generated account types, so the logic is unit-testable.
+#[derive(Debug, Clone, Copy)]
+pub struct PhaseInputs {
+    pub creation_epoch: u64,
+    pub start_epoch: u64,
+    pub end_epoch: u64,
+    pub voting: bool,
+    pub finalized: bool,
+    pub max_support_epochs: u64,
+    pub discussion_epochs: u64,
+    pub snapshot_epoch_extension: u64,
+    pub voting_epochs: u64,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ProposalPhase {
+    Support,
+    Discussion,
+    Snapshot,
+    Voting,
+    Ended,
+    Finalized,
+    Failed,
+}
+
+impl ProposalPhase {
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Support => "Support",
+            Self::Discussion => "Discussion",
+            Self::Snapshot => "Snapshot",
+            Self::Voting => "Voting",
+            Self::Ended => "Ended (awaiting finalization)",
+            Self::Finalized => "Finalized",
+            Self::Failed => "Failed (support threshold not reached)",
+        }
+    }
+
+    /// Lowercase identifier used by `--status` filters and JSON output.
+    pub fn id(self) -> &'static str {
+        match self {
+            Self::Support => "support",
+            Self::Discussion => "discussion",
+            Self::Snapshot => "snapshot",
+            Self::Voting => "voting",
+            Self::Ended => "ended",
+            Self::Finalized => "finalized",
+            Self::Failed => "failed",
+        }
+    }
+}
+
+pub fn proposal_phase(p: &PhaseInputs, current_epoch: u64) -> ProposalPhase {
+    if p.finalized {
+        return ProposalPhase::Finalized;
+    }
+
+    if p.voting {
+        // Support succeeded and the program pinned the schedule. Nothing here
+        // may fall back to the config model.
+        if current_epoch >= p.end_epoch {
+            return ProposalPhase::Ended;
+        }
+        if current_epoch >= p.start_epoch {
+            return ProposalPhase::Voting;
+        }
+        // The snapshot is taken in the epoch immediately before voting opens.
+        // Written as an addition so a start_epoch of 0 cannot underflow.
+        if current_epoch + 1 >= p.start_epoch {
+            return ProposalPhase::Snapshot;
+        }
+        return ProposalPhase::Discussion;
+    }
+
+    // Not activated. The program only accepts support inside
+    // [creation_epoch, creation_epoch + max_support_epochs]; past that with
+    // `voting` still unset, the proposal can never advance.
+    if current_epoch <= p.creation_epoch.saturating_add(p.max_support_epochs) {
+        ProposalPhase::Support
+    } else {
+        ProposalPhase::Failed
+    }
+}
+
+/// Inclusive epoch ranges for each phase. `projected` marks a schedule inferred
+/// from the config because the proposal has not activated yet — those epochs
+/// will shift if it crosses the threshold earlier than the window's last epoch.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct PhaseTimeline {
+    pub support: (u64, u64),
+    pub discussion: (u64, u64),
+    pub snapshot: (u64, u64),
+    pub voting: (u64, u64),
+    pub projected: bool,
+}
+
+pub fn phase_timeline(p: &PhaseInputs) -> PhaseTimeline {
+    // The epoch support crossed the threshold. `activate_voting` computes
+    // start_epoch = crossing + discussion_epochs + snapshot_epoch_extension + 1,
+    // so inverting it recovers the crossing epoch from on-chain state alone.
+    let crossing = if p.voting {
+        p.start_epoch
+            .saturating_sub(1)
+            .saturating_sub(p.discussion_epochs)
+            .saturating_sub(p.snapshot_epoch_extension)
+    } else {
+        // Not activated: project the latest it could still cross.
+        p.creation_epoch.saturating_add(p.max_support_epochs)
+    };
+
+    let discussion_start = crossing.saturating_add(1);
+    let discussion_end = crossing.saturating_add(p.discussion_epochs);
+    let snapshot_epoch = discussion_end.saturating_add(p.snapshot_epoch_extension);
+
+    let (voting_start, voting_end) = if p.voting {
+        (p.start_epoch, p.end_epoch)
+    } else {
+        let start = snapshot_epoch.saturating_add(1);
+        (start, start.saturating_add(p.voting_epochs))
+    };
+
+    PhaseTimeline {
+        support: (p.creation_epoch, crossing),
+        discussion: (discussion_start, discussion_end),
+        snapshot: (snapshot_epoch, snapshot_epoch),
+        voting: (voting_start, voting_end),
+        projected: !p.voting,
+    }
+}
+
+/// How many epochs until the current phase gives way to the next.
+pub fn epochs_remaining(p: &PhaseInputs, current_epoch: u64) -> Option<(u64, &'static str)> {
+    let timeline = phase_timeline(p);
+    match proposal_phase(p, current_epoch) {
+        ProposalPhase::Support => Some((
+            timeline.support.1.saturating_sub(current_epoch),
+            "until the support window closes",
+        )),
+        ProposalPhase::Discussion => Some((
+            timeline.snapshot.0.saturating_sub(current_epoch),
+            "until snapshot",
+        )),
+        ProposalPhase::Snapshot => Some((
+            timeline.voting.0.saturating_sub(current_epoch),
+            "until voting opens",
+        )),
+        ProposalPhase::Voting => Some((
+            p.end_epoch.saturating_sub(current_epoch),
+            "until voting ends",
+        )),
+        ProposalPhase::Ended | ProposalPhase::Finalized | ProposalPhase::Failed => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// "Double Disinflation" as it stood on-chain in epoch 1012: created in
+    /// 1011, crossed the threshold in 1012 — early in a seven-epoch support
+    /// window — so the program scheduled voting for 1021-1024.
+    fn double_disinflation() -> PhaseInputs {
+        PhaseInputs {
+            creation_epoch: 1011,
+            start_epoch: 1021,
+            end_epoch: 1024,
+            voting: true,
+            finalized: false,
+            max_support_epochs: 7,
+            discussion_epochs: 7,
+            snapshot_epoch_extension: 1,
+            voting_epochs: 3,
+        }
+    }
+
+    #[test]
+    fn an_early_crossing_is_not_reported_as_still_gathering_support() {
+        // The reported bug: the CLI said "Support" with "6 epoch(s) until
+        // discussion" for a proposal that had already advanced, because
+        // current_epoch was still inside the config-derived support window.
+        let p = double_disinflation();
+        assert_eq!(proposal_phase(&p, 1012), ProposalPhase::Discussion);
+        assert_eq!(
+            epochs_remaining(&p, 1012).map(|(n, _)| n),
+            Some(8) // 1020 - 1012
+        );
+    }
+
+    #[test]
+    fn recovers_the_crossing_epoch_from_on_chain_state() {
+        // start_epoch inverts back to the epoch support actually crossed, so
+        // the printed timeline matches reality instead of the config model.
+        let t = phase_timeline(&double_disinflation());
+        assert!(!t.projected);
+        assert_eq!(t.support, (1011, 1012));
+        assert_eq!(t.discussion, (1013, 1019));
+        assert_eq!(t.snapshot, (1020, 1020)); // snapshot_slot 440_641_000 / 432_000
+        assert_eq!(t.voting, (1021, 1024));
+    }
+
+    #[test]
+    fn the_timeline_is_internally_ordered() {
+        // The old output had voting (1021-1024) starting before the snapshot
+        // (1026) and before discussion ended (1025).
+        let t = phase_timeline(&double_disinflation());
+        assert!(t.support.1 < t.discussion.0);
+        assert!(t.discussion.1 < t.snapshot.0);
+        assert!(t.snapshot.1 < t.voting.0);
+        assert!(t.voting.0 < t.voting.1);
+    }
+
+    #[test]
+    fn walks_the_whole_lifecycle() {
+        let p = double_disinflation();
+        assert_eq!(proposal_phase(&p, 1011), ProposalPhase::Discussion);
+        assert_eq!(proposal_phase(&p, 1019), ProposalPhase::Discussion);
+        assert_eq!(proposal_phase(&p, 1020), ProposalPhase::Snapshot);
+        assert_eq!(proposal_phase(&p, 1021), ProposalPhase::Voting);
+        assert_eq!(proposal_phase(&p, 1023), ProposalPhase::Voting);
+        assert_eq!(proposal_phase(&p, 1024), ProposalPhase::Ended);
+    }
+
+    #[test]
+    fn an_unactivated_proposal_stays_in_support_until_its_window_closes() {
+        let p = PhaseInputs {
+            voting: false,
+            start_epoch: 0,
+            end_epoch: 0,
+            ..double_disinflation()
+        };
+        assert_eq!(proposal_phase(&p, 1011), ProposalPhase::Support);
+        assert_eq!(proposal_phase(&p, 1018), ProposalPhase::Support);
+    }
+
+    #[test]
+    fn an_unactivated_proposal_past_its_window_has_failed() {
+        // The old code reported "support" forever here. Support and retally
+        // both reject past creation_epoch + max_support_epochs, so the proposal
+        // can never advance.
+        let p = PhaseInputs {
+            voting: false,
+            start_epoch: 0,
+            end_epoch: 0,
+            ..double_disinflation()
+        };
+        assert_eq!(proposal_phase(&p, 1019), ProposalPhase::Failed);
+        assert_eq!(epochs_remaining(&p, 1019), None);
+    }
+
+    #[test]
+    fn an_unactivated_timeline_is_marked_projected() {
+        let p = PhaseInputs {
+            voting: false,
+            start_epoch: 0,
+            end_epoch: 0,
+            ..double_disinflation()
+        };
+        let t = phase_timeline(&p);
+        assert!(t.projected);
+        // Latest possible crossing is the last epoch of the support window.
+        assert_eq!(t.support, (1011, 1018));
+        assert_eq!(t.voting, (1027, 1030));
+    }
+
+    #[test]
+    fn finalized_wins_over_everything() {
+        let p = PhaseInputs {
+            finalized: true,
+            ..double_disinflation()
+        };
+        assert_eq!(proposal_phase(&p, 1012), ProposalPhase::Finalized);
+        assert_eq!(epochs_remaining(&p, 1012), None);
+    }
+
+    #[test]
+    fn a_zero_start_epoch_does_not_underflow() {
+        let p = PhaseInputs {
+            voting: true,
+            start_epoch: 0,
+            end_epoch: 0,
+            creation_epoch: 0,
+            ..double_disinflation()
+        };
+        // end_epoch 0 means current >= end, so this is Ended rather than a panic.
+        assert_eq!(proposal_phase(&p, 0), ProposalPhase::Ended);
+        let _ = phase_timeline(&p);
+    }
+}


### PR DESCRIPTION
## TLDR

`svmgov proposal <id>` reported the double disinflation proposal as still in the support phase after it had already advanced, alongside a phase timeline whose voting window began before its own snapshot. The CLI recomputed the schedule from
`creation_epoch` plus config durations instead of reading the epochs the program had already committed onchain

The frontend half of this was fixed in #133; this is the CLI half

Note that this closes part of #141

## Cause

`activate_voting` anchors a proposal's schedule on whichever epoch support crossed the threshold, which can be any epoch inside the support window. The CLI's `get_proposal_status` consulted `voting` only for the voting and ended
phases, then fell through to a model built from `creation_epoch + config`:

```rust
if proposal.voting && current_epoch >= proposal.end_epoch { return "ended"; }
if proposal.voting && current_epoch >= proposal.start_epoch { return "voting"; }

// falls through here even when voting is true
let support_end = proposal.creation_epoch + config.max_support_epochs;
if current_epoch <= support_end { "support" } ...
```

That model is only correct for a proposal that crosses on the very last epoch of its window

There are three distinct bugs, with one cause:

1. **Status wrong** for any proposal that crosses early
2. **Timeline self-contradictory** — real on-chain epochs printed alongside projected ones, with no indication which was which
3. **`Failed` unreachable** — an unactivated proposal past its support window reported `support` indefinitely, though `support_proposal` and `retally_support` both reject past `creation_epoch + max_support_epochs`

All four CLI surfaces (i.e., detail view, `--status` filter, JSON output, list table) share `get_proposal_status`, so all four were affected

## Fix

We fix this with a new pure `svmgov/cli/src/utils/phase.rs`. Once `voting` is set, the onchain epochs are authoritative, and the config model is never consulted; it is used only to project a schedule for an unactivated proposal, labeled
`(projected — set once support crosses)`

The epoch support crossed the threshold is **not recorded on-chain**, and cannot be recovered from `start_epoch`:

- `flush_merkle_root` re-anchors with `target = current_epoch + snapshot_epoch_extension`, omitting `discussion_epochs`, so inverting `activate_voting`'s formula against a recovered proposal can produce a crossing epoch that predates the proposal; a recovery at epoch 1015 sets `start_epoch = 1017`, and `1017 - 1 - 7 - 1 = 1008` against a `creation_epoch` of 1011
- `update_config` can change `discussion_epochs` and `snapshot_epoch_extension` after activation, so the stored `start_epoch` may have been computed with values the inversion no longer sees

So it is reported as unknown rather than guessed. `support` and the discussion start are `Option`, and an activated proposal prints only what is stored:

```
created: epoch 1011 | discussion: through epoch 1019 |
snapshot: epoch 1020 | voting: epochs 1021-1024
```

The snapshot epoch comes from `start_epoch - 1`, which holds by construction in both the `activate_voting` and `flush_merkle_root` paths; more robust than dividing `snapshot_slot`, which depends on `snapshot_slot_offset`. For this proposal it gives 1020, matching the stored `snapshot_slot` of 440,641,000 (1020 × 432,000 + 1,000)

## Tests

Twelve tests in the new module, built on the real proposal's onchain values rather than invented ones. `GlobalConfig` was read from `4V8PnDoVa7BSUWj16uhUkgHhXPoBEvMSk4EFhKA9wyFA` and the proposal from its own account, so the fixture is not inferred from the CLI output being fixed

The ones carrying the most weight:

- **`an_early_crossing_is_not_reported_as_still_gathering_support`** — the reported case: epoch 1012 reports Discussion, and not Support
- **`the_timeline_agrees_with_the_phase_at_every_epoch`** — walks every epoch of the timeline and checks `proposal_phase` reports the phase whose window it falls in. An ordering-only check passed while the two definitions disagreed about a boundary epoch, so this replaces it
- **`a_flushed_proposal_does_not_get_a_fabricated_crossing_epoch`** — a `flush_merkle_root`-recovered proposal (`start_epoch = 1017`), asserting nothing is claimed about the crossing and the rest of the timeline stays correct
- **`changing_the_config_durations_cannot_corrupt_an_activated_timeline`** — the same proposal with very different durations must yield an identical timeline
- **`an_unactivated_proposal_past_its_window_has_failed`** — previously unreachable

`cargo test` in `svmgov/cli` → 42 passed. Build clean, `phase.rs` rustfmt-clean as well
