### PR TITLE
fix(frontend): validate connected wallet stays consistent through vot…

### DIFF
--- a/frontend/src/chain/instructions/__tests__/castVoteOverride.test.ts
+++ b/frontend/src/chain/instructions/__tests__/castVoteOverride.test.ts
@@ -135,18 +135,28 @@ describe("castVoteOverride", () => {
     };
   }
 
-  const mockSignTransaction = jest.fn(async (transaction: Transaction) => {
-    void transaction;
-    return { serialize: () => Buffer.alloc(0) };
-  });
-  const wallet = {
+  const mockSignTransaction = jest.fn();
+  const walletState = {
     publicKey: new PublicKey(SIGNER),
     signTransaction: mockSignTransaction,
     signAllTransactions: jest.fn(),
-  } as unknown as AnchorWallet;
+  };
+  const wallet = walletState as unknown as AnchorWallet;
+
+  function signedTransactionResponse(
+    signature: Buffer | null = Buffer.alloc(64)
+  ): Transaction {
+    return {
+      signatures: [{ publicKey: new PublicKey(SIGNER), signature }],
+      verifySignatures: () => true,
+      serialize: () => Buffer.alloc(0),
+    } as unknown as Transaction;
+  }
 
   beforeEach(() => {
     jest.clearAllMocks();
+    walletState.publicKey = new PublicKey(SIGNER);
+    mockSignTransaction.mockResolvedValue(signedTransactionResponse());
     mockCreateProgramWithWallet.mockReturnValue(buildFakeProgram());
     mockCreateGovV1ProgramWithWallet.mockReturnValue(buildFakeGovV1Program());
     mockComputeProofCloseTimestamp.mockResolvedValue(2_000_000_000);
@@ -361,5 +371,27 @@ describe("castVoteOverride", () => {
     );
     expect(mockSignTransaction).toHaveBeenCalledTimes(1);
     expect(mockSendRawTransaction).toHaveBeenCalledTimes(1);
+  });
+
+  it("reports an unsigned wallet response without submitting the transaction", async () => {
+    mockSignTransaction.mockResolvedValueOnce(signedTransactionResponse(null));
+
+    await expect(castVoteOverride(params, blockchainParams)).rejects.toThrow(
+      /wallet did not sign the transaction/i
+    );
+    expect(mockSendRawTransaction).not.toHaveBeenCalled();
+  });
+
+  it("reports an account change while the wallet approval is open", async () => {
+    const otherAccount = new PublicKey(keyFromByte(12));
+    mockSignTransaction.mockImplementationOnce(async () => {
+      walletState.publicKey = otherAccount;
+      return signedTransactionResponse();
+    });
+
+    await expect(castVoteOverride(params, blockchainParams)).rejects.toThrow(
+      /connected wallet account changed while signing/i
+    );
+    expect(mockSendRawTransaction).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/chain/instructions/__tests__/castVoteOverride.test.ts
+++ b/frontend/src/chain/instructions/__tests__/castVoteOverride.test.ts
@@ -144,10 +144,12 @@ describe("castVoteOverride", () => {
   const wallet = walletState as unknown as AnchorWallet;
 
   function signedTransactionResponse(
-    signature: Buffer | null = Buffer.alloc(64)
+    signatures: { publicKey: PublicKey; signature: Buffer | null }[] = [
+      { publicKey: new PublicKey(SIGNER), signature: Buffer.alloc(64) },
+    ]
   ): Transaction {
     return {
-      signatures: [{ publicKey: new PublicKey(SIGNER), signature }],
+      signatures,
       verifySignatures: () => true,
       serialize: () => Buffer.alloc(0),
     } as unknown as Transaction;
@@ -374,7 +376,11 @@ describe("castVoteOverride", () => {
   });
 
   it("reports an unsigned wallet response without submitting the transaction", async () => {
-    mockSignTransaction.mockResolvedValueOnce(signedTransactionResponse(null));
+    mockSignTransaction.mockResolvedValueOnce(
+      signedTransactionResponse([
+        { publicKey: new PublicKey(SIGNER), signature: null },
+      ])
+    );
 
     await expect(castVoteOverride(params, blockchainParams)).rejects.toThrow(
       /wallet did not sign the transaction/i
@@ -382,15 +388,17 @@ describe("castVoteOverride", () => {
     expect(mockSendRawTransaction).not.toHaveBeenCalled();
   });
 
-  it("reports an account change while the wallet approval is open", async () => {
+  it("reports a returned signature from a different account", async () => {
     const otherAccount = new PublicKey(keyFromByte(12));
-    mockSignTransaction.mockImplementationOnce(async () => {
-      walletState.publicKey = otherAccount;
-      return signedTransactionResponse();
-    });
+    mockSignTransaction.mockResolvedValueOnce(
+      signedTransactionResponse([
+        { publicKey: new PublicKey(SIGNER), signature: null },
+        { publicKey: otherAccount, signature: Buffer.alloc(64) },
+      ])
+    );
 
     await expect(castVoteOverride(params, blockchainParams)).rejects.toThrow(
-      /connected wallet account changed while signing/i
+      /signed with a different account/i
     );
     expect(mockSendRawTransaction).not.toHaveBeenCalled();
   });

--- a/frontend/src/chain/instructions/castVoteOverride.ts
+++ b/frontend/src/chain/instructions/castVoteOverride.ts
@@ -25,6 +25,7 @@ import {
   deriveVoteOverrideCachePda,
   getMetaMerkleProofPda,
   computeProofCloseTimestamp,
+  signTransactionForWallet,
 } from "./helpers";
 import { BN } from "@coral-xyz/anchor";
 
@@ -48,6 +49,10 @@ export async function castVoteOverride(
   if (!wallet || !wallet.publicKey) {
     throw new Error("Wallet not connected");
   }
+
+  // Keep the signing account stable throughout the two-transaction flow. A wallet extension can
+  // switch accounts while its approval dialog is open, in which case it cannot sign this vote.
+  const signer = wallet.publicKey;
 
   if (consensusResult === undefined) {
     throw new Error("Consensus result not defined");
@@ -140,7 +145,7 @@ export async function castVoteOverride(
       .accountsStrict({
         consensusResult,
         merkleProof: metaMerkleProofPda,
-        payer: wallet.publicKey,
+        payer: signer,
         systemProgram: SystemProgram.programId,
       })
       .instruction();
@@ -153,11 +158,14 @@ export async function castVoteOverride(
       await program.provider.connection.getLatestBlockhash("confirmed");
     const initTransaction = new Transaction();
     initTransaction.add(initMerkleInstruction);
-    initTransaction.feePayer = wallet.publicKey;
+    initTransaction.feePayer = signer;
     initTransaction.recentBlockhash = initBlockhash.blockhash;
 
-    const signedInitTransaction =
-      await wallet.signTransaction(initTransaction);
+    const signedInitTransaction = await signTransactionForWallet(
+      wallet,
+      initTransaction,
+      signer
+    );
     const initSignature =
       await program.provider.connection.sendRawTransaction(
         signedInitTransaction.serialize(),
@@ -217,7 +225,7 @@ export async function castVoteOverride(
       stakeMerkleLeaf
     )
     .accountsStrict({
-      signer: wallet.publicKey,
+      signer,
       splVoteAccount: splVoteAccount,
       splStakeAccount: stakeAccountPubkey,
       proposal: proposalPubkey,
@@ -233,12 +241,12 @@ export async function castVoteOverride(
 
   const transaction = new Transaction();
   transaction.add(castVoteOverrideInstruction);
-  transaction.feePayer = wallet.publicKey;
+  transaction.feePayer = signer;
   transaction.recentBlockhash = (
     await program.provider.connection.getLatestBlockhash("confirmed")
   ).blockhash;
 
-  const tx = await wallet.signTransaction(transaction);
+  const tx = await signTransactionForWallet(wallet, transaction, signer);
 
   const signature = await program.provider.connection.sendRawTransaction(
     tx.serialize(),

--- a/frontend/src/chain/instructions/castVoteOverride.ts
+++ b/frontend/src/chain/instructions/castVoteOverride.ts
@@ -50,8 +50,8 @@ export async function castVoteOverride(
     throw new Error("Wallet not connected");
   }
 
-  // Keep the signing account stable throughout the two-transaction flow. A wallet extension can
-  // switch accounts while its approval dialog is open, in which case it cannot sign this vote.
+  // Both transactions require this same account. signTransactionForWallet verifies that the
+  // wallet-returned transaction contains its signature before either transaction is submitted.
   const signer = wallet.publicKey;
 
   if (consensusResult === undefined) {

--- a/frontend/src/chain/instructions/helpers.ts
+++ b/frontend/src/chain/instructions/helpers.ts
@@ -1,4 +1,4 @@
-import { PublicKey, Connection, Keypair } from "@solana/web3.js";
+import { PublicKey, Connection, Keypair, Transaction } from "@solana/web3.js";
 import { AnchorProvider, Program, BN } from "@coral-xyz/anchor";
 import idl from "@/chain/idl/svmgov_program.json";
 import govV1Idl from "@/chain/idl/gov-v1.json";
@@ -13,6 +13,56 @@ import { AnchorWallet } from "@solana/wallet-adapter-react";
 import { SvmgovProgram, GovV1 } from "../types";
 import { RPC_URLS } from "@/contexts/EndpointContext";
 import { DEFAULT_NCN_API_URL, fetchNcnJson } from "@/lib/ncnApi";
+
+/** Thrown when the wallet cannot provide the signature required by a transaction. */
+export class WalletSigningError extends Error {
+  name = "WalletSigningError";
+}
+
+/**
+ * Signs a transaction and verifies that the wallet signed for the account used to build it.
+ *
+ * Wallet extensions can switch accounts while a signing request is open. In that case, sending
+ * the returned transaction would otherwise fail later with web3.js's opaque "missing signature"
+ * serialization error.
+ *
+ * @param wallet - Wallet adapter used to sign the transaction.
+ * @param transaction - Fully constructed transaction with a fee payer and recent blockhash.
+ * @param expectedSigner - Account captured when the transaction was constructed.
+ * @returns The transaction signed by the expected account.
+ * @throws {WalletSigningError} If the connected account changes or does not sign the transaction.
+ */
+export async function signTransactionForWallet(
+  wallet: AnchorWallet,
+  transaction: Transaction,
+  expectedSigner: PublicKey
+): Promise<Transaction> {
+  if (!wallet.publicKey.equals(expectedSigner)) {
+    throw new WalletSigningError(
+      "Your connected wallet account changed. Reconnect the account that started this vote and try again."
+    );
+  }
+
+  const signedTransaction = await wallet.signTransaction(transaction);
+
+  if (!wallet.publicKey.equals(expectedSigner)) {
+    throw new WalletSigningError(
+      "Your connected wallet account changed while signing. Reconnect the account that started this vote and try again."
+    );
+  }
+
+  const expectedSignature = signedTransaction.signatures.find(({ publicKey }) =>
+    publicKey.equals(expectedSigner)
+  );
+
+  if (!expectedSignature?.signature || !signedTransaction.verifySignatures()) {
+    throw new WalletSigningError(
+      "Your wallet did not sign the transaction with the connected account. Reconnect the account that started this vote and try again."
+    );
+  }
+
+  return signedTransaction;
+}
 
 // PDA derivation functions (based on test implementation)
 export function deriveProposalPda(

--- a/frontend/src/chain/instructions/helpers.ts
+++ b/frontend/src/chain/instructions/helpers.ts
@@ -20,44 +20,50 @@ export class WalletSigningError extends Error {
 }
 
 /**
- * Signs a transaction and verifies that the wallet signed for the account used to build it.
+ * Signs a transaction and verifies that the returned signature is for the account that built it.
  *
- * Wallet extensions can switch accounts while a signing request is open. In that case, sending
- * the returned transaction would otherwise fail later with web3.js's opaque "missing signature"
- * serialization error.
+ * A wallet can return a transaction signed by a different account, or no signature at all. This
+ * guard prevents either response from reaching web3.js serialization, where it would otherwise
+ * surface as an opaque "missing signature" error. It cannot observe later React wallet-provider
+ * updates; it validates only the transaction returned by the wallet.
  *
  * @param wallet - Wallet adapter used to sign the transaction.
  * @param transaction - Fully constructed transaction with a fee payer and recent blockhash.
  * @param expectedSigner - Account captured when the transaction was constructed.
  * @returns The transaction signed by the expected account.
- * @throws {WalletSigningError} If the connected account changes or does not sign the transaction.
+ * @throws {WalletSigningError} If the returned transaction is unsigned, invalid, or signed by a
+ * different account.
  */
 export async function signTransactionForWallet(
   wallet: AnchorWallet,
   transaction: Transaction,
   expectedSigner: PublicKey
 ): Promise<Transaction> {
-  if (!wallet.publicKey.equals(expectedSigner)) {
-    throw new WalletSigningError(
-      "Your connected wallet account changed. Reconnect the account that started this vote and try again."
-    );
-  }
-
   const signedTransaction = await wallet.signTransaction(transaction);
-
-  if (!wallet.publicKey.equals(expectedSigner)) {
-    throw new WalletSigningError(
-      "Your connected wallet account changed while signing. Reconnect the account that started this vote and try again."
-    );
-  }
 
   const expectedSignature = signedTransaction.signatures.find(({ publicKey }) =>
     publicKey.equals(expectedSigner)
   );
+  const unexpectedSignature = signedTransaction.signatures.find(
+    ({ publicKey, signature }) =>
+      signature !== null && !publicKey.equals(expectedSigner)
+  );
 
-  if (!expectedSignature?.signature || !signedTransaction.verifySignatures()) {
+  if (!expectedSignature?.signature && unexpectedSignature) {
+    throw new WalletSigningError(
+      "Your wallet signed with a different account than the one that started this vote. Reconnect the original account and try again."
+    );
+  }
+
+  if (!expectedSignature?.signature) {
     throw new WalletSigningError(
       "Your wallet did not sign the transaction with the connected account. Reconnect the account that started this vote and try again."
+    );
+  }
+
+  if (!signedTransaction.verifySignatures()) {
+    throw new WalletSigningError(
+      "Your wallet returned an invalid transaction signature. Reconnect the account that started this vote and try again."
     );
   }
 

--- a/frontend/src/chain/instructions/modifyVoteOverride.ts
+++ b/frontend/src/chain/instructions/modifyVoteOverride.ts
@@ -25,6 +25,7 @@ import {
   deriveVotePda,
   getMetaMerkleProofPda,
   computeProofCloseTimestamp,
+  signTransactionForWallet,
 } from "./helpers";
 import { BN } from "@coral-xyz/anchor";
 
@@ -48,6 +49,10 @@ export async function modifyVoteOverride(
   if (!wallet || !wallet.publicKey) {
     throw new Error("Wallet not connected");
   }
+
+  // Keep the signing account stable throughout the two-transaction flow. A wallet extension can
+  // switch accounts while its approval dialog is open, in which case it cannot sign this vote.
+  const signer = wallet.publicKey;
 
   if (consensusResult === undefined) {
     throw new Error("Consensus result not defined");
@@ -141,7 +146,7 @@ export async function modifyVoteOverride(
       .accountsStrict({
         consensusResult,
         merkleProof: metaMerkleProofPda,
-        payer: wallet.publicKey,
+        payer: signer,
         systemProgram: SystemProgram.programId,
       })
       .instruction();
@@ -154,11 +159,14 @@ export async function modifyVoteOverride(
       await program.provider.connection.getLatestBlockhash("confirmed");
     const initTransaction = new Transaction();
     initTransaction.add(initMerkleInstruction);
-    initTransaction.feePayer = wallet.publicKey;
+    initTransaction.feePayer = signer;
     initTransaction.recentBlockhash = initBlockhash.blockhash;
 
-    const signedInitTransaction =
-      await wallet.signTransaction(initTransaction);
+    const signedInitTransaction = await signTransactionForWallet(
+      wallet,
+      initTransaction,
+      signer
+    );
     const initSignature =
       await program.provider.connection.sendRawTransaction(
         signedInitTransaction.serialize(),
@@ -218,7 +226,7 @@ export async function modifyVoteOverride(
       stakeMerkleLeaf
     )
     .accountsStrict({
-      signer: wallet.publicKey,
+      signer,
       splVoteAccount: splVoteAccount,
       splStakeAccount: stakeAccountPubkey,
       proposal: proposalPubkey,
@@ -234,12 +242,12 @@ export async function modifyVoteOverride(
 
   const transaction = new Transaction();
   transaction.add(modifyVoteOverrideInstruction);
-  transaction.feePayer = wallet.publicKey;
+  transaction.feePayer = signer;
   transaction.recentBlockhash = (
     await program.provider.connection.getLatestBlockhash("confirmed")
   ).blockhash;
 
-  const tx = await wallet.signTransaction(transaction);
+  const tx = await signTransactionForWallet(wallet, transaction, signer);
 
   const signature = await program.provider.connection.sendRawTransaction(
     tx.serialize(),

--- a/frontend/src/chain/instructions/modifyVoteOverride.ts
+++ b/frontend/src/chain/instructions/modifyVoteOverride.ts
@@ -50,8 +50,8 @@ export async function modifyVoteOverride(
     throw new Error("Wallet not connected");
   }
 
-  // Keep the signing account stable throughout the two-transaction flow. A wallet extension can
-  // switch accounts while its approval dialog is open, in which case it cannot sign this vote.
+  // Both transactions require this same account. signTransactionForWallet verifies that the
+  // wallet-returned transaction contains its signature before either transaction is submitted.
   const signer = wallet.publicKey;
 
   if (consensusResult === undefined) {


### PR DESCRIPTION
…e signatures

---

Sentry was reporting issues with invalid transaction signatures. From the looks of it, they were caused by users starting the process with one wallet connected, then switching accounts when signing. This is causing a mismatch between expected + actual signer in the tx. 