### PR TITLE
fix(svmgov): Distinguish support-already-activated from voting-ended

### DIFF
--- a/frontend/src/chain/idl/svmgov_program.json
+++ b/frontend/src/chain/idl/svmgov_program.json
@@ -1934,6 +1934,11 @@
       "code": 6057,
       "name": "InvalidMaxSupporters",
       "msg": "Invalid max supporters (must be greater than 0 and less than or equal to the supporter limit)"
+    },
+    {
+      "code": 6058,
+      "name": "SupportAlreadyActivated",
+      "msg": "Support is closed: this proposal already reached its support threshold and voting has been scheduled"
     }
   ],
   "types": [

--- a/frontend/src/chain/types/svmgov_program.ts
+++ b/frontend/src/chain/types/svmgov_program.ts
@@ -1940,6 +1940,11 @@ export type SvmgovProgram = {
       "code": 6057,
       "name": "invalidMaxSupporters",
       "msg": "Invalid max supporters (must be greater than 0 and less than or equal to the supporter limit)"
+    },
+    {
+      "code": 6058,
+      "name": "supportAlreadyActivated",
+      "msg": "Support is closed: this proposal already reached its support threshold and voting has been scheduled"
     }
   ],
   "types": [

--- a/svmgov/cli/idls/svmgov_program.json
+++ b/svmgov/cli/idls/svmgov_program.json
@@ -1934,6 +1934,11 @@
       "code": 6057,
       "name": "InvalidMaxSupporters",
       "msg": "Invalid max supporters (must be greater than 0 and less than or equal to the supporter limit)"
+    },
+    {
+      "code": 6058,
+      "name": "SupportAlreadyActivated",
+      "msg": "Support is closed: this proposal already reached its support threshold and voting has been scheduled"
     }
   ],
   "types": [

--- a/svmgov/cli/src/instructions/support_proposal.rs
+++ b/svmgov/cli/src/instructions/support_proposal.rs
@@ -39,7 +39,28 @@ pub async fn support_proposal(
     // read fails the instruction itself may still succeed, so fall back to the
     // program's supporter cap rather than aborting on a budgeting detail.
     let num_supporters = match program.account::<Proposal>(proposal_pubkey).await {
-        Ok(proposal) => proposal.num_supporters,
+        Ok(proposal) => {
+            // Refuse before building a transaction the program will reject.
+            // `voting` is set the moment support crosses the threshold, while
+            // start_epoch is still in the future, so the useful next action is
+            // to vote once voting opens — not to keep trying to support.
+            if proposal.finalized {
+                return Err(anyhow!(
+                    "Proposal {proposal_pubkey} is finalized; support is closed."
+                ));
+            }
+            if proposal.voting {
+                return Err(anyhow!(
+                    "Proposal {proposal_pubkey} has already reached its support threshold, so \
+                     support is closed. Voting runs from epoch {} to {} — use `svmgov cast-vote` \
+                     once epoch {} begins.",
+                    proposal.start_epoch,
+                    proposal.end_epoch,
+                    proposal.start_epoch,
+                ));
+            }
+            proposal.num_supporters
+        }
         Err(e) => {
             log::warn!(
                 "Could not read the supporter count for {proposal_pubkey}: {e}. Requesting the \

--- a/svmgov/program/programs/svmgov_program/src/error.rs
+++ b/svmgov/program/programs/svmgov_program/src/error.rs
@@ -126,4 +126,10 @@ pub enum GovernanceError {
     SupporterLimitReached,
     #[msg("Invalid max supporters (must be greater than 0 and less than or equal to the supporter limit)")]
     InvalidMaxSupporters,
+    // Appended rather than inserted: Anchor derives error codes from declaration
+    // order, so adding anywhere above would renumber every variant after it.
+    #[msg(
+        "Support is closed: this proposal already reached its support threshold and voting has been scheduled"
+    )]
+    SupportAlreadyActivated,
 }

--- a/svmgov/program/programs/svmgov_program/src/instructions/retally_support.rs
+++ b/svmgov/program/programs/svmgov_program/src/instructions/retally_support.rs
@@ -62,9 +62,10 @@ impl<'info> RetallySupport<'info> {
 
         // Same eligibility gates as support_proposal: not yet voting, not
         // finalized, and inside the support window.
+        require!(!self.proposal.finalized, GovernanceError::ProposalFinalized);
         require!(
-            self.proposal.voting == false && self.proposal.finalized == false,
-            GovernanceError::ProposalClosed
+            !self.proposal.voting,
+            GovernanceError::SupportAlreadyActivated
         );
         check_support_window(
             clock.epoch,

--- a/svmgov/program/programs/svmgov_program/src/instructions/retally_support.rs
+++ b/svmgov/program/programs/svmgov_program/src/instructions/retally_support.rs
@@ -60,8 +60,8 @@ impl<'info> RetallySupport<'info> {
     pub fn retally_support(&mut self) -> Result<()> {
         let clock = Clock::get()?;
 
-        // Same eligibility gates as support_proposal: not yet voting, not
-        // finalized, and inside the support window.
+        // Same eligibility gates as support_proposal: not finalized, not being
+        // voted on, and inside the support window.
         require!(!self.proposal.finalized, GovernanceError::ProposalFinalized);
         require!(
             !self.proposal.voting,

--- a/svmgov/program/programs/svmgov_program/src/instructions/support_proposal.rs
+++ b/svmgov/program/programs/svmgov_program/src/instructions/support_proposal.rs
@@ -84,10 +84,15 @@ impl<'info> SupportProposal<'info> {
     pub fn support_proposal(&mut self, bumps: &SupportProposalBumps) -> Result<()> {
         let clock = Clock::get()?;
 
-        // Ensure proposal is eligible for support
+        // Ensure proposal is eligible for support. Split from a single
+        // ProposalClosed check so the two states are distinguishable: an
+        // activated proposal has *not* finished voting — voting may not even
+        // have started — and "the voting period has ended" sent validators
+        // looking for the wrong problem.
+        require!(!self.proposal.finalized, GovernanceError::ProposalFinalized);
         require!(
-            self.proposal.voting == false && self.proposal.finalized == false,
-            GovernanceError::ProposalClosed
+            !self.proposal.voting,
+            GovernanceError::SupportAlreadyActivated
         );
 
         // Support is accepted anywhere inside the window

--- a/svmgov/program/programs/svmgov_program/src/instructions/support_proposal.rs
+++ b/svmgov/program/programs/svmgov_program/src/instructions/support_proposal.rs
@@ -84,11 +84,7 @@ impl<'info> SupportProposal<'info> {
     pub fn support_proposal(&mut self, bumps: &SupportProposalBumps) -> Result<()> {
         let clock = Clock::get()?;
 
-        // Ensure proposal is eligible for support. Split from a single
-        // ProposalClosed check so the two states are distinguishable: an
-        // activated proposal has *not* finished voting — voting may not even
-        // have started — and "the voting period has ended" sent validators
-        // looking for the wrong problem.
+        // A proposal that is already finalized or being voted on is not eligible for support
         require!(!self.proposal.finalized, GovernanceError::ProposalFinalized);
         require!(
             !self.proposal.voting,

--- a/svmgov/program/programs/svmgov_program/tests/support_150_of_1000.rs
+++ b/svmgov/program/programs/svmgov_program/tests/support_150_of_1000.rs
@@ -119,8 +119,14 @@ fn support_proposal_remeasures_prior_stake_across_epochs() {
     assert_eq!(after.snapshot_slot, expected_snapshot_slot(crossing_epoch));
 }
 
-/// Once voting is active, both `support_proposal` and `retally_support` return
-/// `ProposalClosed`.
+/// Once voting is active, both `support_proposal` and `retally_support` reject
+/// with `SupportAlreadyActivated`.
+///
+/// The error is deliberately not `ProposalClosed` ("the voting period has
+/// ended"): activation happens the moment the threshold is crossed, while
+/// `start_epoch` is still in the future, so at this point voting has not even
+/// begun. Reporting it as ended sent validators looking for the wrong problem
+/// (issue #141).
 #[test_log::test]
 fn support_and_retally_reject_after_voting_activated() {
     const CREATION_EPOCH: u64 = 10;
@@ -142,9 +148,19 @@ fn support_and_retally_reject_after_voting_activated() {
     retally_one(&mut h, proposal, UNDER_THRESHOLD, ballot_box);
     assert!(fetch_proposal(&h.svm, &proposal).voting);
 
+    // The transition state the issue describes: activated, but before
+    // start_epoch, so voting has not started.
+    let state = fetch_proposal(&h.svm, &proposal);
+    assert!(state.voting && !state.finalized);
+    assert!(
+        CREATION_EPOCH < state.start_epoch,
+        "current epoch must still be below start_epoch for this to be the \
+         activated-but-not-yet-voting case"
+    );
+
     let closed = TransactionError::InstructionError(
         1,
-        anchor_custom_error(GovernanceError::ProposalClosed),
+        anchor_custom_error(GovernanceError::SupportAlreadyActivated),
     );
     let support_err = try_support_one(&mut h, proposal, UNDER_THRESHOLD, ballot_box)
         .expect_err("support after voting should fail");

--- a/svmgov/program/programs/svmgov_program/tests/support_150_of_1000.rs
+++ b/svmgov/program/programs/svmgov_program/tests/support_150_of_1000.rs
@@ -172,6 +172,64 @@ fn support_and_retally_reject_after_voting_activated() {
     assert_eq!(retally_err.err, closed);
 }
 
+/// Once the proposal is finalized, both `support_proposal` and
+/// `retally_support` reject with `ProposalFinalized` rather than
+/// `SupportAlreadyActivated`.
+///
+/// The two guards sit one after the other and a finalized proposal always has
+/// `voting == true`, so the ordering is what decides which error a caller sees.
+/// Reversing them would report every finalized proposal as merely activated.
+#[test_log::test]
+fn support_and_retally_reject_after_finalization() {
+    const CREATION_EPOCH: u64 = 10;
+    // Cross the threshold via stake drift rather than the last supporter, so a
+    // funded validator is left that has not supported and can make the
+    // post-finalization attempt below.
+    const UNDER_THRESHOLD: usize = SUPPORTER_COUNT - 1;
+    let mut h = setup(CREATION_EPOCH);
+    let ballot_box = seed_ballot_box(&mut h.svm, expected_snapshot_slot(CREATION_EPOCH));
+    let proposal = create_proposal(&mut h, 98, "closed after finalization");
+
+    for i in 0..UNDER_THRESHOLD {
+        support_one(&mut h, proposal, i, ballot_box);
+    }
+    h.svm
+        .set_epoch_stake(h.validators[0].vote.pubkey(), 2 * STAKE_PER_VALIDATOR)
+        .unwrap();
+    h.svm
+        .set_epoch_stake(h.validators[VALIDATOR_COUNT - 1].vote.pubkey(), 0)
+        .unwrap();
+    retally_one(&mut h, proposal, UNDER_THRESHOLD, ballot_box);
+    let activated = fetch_proposal(&h.svm, &proposal);
+    assert!(activated.voting, "proposal must activate before it can finalize");
+
+    // Finalization needs the voting window to have closed.
+    set_clock(&mut h.svm, activated.end_epoch);
+    let finalizer = h.validators[0].identity.insecure_clone();
+    send_ix(
+        &mut h.svm,
+        &finalizer,
+        &[finalize_proposal_ix(&finalizer.pubkey(), proposal)],
+    );
+    let state = fetch_proposal(&h.svm, &proposal);
+    assert!(state.finalized && state.voting);
+
+    let finalized_err = TransactionError::InstructionError(
+        1,
+        anchor_custom_error(GovernanceError::ProposalFinalized),
+    );
+
+    // The support window is long past by now too, so this also pins that the
+    // finalized guard runs before check_support_window.
+    let support_err = try_support_one(&mut h, proposal, UNDER_THRESHOLD, ballot_box)
+        .expect_err("support after finalization should fail");
+    assert_eq!(support_err.err, finalized_err);
+
+    let retally_err = try_retally_one(&mut h, proposal, 1, ballot_box)
+        .expect_err("retally after finalization should fail");
+    assert_eq!(retally_err.err, finalized_err);
+}
+
 /// Retally is rejected once the clock moves past the support window
 /// (same inclusive bound as `support_proposal`).
 #[test_log::test]


### PR DESCRIPTION
## TLDR

A validator whose `support-proposal` was rejected because the proposal had already been activated was told "Proposal voting period has ended" when voting had not yet started. This gives that state its own error, and makes the CLI refuse before building a transaction the program will reject

## Scope 

The issue raises three problems. Two are already fixed in #144 (in review):

| Ask | Where |
|---|---|
| `list-proposals` must not label `voting == true` as `support` | #144 |
| Activated-before-`start_epoch` needs an unambiguous non-support status | #144 reports Discussion, or Snapshot in the epoch before `start_epoch` |
| `ProposalClosed` message is misleading | this PR |

The reporter's root-cause analysis of `get_proposal_status` is exactly right,
and matches what we hit independently on Double Disinflation.

## Bug

`support_proposal` and `retally_support` both gated on:

```rust
require!(!voting && !finalized, GovernanceError::ProposalClosed);
```

One error covering two unrelated states, with a message that is wrong for both. `activate_voting` sets `voting` the instant support crosses the threshold, while `start_epoch` is still epochs away, so "the voting period has ended" describes
the opposite of what happened

## Fix

```rust
require!(!self.proposal.finalized, GovernanceError::ProposalFinalized);
require!(!self.proposal.voting, GovernanceError::SupportAlreadyActivated);
```

`SupportAlreadyActivated`: "Support is closed: this proposal already reached its support threshold and voting has been scheduled"*

`ProposalClosed` is deliberately untouched in `cast_vote`, `cast_vote_override`, `modify_vote` and `modify_vote_override`, where it guards `current_epoch < end_epoch` and the existing message is accurate

### Error Code Stability

The variant is appended instead of inserted since Anchor derives error codes from declaration order. `ProposalClosed` remains 6008 (i.e., the code quoted in the issue), the new variant is 6058, and both IDL diffs are purely additive

### CLI guard

The issue's practical complaint is that validators are prompted to submit an impossible transaction. Since #119 the CLI already fetches the proposal to size the compute budget, so it can refuse up front and name the next action:

```
Proposal 7QJD8Mzhe... has already reached its support threshold, so support is
closed. Voting runs from epoch 1021 to 1024 — use `svmgov cast-vote` once epoch
1021 begins.
```

This is the half that lands without a program redeploy

## Tests

- `support_and_retally_reject_after_voting_activated` now asserts the new error, and additionally asserts the proposal is genuinely in the transition state the issue describes; `voting && !finalized && current_epoch < start_epoch`. Without
that the test would pass for the wrong reason, since any post-activation state produces the same error
- Full program suite green (11 targets), CLI 30 tests, frontend 270 tests
- `tsc` clean
- No new rustfmt drift