### PR TITLE
fix(frontend): add retry to snapshot meta requests

### DIFF
--- a/frontend/src/app/providers.tsx
+++ b/frontend/src/app/providers.tsx
@@ -4,7 +4,12 @@ import { QueryCache, QueryClient } from "@tanstack/react-query";
 import { PersistQueryClientProvider } from "@tanstack/react-query-persist-client";
 import { createAsyncStoragePersister } from "@tanstack/query-async-storage-persister";
 import { GET_GOVERNANCE_CONFIG, GET_PROPOSAL_DOCUMENT } from "@/helpers";
-import { isNetworkFailure } from "@/lib/ncnApi";
+import {
+  classifyNcnFailure,
+  isPermanentNcnFailure,
+  NcnApiHttpError,
+  NcnApiNetworkError,
+} from "@/lib/ncnApi";
 import AppWalletProvider from "../components/AppWalletProvider";
 import { EndpointProvider } from "../contexts/EndpointContext";
 import { GovernanceConfigProvider } from "../contexts/GovernanceConfigContext";
@@ -13,9 +18,24 @@ import { captureException } from "@sentry/nextjs";
 
 const GOVERNANCE_CONFIG_PERSIST_MAX_AGE_MS = 60 * 60 * 1000; // 1 hour (aligns with useGovernanceConfig stale time)
 
+/** Host only, never the full URL: voter summary URLs carry a wallet address, and tags are indexed. */
+const ncnFailureTags = (error: unknown): Record<string, string> => {
+  if (error instanceof NcnApiHttpError) {
+    return { ncn_status: String(error.status), ncn_host: error.host };
+  }
+  if (error instanceof NcnApiNetworkError) return { ncn_host: error.host };
+  return {};
+};
+
 export const queryClient = new QueryClient({
   defaultOptions: {
-    queries: { staleTime: 1000 * 10 },
+    queries: {
+      staleTime: 1000 * 10,
+      // React Query's own default count, but stops early once the upstream has answered
+      // definitively — retrying a 404 only spends the user's time (see isPermanentNcnFailure).
+      retry: (failureCount, error) =>
+        failureCount < 3 && !isPermanentNcnFailure(error),
+    },
   },
   queryCache: new QueryCache({
     // Fires once per query after its retries are exhausted, never for cancellations.
@@ -28,19 +48,48 @@ export const queryClient = new QueryClient({
       // worth an alert.
       if (queryKey === GET_PROPOSAL_DOCUMENT) return;
 
-      // Upstream being unreachable is an infrastructure event, not a bug in the app. Report
-      // it as a warning and collapse it to one issue per query, otherwise a single upstream
-      // outage buries everything else in identical anonymous TypeErrors.
-      if (isNetworkFailure(error)) {
+      const kind = classifyNcnFailure(error);
+      const httpError = error instanceof NcnApiHttpError ? error : undefined;
+      const tags = { query_key: queryKey, ...ncnFailureTags(error) };
+      // The body is how we tell a router refusal from an operator's, since the status alone
+      // never says which hop produced it.
+      const extra = httpError?.bodySnippet
+        ? { ncn_response_body: httpError.bodySnippet }
+        : undefined;
+
+      // Upstream being unreachable or refusing us is an infrastructure event, not a bug in the
+      // app. Report it as a warning and collapse it to one issue per kind, otherwise a single
+      // upstream outage buries everything else.
+      if (kind === "network" || kind === "upstream") {
         captureException(error, {
           level: "warning",
-          tags: { query_key: queryKey, failure_kind: "network" },
-          fingerprint: ["network-failure", queryKey],
+          tags: { ...tags, failure_kind: kind },
+          extra,
+          fingerprint: httpError
+            ? ["ncn-upstream-error", queryKey, String(httpError.status)]
+            : // Unchanged from before this branch existed, so the existing issue keeps its history.
+              ["network-failure", queryKey],
         });
         return;
       }
 
-      captureException(error, { tags: { query_key: queryKey } });
+      // Present only for kind === "request": the upstream understood us and said no, so our
+      // request was wrong (bad network param, or a network with no snapshot). Left at error
+      // level so it does not hide among the infrastructure noise.
+      if (httpError) {
+        captureException(error, {
+          tags: { ...tags, failure_kind: "request" },
+          extra,
+          fingerprint: [
+            "ncn-request-error",
+            queryKey,
+            String(httpError.status),
+          ],
+        });
+        return;
+      }
+
+      captureException(error, { tags });
     },
   }),
 });

--- a/frontend/src/contexts/EndpointContext.tsx
+++ b/frontend/src/contexts/EndpointContext.tsx
@@ -1,8 +1,15 @@
 "use client";
 
-import React, { createContext, useContext, useState, ReactNode } from "react";
+import React, {
+  createContext,
+  useContext,
+  useEffect,
+  useState,
+  ReactNode,
+} from "react";
 import { RPCEndpoint } from "@/types";
 import { useQueryClient } from "@tanstack/react-query";
+import { setTag } from "@sentry/nextjs";
 import { env } from "@/env";
 import { getRpcUrls } from "@/lib/getRpcUrls";
 
@@ -48,6 +55,13 @@ export function EndpointProvider({ children }: { children: ReactNode }) {
   }>(getStoredValues());
 
   const queryClient = useQueryClient();
+
+  // Which network an error came from is otherwise invisible in Sentry, and it is the first thing
+  // you need: the NCN API serves a different snapshot per network. Type only — a custom
+  // endpointUrl can contain an RPC provider API key.
+  useEffect(() => {
+    setTag("solana_network", endpoint.endpointType);
+  }, [endpoint.endpointType]);
 
   const setEndpointData = (type: RPCEndpoint, customUrl?: string) => {
     const url = type === "custom" ? (customUrl ?? "") : RPC_URLS[type];

--- a/frontend/src/hooks/useSnapshotMeta.ts
+++ b/frontend/src/hooks/useSnapshotMeta.ts
@@ -20,7 +20,9 @@ export const useSnapshotMeta = () => {
     // A custom RPC has no corresponding snapshot on the NCN API, so the request can only
     // fail. Skip it rather than spending three retries proving that.
     enabled: endpointType !== "custom",
-    retry: 3,
+    // Retry count comes from the query client default, which also skips retries once the
+    // upstream has answered definitively (see isPermanentNcnFailure).
+    //
     // Jittered so a fleet of clients retrying at once does not hammer an already-stalling
     // router in lockstep.
     retryDelay: (attempt) =>

--- a/frontend/src/lib/__tests__/ncnApi.test.ts
+++ b/frontend/src/lib/__tests__/ncnApi.test.ts
@@ -1,6 +1,8 @@
 import {
+  classifyNcnFailure,
   fetchNcnJson,
   isNetworkFailure,
+  isPermanentNcnFailure,
   NcnApiHttpError,
   NcnApiNetworkError,
 } from "../ncnApi";
@@ -29,13 +31,16 @@ describe("fetchNcnJson", () => {
     ).resolves.toEqual(meta);
   });
 
-  it("throws NcnApiHttpError carrying the status on a non-ok response", async () => {
+  it("throws NcnApiHttpError naming the status, the operator that answered, and its body", async () => {
     // HTTP/2 has no reason phrase, so statusText is empty in practice — the numeric status
-    // is the only thing that identifies the failure.
+    // is the only thing that identifies the failure. The router redirects, so response.url is
+    // the operator that refused us, not the host we asked.
     global.fetch = jest.fn().mockResolvedValue({
       ok: false,
       status: 503,
       statusText: "",
+      url: "https://ncn.brewlabs.so/meta?network=mainnet",
+      text: async () => '{"error":"snapshot not ready"}',
       json: async () => ({}),
     }) as unknown as typeof fetch;
 
@@ -45,7 +50,65 @@ describe("fetchNcnJson", () => {
 
     expect(error).toBeInstanceOf(NcnApiHttpError);
     expect((error as NcnApiHttpError).status).toBe(503);
+    expect((error as NcnApiHttpError).host).toBe("ncn.brewlabs.so");
+    expect((error as NcnApiHttpError).bodySnippet).toBe(
+      '{"error":"snapshot not ready"}'
+    );
     expect((error as Error).message).toContain("503");
+    expect((error as Error).message).toContain("ncn.brewlabs.so");
+  });
+
+  it("truncates a long error body", async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: false,
+      status: 403,
+      statusText: "Forbidden",
+      url: URL_UNDER_TEST,
+      // A Cloudflare block page is kilobytes of HTML; only the head of it is worth uploading.
+      text: async () => "x".repeat(1000),
+    }) as unknown as typeof fetch;
+
+    const error = await fetchNcnJson(URL_UNDER_TEST, {
+      label: "snapshot meta info",
+    }).catch((e: unknown) => e);
+
+    expect((error as NcnApiHttpError).bodySnippet).toHaveLength(200);
+  });
+
+  it("still reports the status when the error body cannot be read", async () => {
+    // The internal timeout stays armed while the body is read, so the read itself can abort.
+    // Losing a known 403 to an opaque AbortError is the failure this client exists to prevent.
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: false,
+      status: 403,
+      statusText: "Forbidden",
+      url: URL_UNDER_TEST,
+      text: () => Promise.reject(new DOMException("Aborted", "AbortError")),
+    }) as unknown as typeof fetch;
+
+    const error = await fetchNcnJson(URL_UNDER_TEST, {
+      label: "snapshot meta info",
+    }).catch((e: unknown) => e);
+
+    expect(error).toBeInstanceOf(NcnApiHttpError);
+    expect((error as NcnApiHttpError).status).toBe(403);
+    expect((error as NcnApiHttpError).bodySnippet).toBe("");
+  });
+
+  it("falls back to the requested host when the response has no url", async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: false,
+      status: 500,
+      statusText: "",
+      url: "",
+      text: async () => "",
+    }) as unknown as typeof fetch;
+
+    const error = await fetchNcnJson(URL_UNDER_TEST, {
+      label: "snapshot meta info",
+    }).catch((e: unknown) => e);
+
+    expect((error as NcnApiHttpError).host).toBe("ncn-governance.solana.com");
   });
 
   it("wraps a network-level TypeError, naming the host", async () => {
@@ -84,6 +147,12 @@ describe("fetchNcnJson", () => {
 
     expect(error).toBeInstanceOf(NcnApiNetworkError);
     expect((error as Error).message).toContain("Timed out after 50ms");
+    expect((error as NcnApiNetworkError).host).toBe(
+      "ncn-governance.solana.com"
+    );
+    // The only cause available is our own abort. Attaching it just adds a second, contentless
+    // "signal is aborted without reason" exception to the Sentry event.
+    expect((error as NcnApiNetworkError).cause).toBeUndefined();
   });
 
   it("does not start work when the caller's signal is already aborted", async () => {
@@ -148,6 +217,68 @@ describe("isNetworkFailure", () => {
   });
 
   it("does not classify an HTTP error as a network failure", () => {
-    expect(isNetworkFailure(new NcnApiHttpError("meta", 503, ""))).toBe(false);
+    expect(
+      isNetworkFailure(new NcnApiHttpError("meta", 503, { url: URL_UNDER_TEST }))
+    ).toBe(false);
+  });
+});
+
+describe("classifyNcnFailure", () => {
+  it.each([
+    // A hop refused or shed the request: infrastructure, and a retry may land on a healthy operator.
+    [403, "upstream"],
+    [408, "upstream"],
+    [429, "upstream"],
+    [500, "upstream"],
+    [502, "upstream"],
+    [503, "upstream"],
+    [522, "upstream"],
+    // The upstream understood us and said no — asking again changes nothing.
+    [400, "request"],
+    [404, "request"],
+    // Unrecognized statuses stay loud rather than being assumed to be someone else's problem.
+    [418, "request"],
+  ])("classifies HTTP %i as %s", (status, expected) => {
+    expect(
+      classifyNcnFailure(
+        new NcnApiHttpError("meta", status, { url: URL_UNDER_TEST })
+      )
+    ).toBe(expected);
+  });
+
+  it.each([
+    ["NcnApiNetworkError", new NcnApiNetworkError("nope", URL_UNDER_TEST)],
+    ["a network TypeError", new TypeError("Load failed")],
+  ])("classifies %s as network", (_label, error) => {
+    expect(classifyNcnFailure(error)).toBe("network");
+  });
+
+  it.each([
+    ["an unrelated Error", new Error("boom")],
+    ["a non-Error", "nope"],
+  ])("returns undefined for %s", (_label, error) => {
+    expect(classifyNcnFailure(error)).toBeUndefined();
+  });
+});
+
+describe("isPermanentNcnFailure", () => {
+  it.each([
+    [400, true],
+    [404, true],
+    [403, false],
+    [503, false],
+  ])("HTTP %i => %s", (status, expected) => {
+    expect(
+      isPermanentNcnFailure(
+        new NcnApiHttpError("meta", status, { url: URL_UNDER_TEST })
+      )
+    ).toBe(expected);
+  });
+
+  it.each([
+    ["a network failure", new NcnApiNetworkError("nope", URL_UNDER_TEST)],
+    ["an unrelated error", new Error("boom")],
+  ])("does not treat %s as permanent", (_label, error) => {
+    expect(isPermanentNcnFailure(error)).toBe(false);
   });
 });

--- a/frontend/src/lib/ncnApi.ts
+++ b/frontend/src/lib/ncnApi.ts
@@ -15,18 +15,48 @@ export const DEFAULT_NCN_API_URL = "https://ncn-governance.solana.com";
 /** The router stalls for ~20s when unhealthy; fail sooner and let React Query retry. */
 const DEFAULT_TIMEOUT_MS = 10_000;
 
+/** Enough of an error body to identify who refused us, without shipping a whole HTML page. */
+const MAX_BODY_SNIPPET_CHARS = 200;
+
+const hostOf = (url: string): string => {
+  try {
+    return new URL(url).host;
+  } catch {
+    return url;
+  }
+};
+
 /** The API answered, but with a non-2xx status. */
 export class NcnApiHttpError extends Error {
   readonly status: number;
+  /**
+   * Host that actually answered. Because the router redirects, this names the verifier operator
+   * that refused the request rather than the router we asked.
+   */
+  readonly host: string;
+  /** Start of the response body, or "" when it could not be read. Names which hop refused us. */
+  readonly bodySnippet: string;
 
-  constructor(label: string, status: number, statusText: string) {
+  constructor(
+    label: string,
+    status: number,
+    {
+      url,
+      statusText,
+      bodySnippet = "",
+    }: { url: string; statusText?: string; bodySnippet?: string }
+  ) {
+    const host = hostOf(url);
+
     // These endpoints are served over HTTP/2, which has no reason phrase, so statusText is
     // almost always empty. Always include the numeric status.
     super(
-      `Failed to get ${label}: ${statusText ? `${status} ${statusText}` : status}`
+      `Failed to get ${label} from ${host}: ${statusText ? `${status} ${statusText}` : status}`
     );
     this.name = "NcnApiHttpError";
     this.status = status;
+    this.host = host;
+    this.bodySnippet = bodySnippet;
   }
 }
 
@@ -36,21 +66,16 @@ export class NcnApiHttpError extends Error {
  */
 export class NcnApiNetworkError extends Error {
   readonly url: string;
+  /** Host we could not reach, or whose response failed the CORS check. */
+  readonly host: string;
 
   constructor(message: string, url: string, options?: { cause?: unknown }) {
     super(message, options);
     this.name = "NcnApiNetworkError";
     this.url = url;
+    this.host = hostOf(url);
   }
 }
-
-const hostOf = (url: string): string => {
-  try {
-    return new URL(url).host;
-  } catch {
-    return url;
-  }
-};
 
 /**
  * Whether an error is a network-level fetch failure rather than an application error.
@@ -68,6 +93,53 @@ export const isNetworkFailure = (error: unknown): boolean => {
       error.message
     )
   );
+};
+
+/** Sub-500 statuses that still mean a hop refused or shed the request, not that we asked wrong. */
+const UPSTREAM_STATUSES = new Set([403, 408, 429]);
+
+export type NcnFailureKind = "network" | "upstream" | "request";
+
+/**
+ * How to treat an NCN API failure, or `undefined` for an error that did not come out of this
+ * client (which the caller should report unchanged).
+ *
+ * `request` is the fallback for unrecognized statuses on purpose: a status meaning our request was
+ * wrong has to stay visible, while a new upstream status costs one noisy report before we add it
+ * to `UPSTREAM_STATUSES`.
+ */
+export const classifyNcnFailure = (
+  error: unknown
+): NcnFailureKind | undefined => {
+  if (isNetworkFailure(error)) return "network";
+  if (!(error instanceof NcnApiHttpError)) return undefined;
+
+  return error.status >= 500 || UPSTREAM_STATUSES.has(error.status)
+    ? "upstream"
+    : "request";
+};
+
+/**
+ * Whether retrying is pointless because the upstream already answered definitively.
+ *
+ * The router redirects to a randomly chosen operator per request, so a retry doubles as this app's
+ * operator failover: worth spending on a 403 or a 5xx, wasted on a 404 that every operator would
+ * repeat.
+ */
+export const isPermanentNcnFailure = (error: unknown): boolean =>
+  classifyNcnFailure(error) === "request";
+
+/**
+ * Never throws. The internal timeout is still armed while the body is read, so letting an abort
+ * escape here would trade a known status for an opaque AbortError — the exact failure this client
+ * exists to prevent.
+ */
+const readBodySnippet = async (response: Response): Promise<string> => {
+  try {
+    return (await response.text()).trim().slice(0, MAX_BODY_SNIPPET_CHARS);
+  } catch {
+    return "";
+  }
 };
 
 interface FetchNcnJsonOptions {
@@ -104,7 +176,13 @@ export async function fetchNcnJson<T>(
     const response = await fetch(url, { signal: controller.signal });
 
     if (!response.ok) {
-      throw new NcnApiHttpError(label, response.status, response.statusText);
+      throw new NcnApiHttpError(label, response.status, {
+        // After the router's redirect this is the operator that actually answered, which is the
+        // one fact the status alone never tells us.
+        url: response.url || url,
+        statusText: response.statusText,
+        bodySnippet: await readBodySnippet(response),
+      });
     }
 
     return (await response.json()) as T;
@@ -115,10 +193,12 @@ export async function fetchNcnJson<T>(
     if (signal?.aborted) throw error;
 
     if (timedOut) {
+      // No `cause`: the only error reachable here is the DOMException from our own
+      // controller.abort(), which Sentry's linkedErrors integration would upload as a second
+      // exception ("signal is aborted without reason") saying nothing beyond "we aborted".
       throw new NcnApiNetworkError(
         `Timed out after ${timeoutMs}ms getting ${label} from ${hostOf(url)}`,
-        url,
-        { cause: error }
+        url
       );
     }
 


### PR DESCRIPTION
 - add manual retry to snapshot meta requests
 - add additional info to failure logs for better sentry filtering