### PR TITLE
feat(verifier): Record and Serve the Snapshot's Total Active Stake

### DIFF
--- a/ncn/verifier-service/src/database/constants.rs
+++ b/ncn/verifier-service/src/database/constants.rs
@@ -4,7 +4,10 @@
 pub const CURRENT_SCHEMA_VERSION: i32 = 1;
 
 /// Migration descriptions
-pub const MIGRATION_DESCRIPTIONS: &[&str] = &["Initial schema with network support"];
+pub const MIGRATION_DESCRIPTIONS: &[&str] = &[
+    "Initial schema with network support",
+    "Add snapshot_meta.total_active_stake",
+];
 
 /// Default database file name
 pub const DEFAULT_DB_PATH: &str = "governance.db";

--- a/ncn/verifier-service/src/database/constants.rs
+++ b/ncn/verifier-service/src/database/constants.rs
@@ -1,7 +1,7 @@
 //! Database migration constants and metadata
 
 /// Current database schema version
-pub const CURRENT_SCHEMA_VERSION: i32 = 1;
+pub const CURRENT_SCHEMA_VERSION: i32 = 2;
 
 /// Migration descriptions
 pub const MIGRATION_DESCRIPTIONS: &[&str] = &[

--- a/ncn/verifier-service/src/database/migrator.rs
+++ b/ncn/verifier-service/src/database/migrator.rs
@@ -90,11 +90,12 @@ async fn apply_migration_v1(pool: &SqlitePool) -> Result<()> {
 
 /// Apply migration version 2: record the snapshot's total active stake.
 ///
-/// v1 databases already contain the column when created fresh, because
-/// `CREATE_SNAPSHOT_META_TABLE_SQL` was updated alongside this migration; the
-/// `ALTER TABLE` is therefore only reached by a database created before that
-/// change. Its failure is treated as fatal rather than ignored, so a genuinely
-/// broken schema surfaces at start-up instead of at query time.
+/// A database created after this change already has the column, because
+/// `CREATE_SNAPSHOT_META_TABLE_SQL` gained it at the same time — so the
+/// `ALTER TABLE` is only needed by a database created before it. SQLite has no
+/// `ADD COLUMN IF NOT EXISTS`, so the column is probed first rather than
+/// running the `ALTER` and swallowing its error, which would also hide a
+/// genuinely broken schema.
 async fn apply_migration_v2(pool: &SqlitePool) -> Result<()> {
     info!("Applying migration v2: {}", MIGRATION_DESCRIPTIONS[1]);
 
@@ -125,4 +126,108 @@ async fn apply_migration_v2(pool: &SqlitePool) -> Result<()> {
 
     info!("Migration v2 completed successfully");
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::database::models::SnapshotMetaRecord;
+    use crate::database::sql::{
+        CREATE_MIGRATIONS_TABLE_SQL, CREATE_STAKE_ACCOUNTS_TABLE_SQL,
+        CREATE_VOTE_ACCOUNTS_TABLE_SQL,
+    };
+
+    /// `snapshot_meta` exactly as v1 created it, before `total_active_stake`.
+    const V1_SNAPSHOT_META_TABLE_SQL: &str = r#"
+CREATE TABLE snapshot_meta (
+    network TEXT NOT NULL,
+    slot INTEGER NOT NULL,
+    merkle_root TEXT NOT NULL,
+    snapshot_hash TEXT NOT NULL,
+    created_at TEXT NOT NULL,
+    PRIMARY KEY (network, slot)
+)
+"#;
+
+    async fn pool() -> SqlitePool {
+        SqlitePool::connect("sqlite::memory:").await.unwrap()
+    }
+
+    /// A database at the pre-v2 schema, with a row already in it.
+    async fn legacy_v1_database() -> SqlitePool {
+        let pool = pool().await;
+        for sql in [
+            CREATE_MIGRATIONS_TABLE_SQL,
+            CREATE_VOTE_ACCOUNTS_TABLE_SQL,
+            CREATE_STAKE_ACCOUNTS_TABLE_SQL,
+            V1_SNAPSHOT_META_TABLE_SQL,
+        ] {
+            sqlx::query(sql).execute(&pool).await.unwrap();
+        }
+        sqlx::query(
+            "INSERT INTO schema_migrations (version, applied_at, description) VALUES (1, '', 'v1')",
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+        sqlx::query(
+            "INSERT INTO snapshot_meta (network, slot, merkle_root, snapshot_hash, created_at)
+             VALUES ('mainnet', 100, 'root', 'hash', '2026-01-01T00:00:00Z')",
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+        pool
+    }
+
+    #[tokio::test]
+    async fn upgrading_a_v1_database_adds_the_column_and_keeps_existing_rows() {
+        let pool = legacy_v1_database().await;
+        run_migrations(&pool).await.unwrap();
+
+        assert_eq!(get_current_version(&pool).await.unwrap(), 2);
+
+        // The pre-existing snapshot survives, with an unknown total rather than
+        // a fabricated one — it cannot be back-filled without the upload.
+        let record = SnapshotMetaRecord::get_latest(&pool, "mainnet")
+            .await
+            .unwrap()
+            .expect("the v1 row must still be readable");
+        assert_eq!(record.slot, 100);
+        assert_eq!(record.merkle_root, "root");
+        assert_eq!(record.total_active_stake, None);
+    }
+
+    #[tokio::test]
+    async fn a_fresh_database_lands_on_v2_with_the_column_present() {
+        let pool = pool().await;
+        run_migrations(&pool).await.unwrap();
+        assert_eq!(get_current_version(&pool).await.unwrap(), 2);
+
+        let record = SnapshotMetaRecord {
+            network: "mainnet".to_string(),
+            slot: 1,
+            merkle_root: "root".to_string(),
+            snapshot_hash: "hash".to_string(),
+            created_at: "2026-01-01T00:00:00Z".to_string(),
+            total_active_stake: Some(4_000_000_000_000_000),
+        };
+        record.insert_exec(&pool).await.unwrap();
+
+        let read = SnapshotMetaRecord::get_latest(&pool, "mainnet")
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(read.total_active_stake, Some(4_000_000_000_000_000));
+    }
+
+    #[tokio::test]
+    async fn migrations_are_idempotent() {
+        // Startup runs these on every boot; a second pass must be a no-op
+        // rather than failing on a duplicate ALTER.
+        let pool = legacy_v1_database().await;
+        run_migrations(&pool).await.unwrap();
+        run_migrations(&pool).await.unwrap();
+        assert_eq!(get_current_version(&pool).await.unwrap(), 2);
+    }
 }

--- a/ncn/verifier-service/src/database/migrator.rs
+++ b/ncn/verifier-service/src/database/migrator.rs
@@ -6,8 +6,9 @@ use tracing::info;
 
 use super::constants::MIGRATION_DESCRIPTIONS;
 use super::sql::{
-    CREATE_DB_INDEXES, CREATE_MIGRATIONS_TABLE_SQL, CREATE_SNAPSHOT_META_TABLE_SQL,
-    CREATE_STAKE_ACCOUNTS_TABLE_SQL, CREATE_VOTE_ACCOUNTS_TABLE_SQL,
+    ADD_SNAPSHOT_TOTAL_ACTIVE_STAKE_SQL, CREATE_DB_INDEXES, CREATE_MIGRATIONS_TABLE_SQL,
+    CREATE_SNAPSHOT_META_TABLE_SQL, CREATE_STAKE_ACCOUNTS_TABLE_SQL,
+    CREATE_VOTE_ACCOUNTS_TABLE_SQL,
 };
 
 /// Run all pending database migrations
@@ -24,6 +25,9 @@ pub async fn run_migrations(pool: &SqlitePool) -> Result<()> {
     // Apply migrations in order
     if current_version < 1 {
         apply_migration_v1(pool).await?;
+    }
+    if current_version < 2 {
+        apply_migration_v2(pool).await?;
     }
 
     info!("All migrations completed");
@@ -81,5 +85,44 @@ async fn apply_migration_v1(pool: &SqlitePool) -> Result<()> {
     tx.commit().await?;
 
     info!("Migration v1 completed successfully");
+    Ok(())
+}
+
+/// Apply migration version 2: record the snapshot's total active stake.
+///
+/// v1 databases already contain the column when created fresh, because
+/// `CREATE_SNAPSHOT_META_TABLE_SQL` was updated alongside this migration; the
+/// `ALTER TABLE` is therefore only reached by a database created before that
+/// change. Its failure is treated as fatal rather than ignored, so a genuinely
+/// broken schema surfaces at start-up instead of at query time.
+async fn apply_migration_v2(pool: &SqlitePool) -> Result<()> {
+    info!("Applying migration v2: {}", MIGRATION_DESCRIPTIONS[1]);
+
+    let mut tx = pool.begin().await?;
+
+    let already_present = sqlx::query_scalar::<_, i64>(
+        "SELECT COUNT(*) FROM pragma_table_info('snapshot_meta') WHERE name = 'total_active_stake'",
+    )
+    .fetch_one(&mut *tx)
+    .await?;
+
+    if already_present == 0 {
+        sqlx::query(ADD_SNAPSHOT_TOTAL_ACTIVE_STAKE_SQL)
+            .execute(&mut *tx)
+            .await?;
+    }
+
+    sqlx::query(
+        "INSERT INTO schema_migrations (version, applied_at, description) VALUES (?, ?, ?)",
+    )
+    .bind(2)
+    .bind(chrono::Utc::now().to_rfc3339())
+    .bind(MIGRATION_DESCRIPTIONS[1])
+    .execute(&mut *tx)
+    .await?;
+
+    tx.commit().await?;
+
+    info!("Migration v2 completed successfully");
     Ok(())
 }

--- a/ncn/verifier-service/src/database/mod.rs
+++ b/ncn/verifier-service/src/database/mod.rs
@@ -109,7 +109,9 @@ CREATE TABLE snapshot_meta (
             .connect_with(
                 SqliteConnectOptions::from_str(&format!("sqlite:{path}"))
                     .unwrap()
-                    .create_if_missing(true),
+                    .create_if_missing(true)
+                    // Match what the pre-v2 service left on disk.
+                    .journal_mode(SqliteJournalMode::Wal),
             )
             .await
             .unwrap();

--- a/ncn/verifier-service/src/database/mod.rs
+++ b/ncn/verifier-service/src/database/mod.rs
@@ -54,14 +54,117 @@ pub async fn init_pool(db_path: &str) -> Result<SqlitePool> {
 
     let max_conns = env_parse::<u32>("SQLITE_MAX_CONNECTIONS", default_max_connections).max(1);
 
+    // Migrate on a dedicated pool, then open the serving pool against the final
+    // schema. A connection established before `ALTER TABLE` keeps the column
+    // metadata it saw at connect time, so `SELECT *` still yields the old column
+    // set and looking up a newly added column by name indexes past the end of the
+    // row, panicking the sqlx worker and turning the first read into a spurious
+    // 404. Only connections opened after the migration see the new column.
+    let migration_pool = SqlitePoolOptions::new()
+        .max_connections(1)
+        .connect_with(connect_options.clone())
+        .await?;
+
+    run_migrations(&migration_pool).await?;
+
     let pool = SqlitePoolOptions::new()
         .max_connections(max_conns)
         .connect_with(connect_options)
         .await?;
 
-    // Run migrations
-    run_migrations(&pool).await?;
+    // Closed only once the serving pool holds a connection: a shared in-memory
+    // database lives exactly as long as one is open.
+    migration_pool.close().await;
 
     info!("Database pool initialized successfully");
     Ok(pool)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::database::models::SnapshotMetaRecord;
+    use crate::database::sql::{
+        CREATE_MIGRATIONS_TABLE_SQL, CREATE_STAKE_ACCOUNTS_TABLE_SQL,
+        CREATE_VOTE_ACCOUNTS_TABLE_SQL,
+    };
+
+    /// `snapshot_meta` exactly as v1 created it, before `total_active_stake`.
+    const V1_SNAPSHOT_META_TABLE_SQL: &str = r#"
+CREATE TABLE snapshot_meta (
+    network TEXT NOT NULL,
+    slot INTEGER NOT NULL,
+    merkle_root TEXT NOT NULL,
+    snapshot_hash TEXT NOT NULL,
+    created_at TEXT NOT NULL,
+    PRIMARY KEY (network, slot)
+)
+"#;
+
+    /// Writes a v1 database to `path` and closes every connection to it, so the
+    /// pool under test has to open its own.
+    async fn write_legacy_v1_file(path: &str) {
+        let pool = SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect_with(
+                SqliteConnectOptions::from_str(&format!("sqlite:{path}"))
+                    .unwrap()
+                    .create_if_missing(true),
+            )
+            .await
+            .unwrap();
+        for sql in [
+            CREATE_MIGRATIONS_TABLE_SQL,
+            CREATE_VOTE_ACCOUNTS_TABLE_SQL,
+            CREATE_STAKE_ACCOUNTS_TABLE_SQL,
+            V1_SNAPSHOT_META_TABLE_SQL,
+        ] {
+            sqlx::query(sql).execute(&pool).await.unwrap();
+        }
+        sqlx::query(
+            "INSERT INTO schema_migrations (version, applied_at, description) VALUES (1, '', 'v1')",
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+        sqlx::query(
+            "INSERT INTO snapshot_meta (network, slot, merkle_root, snapshot_hash, created_at)
+             VALUES ('mainnet', 100, 'root', 'hash', '2026-01-01T00:00:00Z')",
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+        pool.close().await;
+    }
+
+    /// The upgrade path as a deployment actually runs it: an on-disk v1 database,
+    /// migrated by `init_pool`, then read through the pool it returns.
+    ///
+    /// The migrator's own tests cannot catch this. They migrate and read on one
+    /// connection, which sees the new column because it applied the `ALTER` — but
+    /// a serving connection opened beforehand keeps its original column metadata,
+    /// so `SELECT *` yields the v1 columns and resolving `total_active_stake`
+    /// indexes past the end of the row. That panics the sqlx worker, and the read
+    /// surfaces as "no snapshots found" rather than an error.
+    #[tokio::test]
+    async fn a_legacy_database_is_readable_through_the_pool_init_returns() {
+        let path = std::env::temp_dir()
+            .join(format!("verifier-legacy-{}.db", std::process::id()))
+            .to_string_lossy()
+            .into_owned();
+        let _ = fs::remove_file(&path);
+        write_legacy_v1_file(&path).await;
+
+        let pool = init_pool(&path).await.expect("init_pool must migrate");
+
+        let record = SnapshotMetaRecord::get_latest(&pool, "mainnet")
+            .await
+            .expect("reading a migrated legacy database must not fail")
+            .expect("the v1 row must still be found");
+        assert_eq!(record.slot, 100);
+        assert_eq!(record.total_active_stake, None);
+
+        pool.close().await;
+        let _ = fs::remove_file(&path);
+    }
 }

--- a/ncn/verifier-service/src/database/models/database.rs
+++ b/ncn/verifier-service/src/database/models/database.rs
@@ -42,4 +42,12 @@ pub struct SnapshotMetaRecord {
     pub merkle_root: String,
     pub snapshot_hash: String,
     pub created_at: String, // ISO8601 UTC timestamp
+    /// Total active stake across every meta leaf in this snapshot, in lamports.
+    ///
+    /// This is the denominator SGP-0001 Art. IV.3 defines quorum against: the
+    /// snapshot fixes the stake distribution for the whole voting period
+    /// (Art. IV.2), so a live cluster total would drift away from it as votes
+    /// come in. `None` for snapshots uploaded before this was recorded — those
+    /// cannot be back-filled without the original file.
+    pub total_active_stake: Option<u64>,
 }

--- a/ncn/verifier-service/src/database/operations.rs
+++ b/ncn/verifier-service/src/database/operations.rs
@@ -284,9 +284,13 @@ impl SnapshotMetaRecord {
                 merkle_root: row.get("merkle_root"),
                 snapshot_hash: row.get("snapshot_hash"),
                 created_at: row.get("created_at"),
+                // Checked, mirroring the write side. A negative value cannot
+                // be written, but `as u64` would turn one into an enormous
+                // quorum denominator, silently reporting participation as ~0%.
                 total_active_stake: row
                     .get::<Option<i64>, _>("total_active_stake")
-                    .map(|v| v as u64),
+                    .map(u64::try_from)
+                    .transpose()?,
             }))
         } else {
             Ok(None)

--- a/ncn/verifier-service/src/database/operations.rs
+++ b/ncn/verifier-service/src/database/operations.rs
@@ -244,18 +244,20 @@ impl SnapshotMetaRecord {
 
         sqlx::query(
             "INSERT INTO snapshot_meta
-             (network, slot, merkle_root, snapshot_hash, created_at)
-             VALUES (?, ?, ?, ?, ?)
+             (network, slot, merkle_root, snapshot_hash, created_at, total_active_stake)
+             VALUES (?, ?, ?, ?, ?, ?)
              ON CONFLICT(network, slot) DO UPDATE SET
              merkle_root = excluded.merkle_root,
              snapshot_hash = excluded.snapshot_hash,
-             created_at = excluded.created_at",
+             created_at = excluded.created_at,
+             total_active_stake = excluded.total_active_stake",
         )
         .bind(&self.network)
         .bind(i64::try_from(self.slot)?)
         .bind(&self.merkle_root)
         .bind(&self.snapshot_hash)
         .bind(&self.created_at)
+        .bind(self.total_active_stake.map(i64::try_from).transpose()?)
         .execute(exec)
         .await?;
 
@@ -282,6 +284,9 @@ impl SnapshotMetaRecord {
                 merkle_root: row.get("merkle_root"),
                 snapshot_hash: row.get("snapshot_hash"),
                 created_at: row.get("created_at"),
+                total_active_stake: row
+                    .get::<Option<i64>, _>("total_active_stake")
+                    .map(|v| v as u64),
             }))
         } else {
             Ok(None)

--- a/ncn/verifier-service/src/database/sql.rs
+++ b/ncn/verifier-service/src/database/sql.rs
@@ -59,7 +59,7 @@ pub const CREATE_DB_INDEXES: &[&str] = &[
 ];
 
 /// Adds `total_active_stake` to `snapshot_meta` for databases created before it
-/// existed. SQLite has no `ADD COLUMN IF NOT EXISTS`, so the migration is
-/// guarded by the schema version rather than being idempotent on its own.
+/// existed. SQLite has no `ADD COLUMN IF NOT EXISTS`, so `apply_migration_v2`
+/// checks `pragma_table_info` before running this.
 pub const ADD_SNAPSHOT_TOTAL_ACTIVE_STAKE_SQL: &str =
     "ALTER TABLE snapshot_meta ADD COLUMN total_active_stake INTEGER";

--- a/ncn/verifier-service/src/database/sql.rs
+++ b/ncn/verifier-service/src/database/sql.rs
@@ -41,6 +41,10 @@ CREATE TABLE snapshot_meta (
     merkle_root TEXT NOT NULL,
     snapshot_hash TEXT NOT NULL,
     created_at TEXT NOT NULL,
+    -- Total active stake across every meta leaf in the snapshot. NULL for rows
+    -- written before this column existed; those snapshots cannot be
+    -- back-filled without the original upload.
+    total_active_stake INTEGER,
     PRIMARY KEY (network, slot)
 )
 "#;
@@ -53,3 +57,9 @@ pub const CREATE_DB_INDEXES: &[&str] = &[
     "CREATE INDEX idx_vote_voting_wallet_order ON vote_accounts(network, voting_wallet, snapshot_slot, vote_account)",
     "CREATE INDEX idx_stake_voting_wallet_order ON stake_accounts(network, voting_wallet, snapshot_slot, stake_account)",
 ];
+
+/// Adds `total_active_stake` to `snapshot_meta` for databases created before it
+/// existed. SQLite has no `ADD COLUMN IF NOT EXISTS`, so the migration is
+/// guarded by the schema version rather than being idempotent on its own.
+pub const ADD_SNAPSHOT_TOTAL_ACTIVE_STAKE_SQL: &str =
+    "ALTER TABLE snapshot_meta ADD COLUMN total_active_stake INTEGER";

--- a/ncn/verifier-service/src/upload.rs
+++ b/ncn/verifier-service/src/upload.rs
@@ -191,6 +191,23 @@ fn validate_snapshot(snapshot: &MetaMerkleSnapshot) -> Result<()> {
     Ok(())
 }
 
+/// Total active stake across every meta leaf, in lamports.
+///
+/// This is the denominator SGP-0001 Art. IV.3 measures quorum against. It is
+/// summed from the snapshot rather than read from the cluster because Art. IV.2
+/// fixes the stake distribution at snapshot time for the whole voting period —
+/// a live cluster total drifts away from it while voting is open.
+///
+/// `validate_snapshot` has already checked that each bundle's `active_stake`
+/// equals the sum of its stake leaves, so this total is consistent with the
+/// per-account figures served by `/proof/...`.
+fn total_active_stake(snapshot: &MetaMerkleSnapshot) -> Result<u64> {
+    snapshot.leaf_bundles.iter().try_fold(0u64, |acc, bundle| {
+        acc.checked_add(bundle.meta_merkle_leaf.active_stake)
+            .ok_or_else(|| anyhow::anyhow!("overflow summing total active stake"))
+    })
+}
+
 fn derive_stake_merkle_root(
     stake_merkle_leaves: &[ncn_snapshot::StakeMerkleLeaf],
 ) -> Option<[u8; 32]> {
@@ -332,6 +349,7 @@ async fn index_snapshot_data(
         merkle_root: merkle_root.to_string(),
         snapshot_hash: snapshot_hash.to_string(),
         created_at: chrono::Utc::now().to_rfc3339(),
+        total_active_stake: Some(total_active_stake(snapshot)?),
     };
     snapshot_meta.insert_exec(&mut *tx).await?;
 
@@ -435,6 +453,46 @@ mod tests {
         let message = upload_signature_message(slot, network, merkle_root, snapshot_hash);
         let signature = keypair.sign_message(&message);
         (keypair, signature.to_string())
+    }
+
+    fn bundle(active_stake: u64) -> cli::MetaMerkleLeafBundle {
+        cli::MetaMerkleLeafBundle {
+            meta_merkle_leaf: ncn_snapshot::MetaMerkleLeaf {
+                voting_wallet: AnchorPubkey::new_unique(),
+                vote_account: AnchorPubkey::new_unique(),
+                stake_merkle_root: [0u8; 32],
+                active_stake,
+            },
+            stake_merkle_leaves: vec![],
+            proof: None,
+        }
+    }
+
+    fn snapshot_of(stakes: &[u64]) -> MetaMerkleSnapshot {
+        MetaMerkleSnapshot {
+            root: [0u8; 32],
+            leaf_bundles: stakes.iter().copied().map(bundle).collect(),
+            slot: 1,
+        }
+    }
+
+    #[test]
+    fn total_active_stake_sums_every_bundle() {
+        assert_eq!(total_active_stake(&snapshot_of(&[1, 2, 3])).unwrap(), 6);
+    }
+
+    #[test]
+    fn total_active_stake_of_an_empty_snapshot_is_zero() {
+        assert_eq!(total_active_stake(&snapshot_of(&[])).unwrap(), 0);
+    }
+
+    #[test]
+    fn total_active_stake_rejects_overflow() {
+        // Cannot happen with real stake, but a wrapped total would silently
+        // shrink the quorum denominator and make every vote look like it
+        // cleared the bar.
+        let s = snapshot_of(&[u64::MAX, 1]);
+        assert!(total_active_stake(&s).is_err());
     }
 
     #[test]

--- a/ncn/verifier-service/tests/e2e_binary.rs
+++ b/ncn/verifier-service/tests/e2e_binary.rs
@@ -86,12 +86,22 @@ async fn e2e_binary_endpoints() -> anyhow::Result<()> {
         .json()
         .await?;
 
+    // The quorum denominator SGP-0001 Art. IV.3 measures against, summed from
+    // the uploaded snapshot rather than the live cluster. Computed here from the
+    // same fixture the server ingested, so the served value is checked against
+    // the file rather than against itself.
+    let expected_total_active_stake: u64 = snapshot
+        .leaf_bundles
+        .iter()
+        .map(|b| b.meta_merkle_leaf.active_stake)
+        .sum();
     let expected_meta = serde_json::json!({
         "network": "testnet",
         "slot": slot,
         "merkle_root": merkle_root,
         "snapshot_hash": encoded_hash,
         "created_at": meta["created_at"],
+        "total_active_stake": expected_total_active_stake,
     });
     assert_eq!(meta, expected_meta);
 


### PR DESCRIPTION
## TLDR

This PR adds `total_active_stake` to the `/meta` response: the total across every meta leaf in the snapshot. This is the denominator SGP-0001 measures quorum against, and nothing currently exposes it

This is groundwork for showing quorum correctly in the UI before voting opens at epoch 1021. No behavior change to any existing endpoint is introduced into this PR

## Why

SGP-0001 Art. IV.3:

> Each vote will require a quorum of one-third (**1/3**) of network stake in
> order to be considered a valid signal. Participating stake is the sum of
> `For`, `Against`, and `Abstain` allocations.

And Art. IV.2:

> The snapshot fixes the stake distribution that will apply for the duration of
> the Voting Period.

So the denominator is the snapshot's total stake. The frontend currently divides by a live `getVoteAccounts()` sum, which drifts away from the snapshot as soon as stake moves

That case had `voting = true` on-chain as an authoritative fallback once the threshold was crossed. Quorum has no such fallback: the program does not compute it, so whatever the client calculates is the answer. Getting the denominator right matters more here, not less

The verifier is the natural place for it; it already holds every meta leaf at upload time, and `validate_snapshot` already checks that each bundle's `active_stake` equals the sum of its stake leaves, so the total is consistent with the per-account figures served by `/proof/...`

## Changes

- `snapshot_meta.total_active_stake` column, summed from the meta leaves during `index_snapshot_data`
- Migration v2 for existing databases, guarded by a `pragma_table_info` check so it is also safe against a database created fresh after this change, which already has the column via `CREATE_SNAPSHOT_META_TABLE_SQL`
- `Option<u64>` on the record: snapshots uploaded before this cannot be back-filled without the original file. Reporting a fabricated denominator would be worse than reporting none; consumers should render "unknown" rather than a number
- `/meta` serves it automatically; the handler returns the record and it already derives `Serialize`

The sum uses `checked_add`. Overflow is unreachable with real stake, but a wrapped total would shrink the quorum denominator and make every vote look like it cleared the bar, so it errors rather than wrapping

## Compatibility

Checked every `/meta` consumer; the `ncn-router` cron, the frontend, and both CLIs. None uses `deny_unknown_fields`, so the added field breaks no existing reader. Old clients ignore it; new clients get it

The column is additive and nullable, so an existing deployment migrates in place without touching stored rows

## Tests

`cargo test -p verifier-service` → 40 passed

### Migration

The only part of this change that touches existing data, and it had no coverage before:

- `upgrading_a_v1_database_adds_the_column_and_keeps_existing_rows` builds a database at the genuine pre-v2 schema with a row already in it, runs the migration, and asserts the row is still readable with `total_active_stake: None`. An un-backfillable snapshot must report unknown, not a fabricated zero
- `a_fresh_database_lands_on_v2_with_the_column_present` covers the new-install path, plus a write/read round-trip at realistic mainnet magnitude.
- `migrations_are_idempotent` — startup runs migrations on every boot, so a second pass must be a no-op. This one fails without the `pragma_table_info` guard, and nothing else in the suite would have caught that

### Sum

Three unit tests: 
- Every bundle counted
- Empty snapshot is zero
- Overflow rejected

### End-to-end

The e2e binary test performs a real upload → `/meta` round-trip against the committed fixture. Its exact-match assertion now includes the new field, with the expected total computed from the fixture the server ingested, so the served value is checked against the file rather than against itself
