### PR TITLE
fix(ncn-ledger): pick the snapshot pair closest to the target slot

### DIFF
--- a/docs/src/content/ncn/cli/index.mdx
+++ b/docs/src/content/ncn/cli/index.mdx
@@ -122,6 +122,7 @@ Budget roughly **350GB free** for a mainnet run: a ~118GB full-snapshot copy, ~9
 | `unexpected argument '--allow-dead-slots'` | `agave-ledger-tool` is older than the validator | Rebuild the ledger-tool from the validator's own source tree (`--manifest-path dev-bins/Cargo.toml`) and pass it via `--agave-ledger-tool-path` |
 | `Missing snapshot at slot <X>` right after `Extracting genesis.tar.bz2` | genesis files missing from `--backup-ledger-dir` | Copy `genesis.tar.bz2` + `genesis.bin` from the live ledger dir and re-run |
 | `Missing snapshot at slot <X>` with `Blockstore missing data to replay` above it | blockstore no longer covers the slot range | Pick a target inside the retained window, or recover via `snapshot-slot` while the blocks are still present |
+| `Blockstore missing data to replay to slot <X>` when the ledger does cover the target | the replay base and the copied ledger range disagree | Check the `Selected full snapshot` log line. It names the archives the replay starts from, and both must sit inside the copied range |
 | `generate-meta-merkle` fails instantly with `Missing snapshot at slot <X>` | no exact-slot snapshot in `--backup-snapshots-dir` | See **Full-snapshot lookup** below — produce one with `snapshot-slot`, or run the full `await-snapshot` flow |
 | `await-snapshot` polls forever | no retained incremental covers the target | See **Recovery** above |
 | The final error line looks unrelated | the causal error is usually 2-4 lines earlier in the log | Read upward — error propagation was improved by #125 |
@@ -180,6 +181,8 @@ Waits for a target slot to pass and snapshots it from on-disk snapshots. Polls `
 >
 > Always create a **new backup directory** for `--backup-snapshots-dir`.  
 > Do **not** point it to the source snapshots directory (for example, do not reuse `/mnt/snapshots`).
+
+The replay starts from the full and incremental snapshot pair that reaches closest to `--slot`. Snapshots left in `--backup-snapshots-dir` by earlier runs, including the snapshots this command writes itself, are ranked the same way and cannot pull the start slot backwards. The `Selected full snapshot` line in the log names the pair that was chosen.
 
 #### Initial setup (once)
 

--- a/ncn/Cargo.lock
+++ b/ncn/Cargo.lock
@@ -4813,6 +4813,7 @@ dependencies = [
  "solana-shred-version 3.0.1",
  "solana-stake-interface 4.3.0",
  "solana-unified-scheduler-pool",
+ "tempfile",
  "thiserror 2.0.18",
  "tokio",
 ]

--- a/ncn/ledger/Cargo.toml
+++ b/ncn/ledger/Cargo.toml
@@ -29,3 +29,6 @@ libc = "0.2"
 log = "0.4.22"
 thiserror = "2.0"
 tokio = { version = "1.36.0", features = ["full"] }
+
+[dev-dependencies]
+tempfile = "3"

--- a/ncn/ledger/src/ledger_utils.rs
+++ b/ncn/ledger/src/ledger_utils.rs
@@ -9,10 +9,8 @@ use std::{
 };
 
 use agave_snapshots::{
-    error::SnapshotError,
-    paths::{full_snapshot_archives_iter, incremental_snapshot_archives_iter},
-    snapshot_archive_info::SnapshotArchiveInfoGetter,
-    snapshot_config::SnapshotConfig,
+    error::SnapshotError, paths::full_snapshot_archives_iter,
+    snapshot_archive_info::SnapshotArchiveInfoGetter, snapshot_config::SnapshotConfig,
     SnapshotVersion,
 };
 use clap_old::ArgMatches;
@@ -36,7 +34,10 @@ use solana_runtime::{bank::Bank, snapshot_bank_utils};
 use solana_sdk::clock::Slot;
 use thiserror::Error;
 
-use super::{arg_matches, load_and_process_ledger, resource_limits};
+use super::{
+    arg_matches, load_and_process_ledger, resource_limits,
+    snapshot_selection::select_snapshot_archives,
+};
 
 #[derive(Error, Debug)]
 pub enum LedgerUtilsError {
@@ -268,22 +269,22 @@ pub fn get_bank_from_ledger(
         ..Default::default()
     };
 
-    let mut starting_slot = 0; // default start check with genesis
-    let max_slot = process_options.halt_at_slot;
-    let full_snapshot_slot = full_snapshot_archives_iter(&full_snapshots_path)
-        .map(|archive| archive.slot())
-        .filter(|slot| max_slot.is_none_or(|max_slot| *slot <= max_slot))
-        .max();
-    if let Some(full_snapshot_slot) = full_snapshot_slot {
-        let incremental_snapshot_slot =
-            incremental_snapshot_archives_iter(&incremental_snapshots_path)
-                .filter(|archive| archive.base_slot() == full_snapshot_slot)
-                .map(|archive| archive.slot())
-                .filter(|slot| max_slot.is_none_or(|max_slot| *slot <= max_slot))
-                .max()
-                .unwrap_or_default();
-        starting_slot = std::cmp::max(full_snapshot_slot, incremental_snapshot_slot);
-    }
+    // Use the same archives load_and_process_ledger will use, so the range check
+    // below covers the slots the replay actually reads. Falls back to genesis
+    // when the directory holds no usable full snapshot.
+    let starting_slot = select_snapshot_archives(
+        &full_snapshots_path,
+        &incremental_snapshots_path,
+        process_options.halt_at_slot,
+    )
+    .map_or(0, |selected| {
+        info!(
+            "Selected full snapshot {} and incremental snapshot {:?}",
+            selected.full.slot(),
+            selected.incremental.as_ref().map(|archive| archive.slot())
+        );
+        selected.starting_slot()
+    });
     info!("Starting slot {}", starting_slot);
 
     match process_options.halt_at_slot {

--- a/ncn/ledger/src/lib.rs
+++ b/ncn/ledger/src/lib.rs
@@ -12,6 +12,7 @@ pub mod arg_matches;
 pub mod ledger_utils;
 pub mod load_and_process_ledger;
 pub mod resource_limits;
+pub mod snapshot_selection;
 
 /// spl-stake-pool program id
 pub const STAKE_POOL_PROGRAM_ID: Pubkey =

--- a/ncn/ledger/src/load_and_process_ledger.rs
+++ b/ncn/ledger/src/load_and_process_ledger.rs
@@ -1,10 +1,6 @@
 use {
     agave_snapshots::{
-        paths::{full_snapshot_archives_iter, incremental_snapshot_archives_iter},
-        snapshot_archive_info::{
-            FullSnapshotArchiveInfo, IncrementalSnapshotArchiveInfo, SnapshotArchiveInfoGetter,
-        },
-        snapshot_config::SnapshotConfig,
+        snapshot_archive_info::SnapshotArchiveInfoGetter, snapshot_config::SnapshotConfig,
         snapshot_hash::StartingSnapshotHashes,
     },
     clap_old::ArgMatches,
@@ -54,6 +50,8 @@ use {
     },
     thiserror::Error,
 };
+
+use super::snapshot_selection::{select_snapshot_archives, SelectedSnapshots};
 
 pub const LEDGER_TOOL_DIRECTORY: &str = "ledger_tool";
 
@@ -151,21 +149,26 @@ pub fn load_and_process_ledger(
     // Here we configure the SnapshotConfig. It uses the directories the operator has passed in to
     // find the best full and incremental snapshot files to use for a desired slot. TipRouter
     // operators Directories often use different directories than their RPC node's.
+    //
+    // The chosen archives are staged into their own directory so that anything else sitting in the
+    // operator's snapshot directory cannot be picked up by the loader further down.
     let (snapshot_config, starting_slot) = {
         let full_snapshot_archives_dir =
             snapshot_archive_path.unwrap_or_else(|| blockstore.ledger_path().to_path_buf());
         let incremental_snapshot_archives_dir =
             incremental_snapshot_archive_path.unwrap_or_else(|| full_snapshot_archives_dir.clone());
 
-        let selected_full_snapshot_archive: Option<FullSnapshotArchiveInfo> =
-            full_snapshot_archives_iter(&full_snapshot_archives_dir)
-                .filter(|archive| {
-                    snapshot_halt_at_slot.is_none_or(|max_slot| archive.slot() <= max_slot)
-                })
-                .max_by_key(|archive| archive.slot());
+        let selected = select_snapshot_archives(
+            &full_snapshot_archives_dir,
+            &incremental_snapshot_archives_dir,
+            snapshot_halt_at_slot,
+        );
 
-        let selected_full_snapshot_archive = match selected_full_snapshot_archive {
-            Some(selected_full_snapshot_archive) => selected_full_snapshot_archive,
+        let SelectedSnapshots {
+            full: selected_full_snapshot_archive,
+            incremental: selected_incremental_snapshot_archive,
+        } = match selected {
+            Some(selected) => selected,
             None => {
                 return Err(if let Some(halt_slot) = snapshot_halt_at_slot {
                     LoadAndProcessLedgerError::NoSnapshotAtOrBeforeHaltSlot {
@@ -179,14 +182,6 @@ pub fn load_and_process_ledger(
                 });
             }
         };
-
-        let selected_incremental_snapshot_archive: Option<IncrementalSnapshotArchiveInfo> =
-            incremental_snapshot_archives_iter(&incremental_snapshot_archives_dir)
-                .filter(|archive| archive.base_slot() == selected_full_snapshot_archive.slot())
-                .filter(|archive| {
-                    snapshot_halt_at_slot.is_none_or(|max_slot| archive.slot() <= max_slot)
-                })
-                .max_by_key(|archive| archive.slot());
 
         let starting_slot = std::cmp::max(
             selected_full_snapshot_archive.slot(),

--- a/ncn/ledger/src/snapshot_selection.rs
+++ b/ncn/ledger/src/snapshot_selection.rs
@@ -1,0 +1,162 @@
+//! Picks the snapshot pair a replay should resume from.
+//!
+//! Both `ledger_utils::get_bank_from_ledger` (which pre-flights the blockstore
+//! range) and `load_and_process_ledger` (which actually loads the bank) need the
+//! same answer. They live in different modules, so the choice is made here once
+//! and shared.
+
+use std::{collections::HashMap, path::Path};
+
+use agave_snapshots::{
+    paths::{full_snapshot_archives_iter, incremental_snapshot_archives_iter},
+    snapshot_archive_info::{
+        FullSnapshotArchiveInfo, IncrementalSnapshotArchiveInfo, SnapshotArchiveInfoGetter,
+    },
+};
+use solana_sdk::clock::Slot;
+
+/// A full snapshot and, when one exists, the incremental snapshot built on top
+/// of it.
+pub struct SelectedSnapshots {
+    pub full: FullSnapshotArchiveInfo,
+    pub incremental: Option<IncrementalSnapshotArchiveInfo>,
+}
+
+impl SelectedSnapshots {
+    /// The slot the bank resumes from once these archives are loaded.
+    pub fn starting_slot(&self) -> Slot {
+        self.incremental
+            .as_ref()
+            .map_or_else(|| self.full.slot(), |archive| archive.slot())
+    }
+}
+
+/// Find the pair that resumes closest to `halt_at_slot`, ignoring archives above
+/// it.
+///
+/// The highest full snapshot is not always the best starting point. A directory
+/// can hold a full snapshot that no incremental is based on, in which case an
+/// older full plus a recent incremental resumes much later. Scoring every full
+/// snapshot by the slot its pair actually reaches picks the shortest replay and
+/// keeps unrelated archives in the directory from dragging the start slot
+/// backwards.
+///
+/// Returns `None` when the directory holds no full snapshot at or below
+/// `halt_at_slot`.
+pub fn select_snapshot_archives(
+    full_snapshot_archives_dir: &Path,
+    incremental_snapshot_archives_dir: &Path,
+    halt_at_slot: Option<Slot>,
+) -> Option<SelectedSnapshots> {
+    let within_range = |slot: Slot| halt_at_slot.is_none_or(|halt_slot| slot <= halt_slot);
+
+    // Highest usable incremental for each base slot.
+    let mut best_incremental: HashMap<Slot, Slot> = HashMap::new();
+    for archive in incremental_snapshot_archives_iter(incremental_snapshot_archives_dir) {
+        if !within_range(archive.slot()) {
+            continue;
+        }
+        best_incremental
+            .entry(archive.base_slot())
+            .and_modify(|slot| *slot = (*slot).max(archive.slot()))
+            .or_insert(archive.slot());
+    }
+
+    // Rank by the slot the pair reaches, then by the full snapshot's own slot so
+    // that two pairs reaching the same slot resolve to the one with less
+    // incremental data to load.
+    let (full_slot, incremental_slot) = full_snapshot_archives_iter(full_snapshot_archives_dir)
+        .map(|archive| archive.slot())
+        .filter(|slot| within_range(*slot))
+        .map(|full_slot| (full_slot, best_incremental.get(&full_slot).copied()))
+        .max_by_key(|(full_slot, incremental_slot)| {
+            ((*incremental_slot).unwrap_or(*full_slot), *full_slot)
+        })?;
+
+    let full =
+        full_snapshot_archives_iter(full_snapshot_archives_dir).find(|a| a.slot() == full_slot)?;
+    let incremental = incremental_slot.and_then(|incremental_slot| {
+        incremental_snapshot_archives_iter(incremental_snapshot_archives_dir)
+            .find(|a| a.base_slot() == full_slot && a.slot() == incremental_slot)
+    });
+
+    Some(SelectedSnapshots { full, incremental })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    use tempfile::TempDir;
+
+    const HASH: &str = "11111111111111111111111111111111";
+
+    fn write_full(dir: &Path, slot: Slot) {
+        fs::write(dir.join(format!("snapshot-{slot}-{HASH}.tar.zst")), b"").unwrap();
+    }
+
+    fn write_incremental(dir: &Path, base_slot: Slot, slot: Slot) {
+        fs::write(
+            dir.join(format!(
+                "incremental-snapshot-{base_slot}-{slot}-{HASH}.tar.zst"
+            )),
+            b"",
+        )
+        .unwrap();
+    }
+
+    /// A previous run leaves its own generated snapshot in the directory. It is
+    /// the highest full snapshot but nothing is based on it, so pairing an older
+    /// full with a recent incremental resumes much later.
+    #[test]
+    fn skips_a_higher_full_snapshot_that_has_no_incremental() {
+        let dir = TempDir::new().unwrap();
+        write_full(dir.path(), 100);
+        write_incremental(dir.path(), 100, 500);
+        write_full(dir.path(), 300);
+
+        let selected = select_snapshot_archives(dir.path(), dir.path(), Some(600)).unwrap();
+
+        assert_eq!(selected.full.slot(), 100);
+        assert_eq!(
+            selected.incremental.as_ref().map(|archive| archive.slot()),
+            Some(500)
+        );
+        assert_eq!(selected.starting_slot(), 500);
+    }
+
+    #[test]
+    fn ignores_archives_above_the_halt_slot() {
+        let dir = TempDir::new().unwrap();
+        write_full(dir.path(), 100);
+        write_incremental(dir.path(), 100, 500);
+        write_incremental(dir.path(), 100, 900);
+        write_full(dir.path(), 800);
+
+        let selected = select_snapshot_archives(dir.path(), dir.path(), Some(600)).unwrap();
+
+        assert_eq!(selected.starting_slot(), 500);
+    }
+
+    #[test]
+    fn uses_the_full_snapshot_when_nothing_is_based_on_it() {
+        let dir = TempDir::new().unwrap();
+        write_full(dir.path(), 300);
+        write_incremental(dir.path(), 100, 250);
+
+        let selected = select_snapshot_archives(dir.path(), dir.path(), Some(600)).unwrap();
+
+        assert_eq!(selected.full.slot(), 300);
+        assert!(selected.incremental.is_none());
+        assert_eq!(selected.starting_slot(), 300);
+    }
+
+    #[test]
+    fn returns_none_when_every_full_snapshot_is_above_the_halt_slot() {
+        let dir = TempDir::new().unwrap();
+        write_full(dir.path(), 900);
+
+        assert!(select_snapshot_archives(dir.path(), dir.path(), Some(600)).is_none());
+    }
+}


### PR DESCRIPTION
### Problem

`await-snapshot` failed with `Blockstore missing data to replay to slot
440641000` on a node whose ledger fully covered the target.

The replay base is chosen as the highest full snapshot at or below the
target, then the highest incremental built on that full. `await-snapshot`
writes its own output snapshot into `--backup-snapshots-dir`, the same
directory it scans for bases, so a completed run leaves behind a full
snapshot with no incremental attached to it. The next run selects that
leftover and resumes from it instead of from the pair it just copied in.

#113 narrowed the `agave-ledger-tool blockstore copy` range to start at the
matched incremental, so the copied blockstore now covers only the slots
between that incremental and the target. A start slot pulled backwards by a
leftover snapshot falls outside the copied range and the pre-flight
`slot_range_connected` check fails.

### Fix

Score every full snapshot at or below the target by the slot its pair
actually reaches, and take the highest. An older full with a recent
incremental now beats a newer full with none.

`get_bank_from_ledger` and `load_and_process_ledger` had separate copies of
the two-step selection and had to stay in agreement, so the logic moved into
`snapshot_selection::select_snapshot_archives` and both call it. Mismatched
copies would mean the range check passes while the loader starts somewhere
else.

The chosen archives are now logged as `Selected full snapshot <slot> and
incremental snapshot <slot>`.

### Testing

`cargo test -p ncn-ledger` covers the leftover-snapshot case, halt-slot
filtering, a full snapshot with no incremental, and an empty result.

Verified manually against the directory that produced the failure: the
selector picks 440600281 plus 440640293 (707 slots) rather than the
leftover 440607616 (33,384 slots).