### PR TITLE
fix(svmgov): update proposal description validation

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -147,7 +147,7 @@ by full path, or `cargo run --release --bin cli --` for ncn.
 | Flag                            | Meaning                                                                    | Decide   |
 | ------------------------------- | -------------------------------------------------------------------------- | -------- |
 | `--max-title-length`            | proposal title length, **in bytes** (1–200)                                | e.g. 50  |
-| `--max-description-length`      | desc length **in bytes** (1–500); desc must be a `https://github.com` link | e.g. 250 |
+| `--max-description-length`      | desc length **in bytes** (1–500); desc must link to `solana-foundation/solana-governance-proposals` | e.g. 250 |
 | `--max-support-epochs`          | max epochs in support phase                                                | ?        |
 | `--min-proposal-stake-lamports` | min stake to create a proposal                                             | ?        |
 | `--cluster-support-pct-min-bps` | % cluster stake to activate voting (bps, 0–10000)                          | ?        |

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -147,7 +147,7 @@ by full path, or `cargo run --release --bin cli --` for ncn.
 | Flag                            | Meaning                                                                    | Decide   |
 | ------------------------------- | -------------------------------------------------------------------------- | -------- |
 | `--max-title-length`            | proposal title length, **in bytes** (1–200)                                | e.g. 50  |
-| `--max-description-length`      | desc length **in bytes** (1–500); desc must link to `solana-foundation/solana-governance-proposals` | e.g. 250 |
+| `--max-description-length`      | desc length **in bytes** (1–500); desc must link to `https://github.com/solana-foundation/solana-governance-proposals` | e.g. 250 |
 | `--max-support-epochs`          | max epochs in support phase                                                | ?        |
 | `--min-proposal-stake-lamports` | min stake to create a proposal                                             | ?        |
 | `--cluster-support-pct-min-bps` | % cluster stake to activate voting (bps, 0–10000)                          | ?        |

--- a/docs/src/content/reference/arguments.mdx
+++ b/docs/src/content/reference/arguments.mdx
@@ -69,7 +69,7 @@ When voting, `for_votes + against_votes + abstain_votes` must equal exactly **10
 | Argument | Type | Required | Default | Description |
 |---|---|---|---|---|
 | `--title` | String | Yes | — | Proposal title; byte length must be ≤ configured `max_title_length` and ≤ 200 |
-| `--description` | String | Yes | — | GitHub URL (`https://github.com/...`); byte length must be ≤ configured `max_description_length` and ≤ 500 |
+| `--description` | String | Yes | — | URL in `https://github.com/solana-foundation/solana-governance-proposals/...` without `..`; byte length must be ≤ configured `max_description_length` and ≤ 500 |
 | `--network` | String | No | Config value | Network for proof fetching |
 | `--seed` | u64 | No | Random | PDA derivation seed |
 

--- a/docs/src/content/reference/errors/index.mdx
+++ b/docs/src/content/reference/errors/index.mdx
@@ -32,7 +32,7 @@ All error codes from both the `ncn-snapshot` and `svmgov` programs.
 | `TitleTooLong` | Title exceeds `max_title_length` (measured in bytes) |
 | `DescriptionEmpty` | Description is empty |
 | `DescriptionTooLong` | Description exceeds `max_description_length` (measured in bytes) |
-| `DescriptionInvalid` | Description must be a URL in `solana-foundation/solana-governance-proposals` without `..` path segments |
+| `DescriptionInvalid` | Description must be a URL in `https://github.com/solana-foundation/solana-governance-proposals` without `..` path segments |
 | `InvalidProposalId` | Invalid proposal ID |
 | `VotingNotStarted` | Proposal has not entered voting phase yet |
 | `ProposalClosed` | Voting period has ended |

--- a/docs/src/content/reference/errors/index.mdx
+++ b/docs/src/content/reference/errors/index.mdx
@@ -32,7 +32,7 @@ All error codes from both the `ncn-snapshot` and `svmgov` programs.
 | `TitleTooLong` | Title exceeds `max_title_length` (measured in bytes) |
 | `DescriptionEmpty` | Description is empty |
 | `DescriptionTooLong` | Description exceeds `max_description_length` (measured in bytes) |
-| `DescriptionInvalid` | Description must be a `https://github.com` URL |
+| `DescriptionInvalid` | Description must be a URL in `solana-foundation/solana-governance-proposals` without `..` path segments |
 | `InvalidProposalId` | Invalid proposal ID |
 | `VotingNotStarted` | Proposal has not entered voting phase yet |
 | `ProposalClosed` | Voting period has ended |

--- a/docs/src/content/svmgov/index.mdx
+++ b/docs/src/content/svmgov/index.mdx
@@ -36,7 +36,7 @@ CREATED ──► SUPPORT PHASE ──► VOTING PHASE ──► FINALIZED
 
 ### Create Proposal
 
-A validator with enough stake to satisfy `min_proposal_stake_lamports` calls `create_proposal`. They provide a title and a GitHub URL as the description, both bounded by `GlobalConfig`. The proposal receives a unique sequential index.
+A validator with enough stake to satisfy `min_proposal_stake_lamports` calls `create_proposal`. They provide a title and a URL in `solana-foundation/solana-governance-proposals` as the description, both bounded by `GlobalConfig`. The proposal receives a unique sequential index.
 
 ### Support Phase
 

--- a/docs/src/content/svmgov/index.mdx
+++ b/docs/src/content/svmgov/index.mdx
@@ -36,7 +36,7 @@ CREATED ──► SUPPORT PHASE ──► VOTING PHASE ──► FINALIZED
 
 ### Create Proposal
 
-A validator with enough stake to satisfy `min_proposal_stake_lamports` calls `create_proposal`. They provide a title and a URL in `solana-foundation/solana-governance-proposals` as the description, both bounded by `GlobalConfig`. The proposal receives a unique sequential index.
+A validator with enough stake to satisfy `min_proposal_stake_lamports` calls `create_proposal`. They provide a title and a URL in `https://github.com/solana-foundation/solana-governance-proposals` as the description, both bounded by `GlobalConfig`. The proposal receives a unique sequential index.
 
 ### Support Phase
 

--- a/docs/src/content/svmgov/program/index.mdx
+++ b/docs/src/content/svmgov/program/index.mdx
@@ -60,7 +60,7 @@ The main proposal account. One per governance proposal.
 |---|---|---|
 | `author` | `Pubkey` | Validator who created the proposal |
 | `title` | `String` | Short title (length in bytes ≤ `max_title_length`, ≤ 200) |
-| `description` | `String` | GitHub URL for full proposal text (length in bytes ≤ `max_description_length`, ≤ 500) |
+| `description` | `String` | URL in `solana-foundation/solana-governance-proposals` for full proposal text (length in bytes ≤ `max_description_length`, ≤ 500) |
 | `creation_epoch` | `u64` | Epoch when created |
 | `start_epoch` | `u64` | Epoch when voting begins |
 | `end_epoch` | `u64` | Epoch when voting ends |
@@ -242,7 +242,7 @@ Creates a new governance proposal.
 |---|---|---|
 | `seed: u64` | `u64` | Unique seed for PDA derivation |
 | `title: String` | `String` | Non-empty, ≤ `max_title_length` |
-| `description: String` | `String` | Non-empty, ≤ `max_description_length`, must start with `https://github.com` |
+| `description: String` | `String` | Non-empty, ≤ `max_description_length`, must be in `https://github.com/solana-foundation/solana-governance-proposals` and contain no `..` segment |
 
 **Additional checks:** proposer stake ≥ `min_proposal_stake_lamports`
 
@@ -347,7 +347,7 @@ Admin-only recovery instruction. Re-anchors a supported proposal's snapshot/voti
 | `TitleTooLong` | Title exceeds max length (bytes) |
 | `DescriptionEmpty` | Description is empty |
 | `DescriptionTooLong` | Description exceeds max length (bytes) |
-| `DescriptionInvalid` | Description must be a `https://github.com` link |
+| `DescriptionInvalid` | Description must link to `solana-foundation/solana-governance-proposals` without `..` path segments |
 | `InvalidProposalId` | Invalid proposal ID |
 | `VotingNotStarted` | Proposal has not yet entered voting phase |
 | `ProposalClosed` | Voting period has ended |

--- a/docs/src/content/svmgov/program/index.mdx
+++ b/docs/src/content/svmgov/program/index.mdx
@@ -60,7 +60,7 @@ The main proposal account. One per governance proposal.
 |---|---|---|
 | `author` | `Pubkey` | Validator who created the proposal |
 | `title` | `String` | Short title (length in bytes ≤ `max_title_length`, ≤ 200) |
-| `description` | `String` | URL in `solana-foundation/solana-governance-proposals` for full proposal text (length in bytes ≤ `max_description_length`, ≤ 500) |
+| `description` | `String` | URL in `https://github.com/solana-foundation/solana-governance-proposals` for full proposal text (length in bytes ≤ `max_description_length`, ≤ 500) |
 | `creation_epoch` | `u64` | Epoch when created |
 | `start_epoch` | `u64` | Epoch when voting begins |
 | `end_epoch` | `u64` | Epoch when voting ends |
@@ -347,7 +347,7 @@ Admin-only recovery instruction. Re-anchors a supported proposal's snapshot/voti
 | `TitleTooLong` | Title exceeds max length (bytes) |
 | `DescriptionEmpty` | Description is empty |
 | `DescriptionTooLong` | Description exceeds max length (bytes) |
-| `DescriptionInvalid` | Description must link to `solana-foundation/solana-governance-proposals` without `..` path segments |
+| `DescriptionInvalid` | Description must link to `https://github.com/solana-foundation/solana-governance-proposals` without `..` path segments |
 | `InvalidProposalId` | Invalid proposal ID |
 | `VotingNotStarted` | Proposal has not yet entered voting phase |
 | `ProposalClosed` | Voting period has ended |

--- a/docs/src/content/svmgov/validators/create-proposal/index.mdx
+++ b/docs/src/content/svmgov/validators/create-proposal/index.mdx
@@ -8,14 +8,14 @@ Create a new governance proposal on-chain.
 
 Submits a new governance proposal. The validator must have at least **100,000 SOL staked** to their vote account. The proposal is assigned a unique sequential index and a PDA derived from the seed and the validator's vote account.
 
-The `description` must be a GitHub URL — full proposal text, rationale, and discussion lives there. Only the title and GitHub link are stored on-chain to keep accounts small.
+The `description` must link to the [`solana-foundation/solana-governance-proposals`](https://github.com/solana-foundation/solana-governance-proposals) repository. Full proposal text, rationale, and discussion lives there; only the title and GitHub link are stored on-chain to keep accounts small. The URL must not contain a `..` path-traversal segment.
 
 ## Usage
 
 ```bash
 svmgov create-proposal \
   --title "Your Proposal Title" \
-  --description "https://github.com/your-org/repo/issues/1" \
+  --description "https://github.com/solana-foundation/solana-governance-proposals/blob/<commit-sha>/proposals/sgp-0001-title.md" \
   --network mainnet
 ```
 
@@ -24,7 +24,7 @@ svmgov create-proposal \
 | Argument | Type | Required | Default | Description |
 |---|---|---|---|---|
 | `--title` | String | **Yes** | — | Proposal title. Length in bytes must be ≤ `max_title_length` (config-set, up to 200 bytes) |
-| `--description` | String | **Yes** | — | GitHub link for full proposal details. Must start with `https://github.com`; length in bytes must be ≤ `max_description_length` (config-set, up to 500 bytes) |
+| `--description` | String | **Yes** | — | Link in `https://github.com/solana-foundation/solana-governance-proposals`; must not contain `..`; length in bytes must be ≤ `max_description_length` (config-set, up to 500 bytes) |
 | `--network` | String | No | Config value | Network override for proof fetching: `mainnet`, `testnet` |
 | `--seed` | u64 | No | Random | Unique seed for PDA derivation |
 
@@ -39,7 +39,7 @@ svmgov create-proposal \
 
 - Validator must have ≥ **100,000 SOL** staked to their vote account
 - The identity keypair must match the `node_pubkey` of the vote account
-- Description must be a valid `https://github.com/...` URL
+- Description must be a `https://github.com/solana-foundation/solana-governance-proposals/...` URL without `..` path segments
 - `ProposalIndex` must be initialized (run `svmgov init-index` once)
 
 ## Examples
@@ -48,20 +48,20 @@ svmgov create-proposal \
 # With config (recommended)
 svmgov create-proposal \
   --title "Increase max validator commission to 12%" \
-  --description "https://github.com/my-org/governance/issues/42" \
+  --description "https://github.com/solana-foundation/solana-governance-proposals/blob/<commit-sha>/proposals/sgp-0001-title.md" \
   --network mainnet
 
 # With a specific seed for deterministic PDA
 svmgov create-proposal \
   --seed 100 \
   --title "Update cluster fee schedule" \
-  --description "https://github.com/my-org/governance/proposals/fee-update" \
+  --description "https://github.com/solana-foundation/solana-governance-proposals/blob/<commit-sha>/proposals/sgp-0001-title.md" \
   --network mainnet
 
 # With explicit keypair
 svmgov create-proposal \
   --title "My Proposal" \
-  --description "https://github.com/repo/issues/1" \
+  --description "https://github.com/solana-foundation/solana-governance-proposals/blob/<commit-sha>/proposals/sgp-0001-title.md" \
   --network mainnet \
   --keypair ~/.config/solana/validator-identity.json
 ```

--- a/docs/src/content/svmgov/validators/proposal/index.mdx
+++ b/docs/src/content/svmgov/validators/proposal/index.mdx
@@ -43,7 +43,7 @@ The command displays:
 |---|---|
 | Index | Sequential proposal number |
 | Title | Proposal title |
-| Description | GitHub URL link |
+| Description | URL in `solana-foundation/solana-governance-proposals` |
 | Author | Proposer's validator vote account |
 | Status | `support` / `active` / `finalized` |
 | Creation | Creation epoch and timestamp |

--- a/docs/src/content/svmgov/validators/proposal/index.mdx
+++ b/docs/src/content/svmgov/validators/proposal/index.mdx
@@ -43,7 +43,7 @@ The command displays:
 |---|---|
 | Index | Sequential proposal number |
 | Title | Proposal title |
-| Description | URL in `solana-foundation/solana-governance-proposals` |
+| Description | URL in `https://github.com/solana-foundation/solana-governance-proposals` |
 | Author | Proposer's validator vote account |
 | Status | `support` / `active` / `finalized` |
 | Creation | Creation epoch and timestamp |

--- a/frontend/src/lib/github/__tests__/validateProposalUrl.test.ts
+++ b/frontend/src/lib/github/__tests__/validateProposalUrl.test.ts
@@ -5,18 +5,12 @@ import {
 } from "../validateProposalUrl";
 
 const SHA = "27bca51e5c0fc34ddbea6904faf86f5098225316";
-const VALID_SIMD = `https://github.com/${SIMD_REPO}/blob/main/proposals/0022-multi-stake.md`;
 const VALID_SGP = `https://github.com/${SGP_REPO}/blob/${SHA}/proposals/sgp-0001-solana-constitution.md`;
+const MUTABLE_SGP = `https://github.com/${SGP_REPO}/blob/main/proposals/sgp-0001-solana-constitution.md`;
 
 const codes = (issues: { code: string }[]) => issues.map((i) => i.code);
 
 describe("validateProposalUrl - accepted", () => {
-  it("accepts a SIMD proposal link", () => {
-    const result = validateProposalUrl(VALID_SIMD);
-    expect(result.ok).toBe(true);
-    expect(result.errors).toEqual([]);
-  });
-
   it("accepts an SGP proposal link pinned to a commit with no warnings", () => {
     const result = validateProposalUrl(VALID_SGP);
     expect(result.ok).toBe(true);
@@ -60,11 +54,11 @@ describe("validateProposalUrl - rejected", () => {
     ["https://github.com/org/repo", "unsupported"],
     ["https://github.com/org/repo/issues/12", "unsupported"],
     [
-      `https://github.com/${SIMD_REPO}/blob/main/proposals/0022-multi-stake.txt`,
+      `https://github.com/${SGP_REPO}/blob/main/proposals/sgp-0001-solana-constitution.txt`,
       "not-markdown",
     ],
-    [`${VALID_SIMD}?plain=1`, "query-or-fragment"],
-    [`${VALID_SIMD}#L10`, "query-or-fragment"],
+    [`${VALID_SGP}?plain=1`, "query-or-fragment"],
+    [`${VALID_SGP}#L10`, "query-or-fragment"],
   ])("rejects %j with code %s", (url, code) => {
     const result = validateProposalUrl(url);
     expect(result.ok).toBe(false);
@@ -74,8 +68,8 @@ describe("validateProposalUrl - rejected", () => {
   // These resolve fine in a browser but are rejected by the on-chain validator, so accepting
   // them would only surface as an opaque custom program error at transaction time.
   it.each([
-    [`https://www.github.com/${SIMD_REPO}/blob/main/proposals/0022-x.md`],
-    [`https://raw.githubusercontent.com/${SIMD_REPO}/main/proposals/0022-x.md`],
+    [`https://www.github.com/${SGP_REPO}/blob/main/proposals/sgp-0001-x.md`],
+    [`https://raw.githubusercontent.com/${SGP_REPO}/main/proposals/sgp-0001-x.md`],
   ])("rejects %j because the program requires an exact github.com prefix", (url) => {
     const result = validateProposalUrl(url);
     expect(result.ok).toBe(false);
@@ -84,11 +78,11 @@ describe("validateProposalUrl - rejected", () => {
 
   it.each([
     [
-      `https://github.com/${SIMD_REPO}/blob/main/proposals/0022%20multi.md`,
+      `https://github.com/${SGP_REPO}/blob/main/proposals/sgp-0001%20x.md`,
       "character",
     ],
     [
-      `https://github.com/${SIMD_REPO}/blob/main/a/b/c/d/e/f/g/h/0022-x.md`,
+      `https://github.com/${SGP_REPO}/blob/main/a/b/c/d/e/f/g/h/sgp-0001-x.md`,
       "segments",
     ],
   ])("rejects %j as incompatible with the on-chain grammar", (url) => {
@@ -98,7 +92,7 @@ describe("validateProposalUrl - rejected", () => {
   });
 
   it("rejects a link longer than the on-chain description limit", () => {
-    const url = `https://github.com/${SIMD_REPO}/blob/main/proposals/${"a".repeat(500)}/0022-x.md`;
+    const url = `https://github.com/${SGP_REPO}/blob/main/proposals/${"a".repeat(500)}/sgp-0001-x.md`;
     expect(codes(validateProposalUrl(url).errors)).toContain("too-long");
   });
 
@@ -111,17 +105,33 @@ describe("validateProposalUrl - rejected", () => {
 
 describe("validateProposalUrl - warnings", () => {
   it("warns about a branch ref but still passes", () => {
-    const result = validateProposalUrl(VALID_SIMD);
+    const result = validateProposalUrl(MUTABLE_SGP);
     expect(result.ok).toBe(true);
     expect(codes(result.warnings)).toContain("mutable-ref");
   });
 
-  it("warns about an unknown repo but still passes", () => {
+  it("rejects repositories other than solana-governance-proposals", () => {
     const result = validateProposalUrl(
       `https://github.com/someone/fork/blob/${SHA}/proposals/sgp-0002-x.md`,
     );
-    expect(result.ok).toBe(true);
-    expect(codes(result.warnings)).toContain("unknown-repo");
+    expect(result.ok).toBe(false);
+    expect(codes(result.errors)).toContain("not-allowed-repo");
+  });
+
+  it("rejects legacy SIMD repository links", () => {
+    const result = validateProposalUrl(
+      `https://github.com/${SIMD_REPO}/blob/main/proposals/0022-multi-stake.md`,
+    );
+    expect(result.ok).toBe(false);
+    expect(codes(result.errors)).toContain("not-allowed-repo");
+  });
+
+  it("rejects raw path traversal even though URL parsing normalizes it", () => {
+    const result = validateProposalUrl(
+      `https://github.com/${SGP_REPO}/../../attacker/repo/blob/ref/0022-x.md`,
+    );
+    expect(result.ok).toBe(false);
+    expect(codes(result.errors)).toContain("rejected-on-chain");
   });
 
   it("warns when the filename carries no proposal number", () => {

--- a/frontend/src/lib/github/validateProposalUrl.ts
+++ b/frontend/src/lib/github/validateProposalUrl.ts
@@ -1,6 +1,6 @@
 import {
-  isKnownProposalRepo,
   parseProposalUrl,
+  SGP_REPO,
   type ParsedProposalUrl,
 } from "./proposalUrl";
 
@@ -9,6 +9,7 @@ export type ProposalUrlErrorCode =
   | "not-a-url"
   | "not-https"
   | "not-github"
+  | "not-allowed-repo"
   | "pull-request"
   | "tree-or-directory"
   | "not-markdown"
@@ -19,7 +20,6 @@ export type ProposalUrlErrorCode =
 
 export type ProposalUrlWarningCode =
   | "mutable-ref"
-  | "unknown-repo"
   | "unrecognized-filename";
 
 export interface ProposalUrlIssue<Code extends string> {
@@ -169,11 +169,13 @@ export function validateProposalUrl(url: string): ProposalUrlValidation {
     });
   }
 
-  // 10: unknown repos are allowed — only their shape is checked.
-  if (!isKnownProposalRepo(parsed.repo)) {
-    warnings.push({
-      code: "unknown-repo",
-      message: `${parsed.repo.owner}/${parsed.repo.repo} is not a recognized proposal repository.`,
+  // 10: descriptions are an on-chain trust boundary, so creation is limited to the
+  // repository the program accepts. Compare the raw case-sensitive components to mirror the
+  // program rather than treating GitHub's case-insensitive names as interchangeable.
+  if (`${parsed.repo.owner}/${parsed.repo.repo}` !== SGP_REPO) {
+    errors.push({
+      code: "not-allowed-repo",
+      message: `The link must point to https://github.com/${SGP_REPO}.`,
     });
   }
 
@@ -211,6 +213,10 @@ function describeOnChainViolation(url: string): string | undefined {
 
   if (segments.some((segment) => segment === "")) {
     return "The link contains an empty path segment, which the on-chain program rejects.";
+  }
+
+  if (segments.some((segment) => segment === "..")) {
+    return 'The link contains a ".." path-traversal segment, which the on-chain program rejects.';
   }
 
   if (

--- a/svmgov/cli/src/main.rs
+++ b/svmgov/cli/src/main.rs
@@ -108,11 +108,11 @@ enum Commands {
     #[command(
         about = "Create a proposal to vote on",
         long_about = "This command creates a new governance proposal with the help of the Solana Validator Governance program. \
-                      It requires a title and a GitHub link for the proposal description, and optionally a unique seed to derive the proposal's address (PDA). \
+                      It requires a title and a link to a proposal in the solana-foundation/solana-governance-proposals repo for the proposal description, and optionally a unique seed to derive the proposal's address (PDA). \
                       The identity keypair is required to sign the transaction, and an optional RPC URL can be provided to connect to the chain.\n\n\
                       Examples:\n\
-                      $ svmgov -k /path/to/key.json create-proposal --title \"New Governance Rule\" --description \"https://github.com/repo/proposal\"\n\
-                      $ svmgov -k /path/to/key.json --rpc-url https://api.mainnet-beta.solana.com create-proposal --seed 42 --title \"New Governance Rule\" --description \"https://github.com/repo/proposal\""
+                      $ svmgov -k /path/to/key.json create-proposal --title \"New Governance Rule\" --description \"https://github.com/solana-foundation/solana-governance-proposals/blob/<commit-sha>/proposals/sgp-0001-title.md\"\n\
+                      $ svmgov -k /path/to/key.json --rpc-url https://api.mainnet-beta.solana.com create-proposal --seed 42 --title \"New Governance Rule\" --description \"https://github.com/solana-foundation/solana-governance-proposals/blob/<commit-sha>/proposals/sgp-0001-title.md\""
     )]
     CreateProposal {
         /// Optional unique seed for the proposal (used to derive the PDA).
@@ -123,8 +123,8 @@ enum Commands {
         #[arg(long, help = "Proposal title")]
         title: String,
 
-        /// GitHub link for the proposal description.
-        #[arg(long, help = "GitHub link for the proposal description")]
+        /// Link in solana-foundation/solana-governance-proposals for the proposal description.
+        #[arg(long, help = "Proposal link in solana-foundation/solana-governance-proposals (no .. path segments)")]
         description: String,
 
         /// Skip the network check that the linked proposal file exists.

--- a/svmgov/cli/src/main.rs
+++ b/svmgov/cli/src/main.rs
@@ -124,7 +124,7 @@ enum Commands {
         title: String,
 
         /// Link in solana-foundation/solana-governance-proposals for the proposal description.
-        #[arg(long, help = "Proposal link in solana-foundation/solana-governance-proposals (no .. path segments)")]
+        #[arg(long, help = "Proposal link in https://github.com/solana-foundation/solana-governance-proposals (no .. path segments)")]
         description: String,
 
         /// Skip the network check that the linked proposal file exists.

--- a/svmgov/cli/src/utils/proposal_link.rs
+++ b/svmgov/cli/src/utils/proposal_link.rs
@@ -1,10 +1,11 @@
 //! Validation for the `--description` GitHub link on `create-proposal`.
 //!
 //! The on-chain program (`svmgov_program::utils::is_valid_github_link`) only checks that the
-//! description looks broadly like a GitHub URL: an `https://github.com/` prefix, 2-10 path
-//! segments, and characters limited to alphanumerics plus `-`, `_`, `.`. A pull request link
-//! such as `.../owner/repo/pull/3` is four clean segments, so it sails through — and then the
-//! frontend cannot resolve it to a proposal document.
+//! description must name the approved `solana-foundation/solana-governance-proposals` GitHub
+//! repository, have 2-10 path segments, contain no `..` traversal segment, and use only
+//! alphanumerics plus `-`, `_`, `.`. A pull request link such as `.../owner/repo/pull/3` is four
+//! clean segments, so it sails through the broad shape check — and then the frontend cannot
+//! resolve it to a proposal document.
 //!
 //! This module closes that gap client-side. It does NOT reimplement the on-chain rules; it is
 //! strictly stricter by construction, accepting only
@@ -20,6 +21,8 @@ use anyhow::{Result, anyhow};
 /// The exact prefix `is_valid_github_link` requires. A `www.` host or a
 /// `raw.githubusercontent.com` link would be rejected on chain, so they are rejected here.
 const GITHUB_PREFIX: &str = "https://github.com/";
+const PROPOSAL_OWNER: &str = "solana-foundation";
+const PROPOSAL_REPOSITORY: &str = "solana-governance-proposals";
 
 /// Mirrors `svmgov_program::utils::is_valid_github_link`.
 const MIN_PATH_SEGMENTS: usize = 2;
@@ -166,6 +169,12 @@ pub fn validate_description_structure(description: &str) -> Result<GithubLinkKin
         ));
     };
 
+    if !is_allowed_proposal_repo(owner, repo) {
+        return Err(anyhow!(
+            "`--description` must point to https://github.com/{PROPOSAL_OWNER}/{PROPOSAL_REPOSITORY}\n\n  got: {link}"
+        ));
+    }
+
     // 6
     let file_name = path.rsplit('/').next().unwrap_or_default();
     if !file_name.to_ascii_lowercase().ends_with(".md") {
@@ -183,11 +192,6 @@ pub fn validate_description_structure(description: &str) -> Result<GithubLinkKin
             "`{git_ref}` is a branch or tag. The description cannot be changed once it is on chain, \
              so a full commit SHA is safer against the branch moving or being deleted."
         );
-    }
-
-    // 10 — unknown repos are allowed; only the shape is enforced.
-    if !is_known_proposal_repo(owner, repo) {
-        log::warn!("{owner}/{repo} is not a recognized proposal repository");
     }
 
     // 11
@@ -295,9 +299,21 @@ fn assert_on_chain_compatible(link: &str) -> Result<()> {
     let path = link.trim_start_matches(GITHUB_PREFIX).trim_end_matches('/');
     let segments: Vec<&str> = path.split('/').collect();
 
+    if segments.get(0) != Some(&PROPOSAL_OWNER) || segments.get(1) != Some(&PROPOSAL_REPOSITORY) {
+        return Err(anyhow!(
+            "`--description` must point to https://github.com/{PROPOSAL_OWNER}/{PROPOSAL_REPOSITORY}\n\n  got: {link}"
+        ));
+    }
+
     if segments.iter().any(|segment| segment.is_empty()) {
         return Err(anyhow!(
             "`--description` contains an empty path segment; the on-chain program rejects it\n\n  got: {link}"
+        ));
+    }
+
+    if segments.iter().any(|segment| *segment == "..") {
+        return Err(anyhow!(
+            "`--description` contains a `..` path-traversal segment, which the on-chain program rejects\n\n  got: {link}"
         ));
     }
 
@@ -325,17 +341,8 @@ fn is_commit_sha(git_ref: &str) -> bool {
     git_ref.len() == 40 && git_ref.chars().all(|c| c.is_ascii_hexdigit())
 }
 
-fn is_known_proposal_repo(owner: &str, repo: &str) -> bool {
-    matches!(
-        (
-            owner.to_ascii_lowercase().as_str(),
-            repo.to_ascii_lowercase().as_str()
-        ),
-        (
-            "solana-foundation",
-            "solana-improvement-documents" | "solana-governance-proposals"
-        )
-    )
+fn is_allowed_proposal_repo(owner: &str, repo: &str) -> bool {
+    owner == PROPOSAL_OWNER && repo == PROPOSAL_REPOSITORY
 }
 
 /// `sgp-0001-title.md` -> `0001`, `0022-multi-stake.md` -> `0022`. Leading zeros are kept.
@@ -426,7 +433,7 @@ mod tests {
 
     #[test]
     fn accepts_real_proposal_links() {
-        for link in [SIMD_FILE, SGP_FILE] {
+        for link in [SGP_FILE] {
             assert!(
                 validate_description_structure(link).is_ok(),
                 "should accept {link}"
@@ -474,7 +481,7 @@ mod tests {
             ("https://github.com/o/r", "link to a file"),
             ("https://github.com/o/r/issues/12", "link to a file"),
             (
-                "https://github.com/o/r/blob/main/proposals/0001-x.txt",
+                "https://github.com/solana-foundation/solana-governance-proposals/blob/main/proposals/sgp-0001-x.txt",
                 ".md file",
             ),
             (
@@ -513,7 +520,7 @@ mod tests {
     #[test]
     fn rejects_characters_the_program_rejects() {
         let error = validate_description_structure(
-            "https://github.com/o/r/blob/main/proposals/0001%20x.md",
+            "https://github.com/solana-foundation/solana-governance-proposals/blob/main/proposals/sgp-0001%20x.md",
         )
         .unwrap_err()
         .to_string();
@@ -523,7 +530,7 @@ mod tests {
     #[test]
     fn rejects_paths_deeper_than_the_program_allows() {
         let link = format!(
-            "https://github.com/o/r/blob/main/{}/0001-x.md",
+            "https://github.com/solana-foundation/solana-governance-proposals/blob/main/{}/sgp-0001-x.md",
             ["deep"; 8].join("/")
         );
         let error = validate_description_structure(&link)
@@ -538,10 +545,9 @@ mod tests {
     #[test]
     fn accepted_links_satisfy_the_on_chain_rules() {
         let accepted = [
-            SIMD_FILE,
             SGP_FILE,
-            "https://github.com/o/r/blob/main/x.md",
-            "https://github.com/o/r/blob/main/a/b/c/d/e/f.md",
+            "https://github.com/solana-foundation/solana-governance-proposals/blob/main/x.md",
+            "https://github.com/solana-foundation/solana-governance-proposals/blob/main/a/b/c/d/e/f.md",
         ];
 
         for link in accepted {
@@ -608,17 +614,27 @@ mod tests {
     }
 
     #[test]
-    fn unknown_repos_are_accepted() {
+    fn only_the_governance_proposals_repository_is_accepted() {
         assert!(
             validate_description_structure(
                 "https://github.com/someone/fork/blob/main/proposals/sgp-0002-x.md"
             )
-            .is_ok()
+            .is_err()
         );
-        assert!(!is_known_proposal_repo("someone", "fork"));
-        assert!(is_known_proposal_repo(
+        assert!(!is_allowed_proposal_repo("someone", "fork"));
+        assert!(is_allowed_proposal_repo(
             "solana-foundation",
             "solana-governance-proposals"
         ));
+    }
+
+    #[test]
+    fn rejects_path_traversal() {
+        let error = validate_description_structure(
+            "https://github.com/solana-foundation/solana-governance-proposals/blob/main/../../attacker/repo.md",
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(error.contains("path-traversal"), "got: {error}");
     }
 }

--- a/svmgov/program/programs/svmgov_program/src/utils.rs
+++ b/svmgov/program/programs/svmgov_program/src/utils.rs
@@ -60,9 +60,10 @@ macro_rules! calculate_vote_lamports {
     }};
 }
 
-/// Validates if the input is a well-formed GitHub repository or issue link.
+/// Validates that the input points to the approved GitHub proposal repository.
 pub fn is_valid_github_link(link: &str) -> bool {
     const PREFIX: &str = "https://github.com/";
+    const REPOSITORY_PATH: &str = "solana-foundation/solana-governance-proposals";
     const MAX_SEGMENTS: usize = 10;
     const MIN_SEGMENTS: usize = 2;
 
@@ -79,6 +80,14 @@ pub fn is_valid_github_link(link: &str) -> bool {
         path = &path[..path.len() - 1];
     }
     if path.is_empty() || path.starts_with('/') {
+        return false;
+    }
+
+    // path must start with repository path followed by another segment
+    if !path
+        .strip_prefix(REPOSITORY_PATH)
+        .is_some_and(|suffix| suffix.starts_with('/'))
+    {
         return false;
     }
 

--- a/svmgov/program/programs/svmgov_program/src/utils.rs
+++ b/svmgov/program/programs/svmgov_program/src/utils.rs
@@ -299,6 +299,22 @@ mod tests {
     use super::*;
     use crate::error::GovernanceError;
 
+    #[test]
+    fn github_link_requires_the_allowed_repository_without_traversal() {
+        assert!(is_valid_github_link(
+            "https://github.com/solana-foundation/solana-governance-proposals/blob/main/proposals/sgp-0001-title.md"
+        ));
+        assert!(!is_valid_github_link(
+            "https://github.com/attacker/repo/blob/ref/0022-x.md"
+        ));
+        assert!(!is_valid_github_link(
+            "https://github.com/solana-foundation/solana-governance-proposals/../../attacker/repo/blob/ref/0022-x.md"
+        ));
+        assert!(!is_valid_github_link(
+            "https://github.com/solana-foundation/solana-governance-proposals"
+        ));
+    }
+
     // --- check_support_window ---
 
     #[test]

--- a/svmgov/program/programs/svmgov_program/src/utils.rs
+++ b/svmgov/program/programs/svmgov_program/src/utils.rs
@@ -91,6 +91,12 @@ pub fn is_valid_github_link(link: &str) -> bool {
         return false;
     }
 
+    // URL consumers normalize `..` by walking to a parent path. Reject it here so the
+    // raw on-chain string and the URL that clients resolve always identify the same repo.
+    if path.contains("/../") || path.ends_with("/..") {
+        return false;
+    }
+
     let mut segment_count = 0;
     let mut in_segment = false;
     let mut has_invalid_char = false;

--- a/svmgov/program/programs/svmgov_program/tests/common/mod.rs
+++ b/svmgov/program/programs/svmgov_program/tests/common/mod.rs
@@ -549,7 +549,7 @@ pub fn create_proposal(h: &mut Harness, seed: u64, title: &str) -> Address {
             h.global_config,
             seed,
             title,
-            "https://github.com/solana-foundation/solana-governance",
+            "https://github.com/solana-foundation/solana-governance-proposals/blob/commit-sha/proposals/title.md",
         )],
     );
     proposal

--- a/svmgov/program/programs/svmgov_program/tests/proposal_validation.rs
+++ b/svmgov/program/programs/svmgov_program/tests/proposal_validation.rs
@@ -16,7 +16,7 @@ use {
 const MAX_TITLE_LEN: usize = 200;
 const MAX_DESCRIPTION_LEN: usize = 500;
 
-const VALID_LINK: &str = "https://github.com/solana-foundation/solana-governance";
+const VALID_LINK: &str = "https://github.com/solana-foundation/solana-governance-proposals";
 
 /// One funded validator is all these tests need.
 fn setup() -> Harness {
@@ -102,7 +102,7 @@ fn description_too_long_rejected() {
     let mut h = setup();
     // Length is checked before link shape: even a well-formed GitHub link is
     // rejected once it exceeds the configured maximum.
-    const PREFIX: &str = "https://github.com/org/";
+    const PREFIX: &str = "https://github.com/solana-foundation/solana-governance-proposals/";
     let description = format!(
         "{PREFIX}{}",
         "a".repeat(MAX_DESCRIPTION_LEN + 1 - PREFIX.len())
@@ -128,6 +128,9 @@ fn description_must_be_github_link() {
         "https://github.com/org/repo#anchor",       // fragment
         "https://github.com/org/repo name",         // whitespace
         "https://github.com/a/b/c/d/e/f/g/h/i/j/k", // 11 segments, max is 10
+        "https://github.com/attacker/repo/blob/ref/0022-x.md", // unapproved repository
+        "https://github.com/solana-foundation/solana-improvement-documents/blob/ref/0022-x.md", // legacy SIMD repository
+        "https://github.com/solana-foundation/solana-governance-proposals/../../attacker/repo/blob/ref/0022-x.md", // path traversal
     ];
     for (i, link) in bad_links.iter().enumerate() {
         assert_rejected(
@@ -141,9 +144,9 @@ fn description_must_be_github_link() {
 fn valid_proposal_accepted() {
     let mut h = setup();
 
-    // Boundary: title exactly at the cap; link with a trailing slash.
+    // Boundary: title exactly at the cap; valid link to a proposal document.
     let title = "t".repeat(MAX_TITLE_LEN);
-    let description = "https://github.com/solana-foundation/solana-governance/";
+    let description = "https://github.com/solana-foundation/solana-governance-proposals/blob/main/proposals/sgp-0001-title.md";
     try_create(&mut h, 1, &title, description).unwrap_or_else(|e| {
         panic!(
             "create_proposal failed: {:#?}\nlogs: {:#?}",
@@ -159,7 +162,7 @@ fn valid_proposal_accepted() {
     assert!(!state.voting);
 
     // Boundary: description exactly at the cap.
-    const PREFIX: &str = "https://github.com/org/";
+    const PREFIX: &str = "https://github.com/solana-foundation/solana-governance-proposals/";
     let max_description = format!("{PREFIX}{}", "a".repeat(MAX_DESCRIPTION_LEN - PREFIX.len()));
     assert_eq!(max_description.len(), MAX_DESCRIPTION_LEN);
     try_create(&mut h, 2, "second", &max_description).unwrap_or_else(|e| {

--- a/svmgov/program/programs/svmgov_program/tests/proposal_validation.rs
+++ b/svmgov/program/programs/svmgov_program/tests/proposal_validation.rs
@@ -16,7 +16,7 @@ use {
 const MAX_TITLE_LEN: usize = 200;
 const MAX_DESCRIPTION_LEN: usize = 500;
 
-const VALID_LINK: &str = "https://github.com/solana-foundation/solana-governance-proposals";
+const VALID_LINK: &str = "https://github.com/solana-foundation/solana-governance-proposals/blob/commit-sha/proposals/title.md";
 
 /// One funded validator is all these tests need.
 fn setup() -> Harness {


### PR DESCRIPTION
Updates proposal link validation on-chain, in the svmgov CLI, and in the frontend proposal creator to:
 - require proposal links point to github.com/solana-foundation/solana-governance-proposals repo AND
 - forbid the use of traversals in the link (i.e. github.com/owner/repo/../../other-owner/other-repo)