### PR TITLE
fix(svmgov-cli): Harden the Vote Path Against Operator API Failures

### DIFF
--- a/svmgov/cli/src/instructions/cast_vote.rs
+++ b/svmgov/cli/src/instructions/cast_vote.rs
@@ -10,7 +10,7 @@ use crate::{
     constants::*,
     svmgov_program::{accounts::Proposal, client::{accounts, args}},
     utils::{
-        api_helpers::{self, get_vote_account_proof},
+        api_helpers::{self, convert_merkle_proof_strings, get_vote_account_proof},
         utils::{
             compute_vote_expiry_timestamp, create_spinner, derive_vote_override_cache_pda,
             derive_vote_pda, setup_all,
@@ -92,8 +92,11 @@ pub async fn cast_vote(
 
         let init_spinner = create_spinner("Initializing meta merkle proof...");
 
-        let voting_wallet = Pubkey::from_str(&proof_response.meta_merkle_leaf.voting_wallet)
-            .map_err(|e| anyhow!("Invalid voting wallet in proof: {}", e))?;
+        // Validate every field from the operator API rather than assuming it is
+        // well-formed: these converters return a clear error, where the const
+        // base58 decoder would panic on a malformed response.
+        let meta_merkle_leaf = MetaMerkleLeaf::try_from(&proof_response.meta_merkle_leaf)?;
+        let meta_merkle_proof = convert_merkle_proof_strings(&proof_response.meta_merkle_proof)?;
 
         let close_timestamp = match close_timestamp_override {
             Some(ts) => ts,
@@ -105,20 +108,8 @@ pub async fn cast_vote(
             .request()
             .args(ncn_snapshot::instruction::InitMetaMerkleProof {
                 close_timestamp,
-                meta_merkle_leaf: MetaMerkleLeaf {
-                    voting_wallet,
-                    vote_account,
-                    stake_merkle_root: Pubkey::from_str_const(
-                        proof_response.meta_merkle_leaf.stake_merkle_root.as_str(),
-                    )
-                    .to_bytes(),
-                    active_stake: proof_response.meta_merkle_leaf.active_stake,
-                },
-                meta_merkle_proof: proof_response
-                    .meta_merkle_proof
-                    .iter()
-                    .map(|s| Pubkey::from_str_const(s).to_bytes())
-                    .collect(),
+                meta_merkle_leaf,
+                meta_merkle_proof,
             })
             .accounts(ncn_snapshot::accounts::InitMetaMerkleProof {
                 consensus_result: consensus_result_pda,

--- a/svmgov/cli/src/instructions/cast_vote.rs
+++ b/svmgov/cli/src/instructions/cast_vote.rs
@@ -93,8 +93,7 @@ pub async fn cast_vote(
         let init_spinner = create_spinner("Initializing meta merkle proof...");
 
         // Validate every field from the operator API rather than assuming it is
-        // well-formed: these converters return a clear error, where the const
-        // base58 decoder would panic on a malformed response.
+        // well-formed
         let meta_merkle_leaf = MetaMerkleLeaf::try_from(&proof_response.meta_merkle_leaf)?;
         let meta_merkle_proof = convert_merkle_proof_strings(&proof_response.meta_merkle_proof)?;
 

--- a/svmgov/cli/src/instructions/cast_vote_override.rs
+++ b/svmgov/cli/src/instructions/cast_vote_override.rs
@@ -118,8 +118,12 @@ pub async fn cast_vote_override(
     if meta_merkle_proof_account.is_none() {
         info!("Creating meta merkle proof account");
 
-        let voting_wallet = Pubkey::from_str(&meta_merkle_proof.meta_merkle_leaf.voting_wallet)
-            .map_err(|e| anyhow!("Invalid voting wallet in proof: {}", e))?;
+        // Validate every field from the operator API rather than assuming it is
+        // well-formed: these converters return a clear error, where the const
+        // base58 decoder would panic on a malformed response.
+        let meta_merkle_leaf = MetaMerkleLeaf::try_from(&meta_merkle_proof.meta_merkle_leaf)?;
+        let meta_merkle_proof_hashes =
+            convert_merkle_proof_strings(&meta_merkle_proof.meta_merkle_proof)?;
 
         let close_timestamp = match close_timestamp_override {
             Some(ts) => ts,
@@ -131,23 +135,8 @@ pub async fn cast_vote_override(
             .request()
             .args(ncn_snapshot::instruction::InitMetaMerkleProof {
                 close_timestamp,
-                meta_merkle_leaf: MetaMerkleLeaf {
-                    voting_wallet,
-                    vote_account: vote_account_pubkey,
-                    stake_merkle_root: Pubkey::from_str_const(
-                        meta_merkle_proof
-                            .meta_merkle_leaf
-                            .stake_merkle_root
-                            .as_str(),
-                    )
-                    .to_bytes(),
-                    active_stake: meta_merkle_proof.meta_merkle_leaf.active_stake,
-                },
-                meta_merkle_proof: meta_merkle_proof
-                    .meta_merkle_proof
-                    .iter()
-                    .map(|s| Pubkey::from_str_const(s).to_bytes())
-                    .collect(),
+                meta_merkle_leaf,
+                meta_merkle_proof: meta_merkle_proof_hashes,
             })
             .accounts(ncn_snapshot::accounts::InitMetaMerkleProof {
                 consensus_result: consensus_result_pda,

--- a/svmgov/cli/src/instructions/cast_vote_override.rs
+++ b/svmgov/cli/src/instructions/cast_vote_override.rs
@@ -119,8 +119,7 @@ pub async fn cast_vote_override(
         info!("Creating meta merkle proof account");
 
         // Validate every field from the operator API rather than assuming it is
-        // well-formed: these converters return a clear error, where the const
-        // base58 decoder would panic on a malformed response.
+        // well-formed
         let meta_merkle_leaf = MetaMerkleLeaf::try_from(&meta_merkle_proof.meta_merkle_leaf)?;
         let meta_merkle_proof_hashes =
             convert_merkle_proof_strings(&meta_merkle_proof.meta_merkle_proof)?;

--- a/svmgov/cli/src/utils/api_helpers.rs
+++ b/svmgov/cli/src/utils/api_helpers.rs
@@ -35,6 +35,25 @@ async fn ensure_ok(
     ))
 }
 
+/// Reject a proof that describes a different account than the one requested.
+/// The leaf seeds the MetaMerkleProof PDA and is what the program verifies
+/// against the consensus root, so its identity is load-bearing — a mismatch
+/// would otherwise surface much later as an on-chain constraint failure.
+fn ensure_matches_request(
+    returned: &str,
+    requested: &str,
+    kind: &str,
+    base_url: &str,
+) -> Result<()> {
+    if returned != requested {
+        return Err(anyhow!(
+            "The operator API at {base_url} returned a proof for {kind} {returned} but \
+             {requested} was requested."
+        ));
+    }
+    Ok(())
+}
+
 fn http_client() -> Result<reqwest::Client> {
     reqwest::Client::builder()
         .timeout(REQUEST_TIMEOUT)
@@ -119,6 +138,13 @@ pub async fn get_vote_account_proof(
         .await
         .map_err(|e| anyhow!("Malformed vote account proof from {}: {}", base_url, e))?;
 
+    ensure_matches_request(
+        &proof.meta_merkle_leaf.vote_account,
+        vote_account,
+        "vote account",
+        &base_url,
+    )?;
+
     log::debug!(
         "Got vote account proof: leaf stake={}, proof elements={}",
         proof.meta_merkle_leaf.active_stake,
@@ -153,6 +179,13 @@ pub async fn get_stake_account_proof(
         .json()
         .await
         .map_err(|e| anyhow!("Malformed stake account proof from {}: {}", base_url, e))?;
+
+    ensure_matches_request(
+        &proof.stake_merkle_leaf.stake_account,
+        stake_account,
+        "stake account",
+        &base_url,
+    )?;
 
     log::debug!(
         "Got stake account proof: leaf stake={}, proof elements={}",
@@ -353,6 +386,24 @@ mod tests {
     fn an_empty_proof_is_valid() {
         // A single-leaf tree yields no sibling hashes; that is not an error.
         assert_eq!(convert_merkle_proof_strings(&[]).unwrap().len(), 0);
+    }
+
+    #[test]
+    fn a_proof_for_a_different_account_is_rejected() {
+        let requested = "11111111111111111111111111111111";
+        assert!(ensure_matches_request(requested, requested, "vote account", "http://x").is_ok());
+
+        let err = ensure_matches_request(
+            "SysvarC1ock11111111111111111111111111111111",
+            requested,
+            "vote account",
+            "http://x",
+        )
+        .expect_err("a proof for another account must be rejected");
+        // The message has to name both accounts, or the operator cannot debug it.
+        let msg = err.to_string();
+        assert!(msg.contains(requested), "{msg}");
+        assert!(msg.contains("SysvarC1ock"), "{msg}");
     }
 
     #[test]

--- a/svmgov/cli/src/utils/api_helpers.rs
+++ b/svmgov/cli/src/utils/api_helpers.rs
@@ -1,10 +1,46 @@
-use std::str::FromStr;
+use std::{str::FromStr, time::Duration};
 
 use anchor_lang::prelude::Pubkey;
 use anyhow::{anyhow, Result};
 use log::info;
 use ncn_snapshot::{MetaMerkleLeaf, MetaMerkleProof, StakeMerkleLeaf};
 use serde::{Deserialize, Serialize};
+
+/// Bound on a single proof request. The operator fleet is externally operated
+/// and some endpoints have been observed accepting connections without ever
+/// responding; `reqwest::get` uses a client with no timeout, which would leave a
+/// validator hanging with no error at all. Mirrors `proposal_link.rs`.
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(15);
+
+/// Turn a non-success response into an actionable error. A stale operator that
+/// has not uploaded the proposal's snapshot answers 404, which would otherwise
+/// reach `response.json()` and surface as an opaque deserialization failure.
+async fn ensure_ok(
+    response: reqwest::Response,
+    what: &str,
+    base_url: &str,
+) -> Result<reqwest::Response> {
+    let status = response.status();
+    if status.is_success() {
+        return Ok(response);
+    }
+    if status == reqwest::StatusCode::NOT_FOUND {
+        return Err(anyhow!(
+            "The operator API at {base_url} has no {what} for this snapshot slot (404). It may not \
+             have uploaded this snapshot yet — retry, or point --operator-api-url at another operator."
+        ));
+    }
+    Err(anyhow!(
+        "The operator API at {base_url} returned {status} for the {what}."
+    ))
+}
+
+fn http_client() -> Result<reqwest::Client> {
+    reqwest::Client::builder()
+        .timeout(REQUEST_TIMEOUT)
+        .build()
+        .map_err(|e| anyhow!("Failed to build HTTP client: {}", e))
+}
 
 /// Vote account summary in voter response
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -72,9 +108,16 @@ pub async fn get_vote_account_proof(
 
     log::debug!("Fetching vote account proof from: {}", url);
 
-    let response = reqwest::get(&url).await?;
-    info!("Response: {:?}", url);
-    let proof: VoteAccountProofResponse = response.json().await?;
+    let response = http_client()?
+        .get(&url)
+        .send()
+        .await
+        .map_err(|e| anyhow!("Failed to reach the operator API at {}: {}", base_url, e))?;
+    let response = ensure_ok(response, "vote account proof", &base_url).await?;
+    let proof: VoteAccountProofResponse = response
+        .json()
+        .await
+        .map_err(|e| anyhow!("Malformed vote account proof from {}: {}", base_url, e))?;
 
     log::debug!(
         "Got vote account proof: leaf stake={}, proof elements={}",
@@ -100,8 +143,16 @@ pub async fn get_stake_account_proof(
 
     log::debug!("Fetching stake account proof from: {}", url);
 
-    let response = reqwest::get(&url).await?;
-    let proof: StakeAccountProofResponse = response.json().await?;
+    let response = http_client()?
+        .get(&url)
+        .send()
+        .await
+        .map_err(|e| anyhow!("Failed to reach the operator API at {}: {}", base_url, e))?;
+    let response = ensure_ok(response, "stake account proof", &base_url).await?;
+    let proof: StakeAccountProofResponse = response
+        .json()
+        .await
+        .map_err(|e| anyhow!("Malformed stake account proof from {}: {}", base_url, e))?;
 
     log::debug!(
         "Got stake account proof: leaf stake={}, proof elements={}",
@@ -250,4 +301,65 @@ pub fn generate_meta_merkle_proof_pda(
 ) -> Result<Pubkey> {
     let (pda, _bump) = MetaMerkleProof::pda(consensus_result_pda, vote_account);
     Ok(pda)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn leaf(stake_merkle_root: &str) -> MetaMerkleLeafData {
+        MetaMerkleLeafData {
+            voting_wallet: "11111111111111111111111111111111".to_string(),
+            vote_account: "11111111111111111111111111111111".to_string(),
+            stake_merkle_root: stake_merkle_root.to_string(),
+            active_stake: 1,
+        }
+    }
+
+    /// The vote paths used to feed these strings to `Pubkey::from_str_const`, a
+    /// const decoder that panics on bad input, so a malformed operator response
+    /// aborted the CLI with a stack trace instead of an error a validator could
+    /// act on. Every rejection below must be an `Err`, never a panic.
+    #[test]
+    fn a_malformed_stake_merkle_root_is_an_error_not_a_panic() {
+        for bad in [
+            "",
+            "abc",
+            "not-base58-0OIl",
+            "1111111111111111111111111111111",
+        ] {
+            let result = MetaMerkleLeaf::try_from(&leaf(bad));
+            assert!(result.is_err(), "expected an error for {bad:?}");
+        }
+    }
+
+    #[test]
+    fn a_valid_leaf_still_converts() {
+        // 32 zero bytes in base58 — the shape a real snapshot root has.
+        let ok = MetaMerkleLeaf::try_from(&leaf("11111111111111111111111111111111"));
+        assert!(ok.is_ok());
+        assert_eq!(ok.unwrap().active_stake, 1);
+    }
+
+    #[test]
+    fn a_malformed_proof_hash_is_an_error_not_a_panic() {
+        for bad in ["", "abc", "not-base58-0OIl"] {
+            let result = convert_merkle_proof_strings(&[bad.to_string()]);
+            assert!(result.is_err(), "expected an error for {bad:?}");
+        }
+    }
+
+    #[test]
+    fn an_empty_proof_is_valid() {
+        // A single-leaf tree yields no sibling hashes; that is not an error.
+        assert_eq!(convert_merkle_proof_strings(&[]).unwrap().len(), 0);
+    }
+
+    #[test]
+    fn a_wrong_length_hash_is_rejected() {
+        // Decodes as valid base58 but is not 32 bytes — the case a length-blind
+        // decoder would silently accept or truncate.
+        let short = bs58::encode([0u8; 31]).into_string();
+        assert!(convert_merkle_proof_strings(&[short]).is_err());
+    }
 }

--- a/svmgov/cli/src/utils/api_helpers.rs
+++ b/svmgov/cli/src/utils/api_helpers.rs
@@ -6,10 +6,6 @@ use log::info;
 use ncn_snapshot::{MetaMerkleLeaf, MetaMerkleProof, StakeMerkleLeaf};
 use serde::{Deserialize, Serialize};
 
-/// Bound on a single proof request. The operator fleet is externally operated
-/// and some endpoints have been observed accepting connections without ever
-/// responding; `reqwest::get` uses a client with no timeout, which would leave a
-/// validator hanging with no error at all. Mirrors `proposal_link.rs`.
 const REQUEST_TIMEOUT: Duration = Duration::from_secs(15);
 
 /// Turn a non-success response into an actionable error. A stale operator that
@@ -35,25 +31,10 @@ async fn ensure_ok(
     ))
 }
 
-/// Reject a proof that describes a different account than the one requested.
-/// The leaf seeds the MetaMerkleProof PDA and is what the program verifies
-/// against the consensus root, so its identity is load-bearing — a mismatch
-/// would otherwise surface much later as an on-chain constraint failure.
-fn ensure_matches_request(
-    returned: &str,
-    requested: &str,
-    kind: &str,
-    base_url: &str,
-) -> Result<()> {
-    if returned != requested {
-        return Err(anyhow!(
-            "The operator API at {base_url} returned a proof for {kind} {returned} but \
-             {requested} was requested."
-        ));
-    }
-    Ok(())
-}
-
+/// The operator fleet is externally operated, and some endpoints have been
+/// observed accepting connections without ever responding. `reqwest::get` uses a
+/// client with no timeout, which leaves a validator hanging with no error at
+/// all, so every request goes through a client that is bounded.
 fn http_client() -> Result<reqwest::Client> {
     reqwest::Client::builder()
         .timeout(REQUEST_TIMEOUT)
@@ -112,6 +93,44 @@ pub struct StakeMerkleLeafData {
     pub active_stake: u64,
 }
 
+/// Rejects a proof whose leaf describes a vote account other than the one
+/// requested. The leaf seeds the `MetaMerkleProof` PDA and is what the program
+/// verifies against the consensus root, so its identity is load-bearing — a
+/// mismatch would otherwise surface much later as an on-chain constraint
+/// failure.
+fn ensure_vote_account_matches(
+    proof: &VoteAccountProofResponse,
+    requested: &str,
+    base_url: &str,
+) -> Result<()> {
+    let returned = &proof.meta_merkle_leaf.vote_account;
+    if returned != requested {
+        return Err(anyhow!(
+            "The operator API at {base_url} returned a proof for vote account {returned} but \
+             {requested} was requested."
+        ));
+    }
+    Ok(())
+}
+
+/// Rejects a proof whose leaf describes a stake account other than the one
+/// requested. See [`ensure_vote_account_matches`] for why the leaf's identity
+/// matters.
+fn ensure_stake_account_matches(
+    proof: &StakeAccountProofResponse,
+    requested: &str,
+    base_url: &str,
+) -> Result<()> {
+    let returned = &proof.stake_merkle_leaf.stake_account;
+    if returned != requested {
+        return Err(anyhow!(
+            "The operator API at {base_url} returned a proof for stake account {returned} but \
+             {requested} was requested."
+        ));
+    }
+    Ok(())
+}
+
 /// Get merkle proof for a vote account
 /// Endpoint: GET /proof/vote_account/:vote_account?snapshot_slot=...
 pub async fn get_vote_account_proof(
@@ -138,12 +157,7 @@ pub async fn get_vote_account_proof(
         .await
         .map_err(|e| anyhow!("Malformed vote account proof from {}: {}", base_url, e))?;
 
-    ensure_matches_request(
-        &proof.meta_merkle_leaf.vote_account,
-        vote_account,
-        "vote account",
-        &base_url,
-    )?;
+    ensure_vote_account_matches(&proof, vote_account, &base_url)?;
 
     log::debug!(
         "Got vote account proof: leaf stake={}, proof elements={}",
@@ -180,12 +194,7 @@ pub async fn get_stake_account_proof(
         .await
         .map_err(|e| anyhow!("Malformed stake account proof from {}: {}", base_url, e))?;
 
-    ensure_matches_request(
-        &proof.stake_merkle_leaf.stake_account,
-        stake_account,
-        "stake account",
-        &base_url,
-    )?;
+    ensure_stake_account_matches(&proof, stake_account, &base_url)?;
 
     log::debug!(
         "Got stake account proof: leaf stake={}, proof elements={}",
@@ -388,19 +397,65 @@ mod tests {
         assert_eq!(convert_merkle_proof_strings(&[]).unwrap().len(), 0);
     }
 
-    #[test]
-    fn a_proof_for_a_different_account_is_rejected() {
-        let requested = "11111111111111111111111111111111";
-        assert!(ensure_matches_request(requested, requested, "vote account", "http://x").is_ok());
+    const OTHER_ACCOUNT: &str = "SysvarC1ock11111111111111111111111111111111";
 
-        let err = ensure_matches_request(
-            "SysvarC1ock11111111111111111111111111111111",
+    fn vote_account_proof(vote_account: &str) -> VoteAccountProofResponse {
+        VoteAccountProofResponse {
+            network: "mainnet".to_string(),
+            snapshot_slot: 1,
+            meta_merkle_leaf: MetaMerkleLeafData {
+                vote_account: vote_account.to_string(),
+                ..leaf("11111111111111111111111111111111")
+            },
+            meta_merkle_proof: vec![],
+        }
+    }
+
+    fn stake_account_proof(stake_account: &str) -> StakeAccountProofResponse {
+        StakeAccountProofResponse {
+            network: "mainnet".to_string(),
+            snapshot_slot: 1,
+            stake_merkle_leaf: StakeMerkleLeafData {
+                voting_wallet: "11111111111111111111111111111111".to_string(),
+                stake_account: stake_account.to_string(),
+                active_stake: 1,
+            },
+            stake_merkle_proof: vec![],
+            vote_account: "11111111111111111111111111111111".to_string(),
+        }
+    }
+
+    #[test]
+    fn a_vote_account_proof_for_a_different_account_is_rejected() {
+        let requested = "11111111111111111111111111111111";
+        assert!(
+            ensure_vote_account_matches(&vote_account_proof(requested), requested, "http://x")
+                .is_ok()
+        );
+
+        let err =
+            ensure_vote_account_matches(&vote_account_proof(OTHER_ACCOUNT), requested, "http://x")
+                .expect_err("a proof for another account must be rejected");
+        // The message has to name both accounts, or the operator cannot debug it.
+        let msg = err.to_string();
+        assert!(msg.contains(requested), "{msg}");
+        assert!(msg.contains("SysvarC1ock"), "{msg}");
+    }
+
+    #[test]
+    fn a_stake_account_proof_for_a_different_account_is_rejected() {
+        let requested = "11111111111111111111111111111111";
+        assert!(
+            ensure_stake_account_matches(&stake_account_proof(requested), requested, "http://x")
+                .is_ok()
+        );
+
+        let err = ensure_stake_account_matches(
+            &stake_account_proof(OTHER_ACCOUNT),
             requested,
-            "vote account",
             "http://x",
         )
         .expect_err("a proof for another account must be rejected");
-        // The message has to name both accounts, or the operator cannot debug it.
         let msg = err.to_string();
         assert!(msg.contains(requested), "{msg}");
         assert!(msg.contains("SysvarC1ock"), "{msg}");


### PR DESCRIPTION
## TL;DR

I swept the CLI vote path ahead of voting opening at epoch 1021 and found four ways it can fail badly: 
- an unbounded request that can hang forever
- an opaque error for the 404 a stale operator returns
- a panic on malformed responses, and
- a leaf/PDA inconsistency that would fail with no explanation

All are on `cast-vote` and `cast-vote-override`, which are the commands validators run to vote

## 1. No request timeout

The proof fetches used `reqwest::get`, whose default client has no timeout. `proposal_link.rs` already builds its own client for precisely this reason, with the comment "the default client has no timeout"; the proof path never got the same treatment

Both fetches are now bounded at 15s

## 2. Unhandled non-200

A non-success response went straight into `response.json()`, so the 404 a stale operator returns for a snapshot it has not uploaded surfaced as an opaque deserialization failure. With four operators still frozen at slot 422497000, that 404 is an expected outcome rather than an edge case

Now:

```
The operator API at https://... has no vote account proof for this snapshot slot
(404). It may not have uploaded this snapshot yet — retry, or point
--operator-api-url at another operator.
```

## 3. Leaf/PDA inconsistency

`init_meta_merkle_proof` seeds its PDA from `meta_merkle_leaf.vote_account`. The old code built that leaf from the locally derived vote account while passing a PDA derived from the API's. Identical in the normal case, but any divergence produced an Anchor `ConstraintSeeds` failure with nothing pointing at the cause

Sourcing the whole leaf from the response makes them consistent. Flagging it explicitly because it is a behavior change sitting inside what otherwise reads as a pure refactor

That also means the CLI now takes the account identity on trust, so it is now checked: a proof returned for a different vote or stake account than the one requested fails immediately, naming both

## 4. Panic on a malformed response

`Pubkey::from_str_const` decodes base58 in a const context and panics on bad input:

```
""                                 -> PANIC
"abc"                              -> PANIC
"not-base58-0OIl"                  -> PANIC
"11111111111111111111111111111111" -> ok
```

Both vote paths passed `stake_merkle_root` and every proof hash from the operator response straight into it, so a malformed reply aborted the CLI with a stack trace instead of an error a validator could act on

Fixed by using `MetaMerkleLeaf::try_from` and `convert_merkle_proof_strings`, validating converters that already existed in the same module and were already used on the stake-proof path. The vote path simply wasn't using them

## Tests

- Six tests covering every input that previously panicked — empty, short, non-base58, and valid-base58-but-wrong-length — asserting an `Err` rather than an abort, plus the valid cases, the legitimately empty proof a single-leaf tree produces, and the wrong-account rejection
- `grep` confirms no `from_str_const` on runtime data and no bare `reqwest::get` remains anywhere in the CLI
- `cargo test` in `svmgov/cli` → 36 passed
- Build clean with no new warnings
- `api_helpers.rs` at its rustfmt baseline