### PR TITLE
fix(frontend): preserve stake precision in merkle proofs

### DIFF
--- a/frontend/src/chain/instructions/helpers.ts
+++ b/frontend/src/chain/instructions/helpers.ts
@@ -170,6 +170,7 @@ export async function getVoteAccountProof(
 
   return fetchNcnJson<VoteAccountProofResponse>(url, {
     label: "vote account proof",
+    losslessIntegerFields: ["active_stake"],
   });
 }
 
@@ -184,6 +185,7 @@ export async function getStakeAccountProof(
 
   return fetchNcnJson<StakeAccountProofResponse>(url, {
     label: "stake account proof",
+    losslessIntegerFields: ["active_stake"],
   });
 }
 

--- a/frontend/src/chain/instructions/types.ts
+++ b/frontend/src/chain/instructions/types.ts
@@ -95,7 +95,7 @@ export interface FinalizeProposalParams {
 // API response types (based on solgov.online API)
 export interface VoteAccountProofResponse {
   meta_merkle_leaf: {
-    active_stake: number;
+    active_stake: string | number;
     stake_merkle_root: string;
     vote_account: string;
     voting_wallet: string;
@@ -106,7 +106,7 @@ export interface VoteAccountProofResponse {
 }
 
 export interface StakeMerkleLeafRaw {
-  active_stake: number;
+  active_stake: string | number;
   stake_account: string;
   voting_wallet: string;
 }

--- a/frontend/src/lib/__tests__/ncnApi.test.ts
+++ b/frontend/src/lib/__tests__/ncnApi.test.ts
@@ -31,6 +31,28 @@ describe("fetchNcnJson", () => {
     ).resolves.toEqual(meta);
   });
 
+  it("preserves selected u64 fields beyond Number.MAX_SAFE_INTEGER", async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      text: async () =>
+        '{"meta_merkle_leaf":{"active_stake":16054077974334921},"snapshot_slot":440641000}',
+    }) as unknown as typeof fetch;
+
+    await expect(
+      fetchNcnJson<{
+        meta_merkle_leaf: { active_stake: string };
+        snapshot_slot: number;
+      }>(URL_UNDER_TEST, {
+        label: "vote account proof",
+        losslessIntegerFields: ["active_stake"],
+      }),
+    ).resolves.toEqual({
+      meta_merkle_leaf: { active_stake: "16054077974334921" },
+      snapshot_slot: 440641000,
+    });
+  });
+
   it("throws NcnApiHttpError naming the status, the operator that answered, and its body", async () => {
     // HTTP/2 has no reason phrase, so statusText is empty in practice — the numeric status
     // is the only thing that identifies the failure. The router redirects, so response.url is

--- a/frontend/src/lib/ncnApi.ts
+++ b/frontend/src/lib/ncnApi.ts
@@ -157,6 +157,8 @@ interface FetchNcnJsonOptions {
   timeoutMs?: number;
   /** Number of retries after the initial request. */
   maxRetries?: number;
+  /** Integer-valued response fields that must be returned as exact decimal strings. */
+  losslessIntegerFields?: readonly string[];
   /** Override the backoff calculation, primarily for callers with tighter latency budgets. */
   retryDelayMs?: (retryNumber: number) => number;
   /** Human-readable name of the resource, used in error messages. */
@@ -167,7 +169,33 @@ interface FetchNcnJsonOnceOptions {
   signal?: AbortSignal;
   timeoutMs: number;
   label: string;
+  losslessIntegerFields?: readonly string[];
 }
+
+/**
+ * Quote selected integer tokens before JSON.parse can round them to IEEE-754 doubles.
+ *
+ * The verifier API currently serializes u64 lamport values as JSON numbers. Validator stake can
+ * exceed Number.MAX_SAFE_INTEGER, and rounding even one lamport changes a Merkle leaf hash. Keep
+ * this scoped to explicitly named, trusted API fields so ordinary response numbers stay numbers.
+ */
+const parseNcnJson = <T>(
+  body: string,
+  losslessIntegerFields: readonly string[],
+): T => {
+  let normalized = body;
+
+  for (const field of losslessIntegerFields) {
+    const escapedField = field.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    const integerValue = new RegExp(
+      `("${escapedField}"\\s*:\\s*)(-?(?:0|[1-9]\\d*))(?=\\s*[,}])`,
+      "g",
+    );
+    normalized = normalized.replace(integerValue, '$1"$2"');
+  }
+
+  return JSON.parse(normalized) as T;
+};
 
 const defaultRetryDelayMs = (retryNumber: number): number =>
   Math.min(1000 * 2 ** retryNumber, MAX_RETRY_DELAY_MS) +
@@ -202,7 +230,12 @@ const waitForRetry = async (
 /** Make one bounded request. Retry orchestration lives in `fetchNcnJson`. */
 const fetchNcnJsonOnce = async <T>(
   url: string,
-  { signal, timeoutMs, label }: FetchNcnJsonOnceOptions,
+  {
+    signal,
+    timeoutMs,
+    label,
+    losslessIntegerFields = [],
+  }: FetchNcnJsonOnceOptions,
 ): Promise<T> => {
   // Composed by hand rather than with AbortSignal.any/AbortSignal.timeout, which need
   // Safari 17.4+ — and Safari users are the ones hitting these failures.
@@ -232,7 +265,11 @@ const fetchNcnJsonOnce = async <T>(
       });
     }
 
-    return (await response.json()) as T;
+    if (losslessIntegerFields.length === 0) {
+      return (await response.json()) as T;
+    }
+
+    return parseNcnJson<T>(await response.text(), losslessIntegerFields);
   } catch (error) {
     // The caller cancelled us (unmount, invalidation). Rethrow untouched so React Query
     // records a cancellation rather than a failure — cancellations never reach
@@ -278,13 +315,19 @@ export async function fetchNcnJson<T>(
     signal,
     timeoutMs = DEFAULT_TIMEOUT_MS,
     maxRetries = DEFAULT_MAX_RETRIES,
+    losslessIntegerFields,
     retryDelayMs = defaultRetryDelayMs,
     label,
   }: FetchNcnJsonOptions,
 ): Promise<T> {
   for (let retryNumber = 0; ; retryNumber += 1) {
     try {
-      return await fetchNcnJsonOnce<T>(url, { signal, timeoutMs, label });
+      return await fetchNcnJsonOnce<T>(url, {
+        signal,
+        timeoutMs,
+        label,
+        losslessIntegerFields,
+      });
     } catch (error) {
       const failureKind = classifyNcnFailure(error);
       const shouldRetry =


### PR DESCRIPTION
## Summary

- parse proof `active_stake` fields as exact decimal strings before native `JSON.parse` can round them
- allow proof response stake values to remain lossless until Anchor encodes them as u64 values
- add a regression test using the live failing value above `Number.MAX_SAFE_INTEGER`

## Root cause

The verifier API serializes u64 lamport values as JSON numbers. The failing validator proof contains `active_stake: 16054077974334921`, which exceeds JavaScript's safe-integer range. Native `JSON.parse` silently changes it to `16054077974334920`; that one-lamport change mutates the MetaMerkleLeaf hash and causes `InitMetaMerkleProof` to fail with error 6009 (`InvalidMerkleProof`).

Reconstructing the reported live proof for proposal `AGHDQ6gjRFJPoyEcHuc4X7sbxJwyJfeKTb3UrGFzFNZD` confirms both console roots exactly:

- exact value `16054077974334921` -> `2Jwjfi6KWQmqMraTkCcWqdj3VvyGcVgfNGYdzTQmaUj8` (on-chain root)
- rounded value `16054077974334920` -> `C2y6YfyyQRoftanedZ4LcpnTvgwpmn9oKWzshsRt3Abc` (failed node)

The lossless handling is opt-in per response field, so slots and ordinary NCN response numbers retain their existing types.

## Testing

- `pnpm test -- --runInBand` (24 suites, 361 tests)
- `pnpm exec tsc --noEmit`
- ESLint on changed frontend files
- `pnpm build`
