### PR TITLE
fix(frontend): route plain vote signing through signTransactionForWallet

### DIFF
--- a/frontend/src/chain/instructions/__tests__/castVote.test.ts
+++ b/frontend/src/chain/instructions/__tests__/castVote.test.ts
@@ -1,0 +1,233 @@
+import { PublicKey, Transaction } from "@solana/web3.js";
+
+// helpers.ts transitively imports EndpointContext -> env.ts (an ESM-only package Jest does not
+// transform). Stub it so the real helpers (including the signTransactionForWallet guard under
+// test) can be required without pulling in the untransformed module.
+jest.mock("@/contexts/EndpointContext", () => ({
+  RPC_URLS: { testnet: "http://localhost:8899" },
+}));
+
+// Mock the network / program-creating helpers; keep the real signTransactionForWallet so the
+// guard behavior is exercised end to end through castVote.
+const mockGetVoteAccountProof = jest.fn();
+const mockCreateProgramWithWallet = jest.fn();
+const mockCreateGovV1ProgramWithWallet = jest.fn();
+const mockComputeProofCloseTimestamp = jest.fn();
+const mockGetMetaMerkleProofPda = jest.fn();
+const mockDeriveVotePda = jest.fn();
+const mockDeriveVoteOverrideCachePda = jest.fn();
+
+jest.mock("../helpers", () => {
+  const actual = jest.requireActual("../helpers");
+  return {
+    ...actual,
+    getVoteAccountProof: (...args: unknown[]) =>
+      mockGetVoteAccountProof(...args),
+    createProgramWithWallet: (...args: unknown[]) =>
+      mockCreateProgramWithWallet(...args),
+    createGovV1ProgramWithWallet: (...args: unknown[]) =>
+      mockCreateGovV1ProgramWithWallet(...args),
+    computeProofCloseTimestamp: (...args: unknown[]) =>
+      mockComputeProofCloseTimestamp(...args),
+    getMetaMerkleProofPda: (...args: unknown[]) =>
+      mockGetMetaMerkleProofPda(...args),
+    deriveVotePda: (...args: unknown[]) => mockDeriveVotePda(...args),
+    deriveVoteOverrideCachePda: (...args: unknown[]) =>
+      mockDeriveVoteOverrideCachePda(...args),
+  };
+});
+
+import { BN } from "@coral-xyz/anchor";
+import type { AnchorWallet } from "@solana/wallet-adapter-react";
+
+import { castVote } from "../castVote";
+import { SVMGOV_PROGRAM_ID } from "../types";
+import type { RPCEndpoint } from "@/types";
+
+// Distinct, valid 32-byte public keys used as stand-ins.
+const keyFromByte = (b: number): string =>
+  new PublicKey(new Uint8Array(32).fill(b)).toBase58();
+const VOTE_ACCOUNT = keyFromByte(1);
+const CONSENSUS_RESULT = keyFromByte(2);
+const PROPOSAL = keyFromByte(3);
+const SIGNER = keyFromByte(4);
+const BLOCKHASH = keyFromByte(5);
+
+const META_MERKLE_PROOF_PDA = new PublicKey(keyFromByte(20));
+const VALIDATOR_VOTE_PDA = new PublicKey(keyFromByte(21));
+const VOTE_OVERRIDE_CACHE_PDA = new PublicKey(keyFromByte(22));
+
+describe("castVote", () => {
+  const mockFetchProposal = jest.fn();
+  const mockGetVoteAccounts = jest.fn();
+  const mockGetAccountInfo = jest.fn();
+  const mockGetLatestBlockhash = jest.fn();
+  const mockSendRawTransaction = jest.fn();
+
+  function buildFakeProgram() {
+    const fakeIx = {
+      keys: [],
+      programId: SVMGOV_PROGRAM_ID,
+      data: Buffer.alloc(0),
+    };
+    const instruction = jest.fn(async () => fakeIx);
+    const accountsStrict = jest.fn(() => ({ instruction }));
+    const castVoteMethod = jest.fn(() => ({ accountsStrict }));
+
+    return {
+      programId: SVMGOV_PROGRAM_ID,
+      provider: {
+        connection: {
+          getVoteAccounts: mockGetVoteAccounts,
+          getAccountInfo: mockGetAccountInfo,
+          getLatestBlockhash: mockGetLatestBlockhash,
+          sendRawTransaction: mockSendRawTransaction,
+        },
+      },
+      account: {
+        proposal: {
+          fetch: mockFetchProposal,
+        },
+      },
+      methods: { castVote: castVoteMethod },
+    };
+  }
+
+  const mockSignTransaction = jest.fn();
+  const walletState = {
+    publicKey: new PublicKey(SIGNER),
+    signTransaction: mockSignTransaction,
+    signAllTransactions: jest.fn(),
+  };
+  const wallet = walletState as unknown as AnchorWallet;
+
+  function signedTransactionResponse(
+    signatures: { publicKey: PublicKey; signature: Buffer | null }[] = [
+      { publicKey: new PublicKey(SIGNER), signature: Buffer.alloc(64) },
+    ]
+  ): Transaction {
+    return {
+      signatures,
+      verifySignatures: () => true,
+      serialize: () => Buffer.alloc(0),
+    } as unknown as Transaction;
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    walletState.publicKey = new PublicKey(SIGNER);
+    // Emulates a real wallet: whatever account is connected NOW provides the signature.
+    mockSignTransaction.mockImplementation(async () =>
+      signedTransactionResponse([
+        { publicKey: new PublicKey(walletState.publicKey), signature: Buffer.alloc(64) },
+      ])
+    );
+    mockCreateProgramWithWallet.mockReturnValue(buildFakeProgram());
+    mockCreateGovV1ProgramWithWallet.mockReturnValue({
+      methods: { initMetaMerkleProof: jest.fn() },
+    });
+    mockComputeProofCloseTimestamp.mockResolvedValue(2_000_000_000);
+    mockGetVoteAccounts.mockResolvedValue({
+      current: [{ nodePubkey: SIGNER, votePubkey: VOTE_ACCOUNT }],
+      delinquent: [],
+    });
+    mockGetAccountInfo.mockResolvedValue({ data: Buffer.alloc(0) });
+    mockGetLatestBlockhash.mockResolvedValue({
+      blockhash: BLOCKHASH,
+      lastValidBlockHeight: 123,
+    });
+    mockSendRawTransaction.mockResolvedValue("test-signature");
+    mockGetMetaMerkleProofPda.mockReturnValue(META_MERKLE_PROOF_PDA);
+    mockDeriveVotePda.mockReturnValue(VALIDATOR_VOTE_PDA);
+    mockDeriveVoteOverrideCachePda.mockReturnValue(VOTE_OVERRIDE_CACHE_PDA);
+    mockFetchProposal.mockResolvedValue({
+      snapshotSlot: new BN(340_850_340),
+      endEpoch: new BN(100),
+    });
+    mockGetVoteAccountProof.mockResolvedValue({
+      network: "testnet",
+      snapshot_slot: 340_850_340,
+      meta_merkle_leaf: {
+        active_stake: 500,
+        stake_merkle_root: keyFromByte(6),
+        vote_account: VOTE_ACCOUNT,
+        voting_wallet: SIGNER,
+      },
+      meta_merkle_proof: [],
+    });
+  });
+
+  const params = {
+    proposalId: PROPOSAL,
+    forVotesBp: 10_000,
+    againstVotesBp: 0,
+    abstainVotesBp: 0,
+    wallet,
+    consensusResult: new PublicKey(CONSENSUS_RESULT),
+  };
+  const blockchainParams = {
+    network: "testnet" as RPCEndpoint,
+    endpoint: "http://localhost:8899",
+    ncnApiUrl: "http://localhost:9000",
+  };
+
+  it("signs with the connected account and submits the vote", async () => {
+    const result = await castVote(params, blockchainParams);
+
+    expect(result).toEqual({ signature: "test-signature", success: true });
+    expect(mockSignTransaction).toHaveBeenCalledTimes(1);
+    expect(mockSendRawTransaction).toHaveBeenCalledTimes(1);
+  });
+
+  it("reports an unsigned wallet response without submitting the transaction", async () => {
+    mockSignTransaction.mockResolvedValueOnce(
+      signedTransactionResponse([
+        { publicKey: new PublicKey(SIGNER), signature: null },
+      ])
+    );
+
+    await expect(castVote(params, blockchainParams)).rejects.toThrow(
+      /wallet did not sign the transaction/i
+    );
+    expect(mockSendRawTransaction).not.toHaveBeenCalled();
+  });
+
+  it("reports a returned signature from a different account without submitting", async () => {
+    const otherAccount = new PublicKey(keyFromByte(12));
+    mockSignTransaction.mockResolvedValueOnce(
+      signedTransactionResponse([
+        { publicKey: new PublicKey(SIGNER), signature: null },
+        { publicKey: otherAccount, signature: Buffer.alloc(64) },
+      ])
+    );
+
+    await expect(castVote(params, blockchainParams)).rejects.toThrow(
+      /signed with a different account/i
+    );
+    expect(mockSendRawTransaction).not.toHaveBeenCalled();
+  });
+
+  it("keeps validating the originally captured signer after an awaited fetch", async () => {
+    // Simulate a wallet switch while the proof and blockhash fetches are in flight: the
+    // connected account changes between construction and signing.
+    mockGetVoteAccountProof.mockImplementationOnce(async () => {
+      walletState.publicKey = new PublicKey(keyFromByte(13));
+      return {
+        network: "testnet",
+        snapshot_slot: 340_850_340,
+        meta_merkle_leaf: {
+          active_stake: 500,
+          stake_merkle_root: keyFromByte(6),
+          vote_account: VOTE_ACCOUNT,
+          voting_wallet: SIGNER,
+        },
+        meta_merkle_proof: [],
+      };
+    });
+
+    await expect(castVote(params, blockchainParams)).rejects.toThrow(
+      /signed with a different account|did not sign the transaction/i
+    );
+    expect(mockSendRawTransaction).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/chain/instructions/__tests__/createProposal.test.ts
+++ b/frontend/src/chain/instructions/__tests__/createProposal.test.ts
@@ -1,0 +1,176 @@
+import { PublicKey, Transaction } from "@solana/web3.js";
+
+// helpers.ts transitively imports EndpointContext -> env.ts (an ESM-only package Jest does not
+// transform). Stub it so the real helpers (including the signTransactionForWallet guard under
+// test) can be required without pulling in the untransformed module.
+jest.mock("@/contexts/EndpointContext", () => ({
+  RPC_URLS: { testnet: "http://localhost:8899" },
+}));
+
+const mockCreateProgramWithWallet = jest.fn();
+
+jest.mock("../helpers", () => {
+  const actual = jest.requireActual("../helpers");
+  return {
+    ...actual,
+    createProgramWithWallet: (...args: unknown[]) =>
+      mockCreateProgramWithWallet(...args),
+  };
+});
+
+import type { AnchorWallet } from "@solana/wallet-adapter-react";
+
+import { createProposal } from "../createProposal";
+import { SVMGOV_PROGRAM_ID } from "../types";
+
+// PublicKey.findProgramAddressSync is unreliable under next/jest's web3.js build (see
+// castVoteOverride.test.ts), and this flow derives proposal PDAs through helpers. Stub it with a
+// fixed viable nonce; the derived addresses are not what these tests assert.
+jest.spyOn(PublicKey, "findProgramAddressSync").mockImplementation(
+  () => [new PublicKey(new Uint8Array(32).fill(9)), 255]
+);
+
+const keyFromByte = (b: number): string =>
+  new PublicKey(new Uint8Array(32).fill(b)).toBase58();
+const VOTE_ACCOUNT = keyFromByte(1);
+const SIGNER = keyFromByte(3);
+const BLOCKHASH = keyFromByte(4);
+
+// A fixed-commit proposal URL, the same shape assertValidProposalUrl accepts in its own tests.
+const DESCRIPTION =
+  "https://github.com/solana-foundation/solana-governance-proposals/blob/27bca51e5c0fc34ddbea6904faf86f5098225316/proposals/sgp-0001-solana-constitution.md";
+
+describe("createProposal", () => {
+  const mockGetVoteAccounts = jest.fn();
+  const mockGetLatestBlockhash = jest.fn();
+  const mockSendRawTransaction = jest.fn();
+
+  function buildFakeProgram() {
+    const fakeIx = {
+      keys: [],
+      programId: SVMGOV_PROGRAM_ID,
+      data: Buffer.alloc(0),
+    };
+    const instruction = jest.fn(async () => fakeIx);
+    const accountsStrict = jest.fn(() => ({ instruction }));
+    const createProposalMethod = jest.fn(() => ({ accountsStrict }));
+
+    return {
+      programId: SVMGOV_PROGRAM_ID,
+      provider: {
+        connection: {
+          getVoteAccounts: mockGetVoteAccounts,
+          getLatestBlockhash: mockGetLatestBlockhash,
+          sendRawTransaction: mockSendRawTransaction,
+        },
+      },
+      methods: { createProposal: createProposalMethod },
+    };
+  }
+
+  const mockSignTransaction = jest.fn();
+  const walletState = {
+    publicKey: new PublicKey(SIGNER),
+    signTransaction: mockSignTransaction,
+    signAllTransactions: jest.fn(),
+  };
+  const wallet = walletState as unknown as AnchorWallet;
+
+  function signedTransactionResponse(
+    signatures: { publicKey: PublicKey; signature: Buffer | null }[] = [
+      { publicKey: new PublicKey(SIGNER), signature: Buffer.alloc(64) },
+    ]
+  ): Transaction {
+    return {
+      signatures,
+      verifySignatures: () => true,
+      serialize: () => Buffer.alloc(0),
+    } as unknown as Transaction;
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    walletState.publicKey = new PublicKey(SIGNER);
+    // Emulates a real wallet: whatever account is connected NOW provides the signature.
+    mockSignTransaction.mockImplementation(async () =>
+      signedTransactionResponse([
+        { publicKey: new PublicKey(walletState.publicKey), signature: Buffer.alloc(64) },
+      ])
+    );
+    mockCreateProgramWithWallet.mockReturnValue(buildFakeProgram());
+    mockGetVoteAccounts.mockResolvedValue({
+      current: [{ nodePubkey: SIGNER, votePubkey: VOTE_ACCOUNT }],
+      delinquent: [],
+    });
+    mockGetLatestBlockhash.mockResolvedValue({
+      blockhash: BLOCKHASH,
+      lastValidBlockHeight: 123,
+    });
+    mockSendRawTransaction.mockResolvedValue("test-signature");
+  });
+
+  const params = { title: "Test proposal", description: DESCRIPTION, wallet };
+  const blockchainParams = {
+    network: "testnet" as const,
+    endpoint: "http://localhost:8899",
+    ncnApiUrl: "http://localhost:9000",
+  };
+
+  it("signs with the connected account and submits the proposal", async () => {
+    const result = await createProposal(params, blockchainParams);
+
+    expect(result).toEqual({ signature: "test-signature", success: true });
+    expect(mockSignTransaction).toHaveBeenCalledTimes(1);
+    expect(mockSendRawTransaction).toHaveBeenCalledTimes(1);
+  });
+
+  it("reports an unsigned wallet response without submitting the transaction", async () => {
+    mockSignTransaction.mockResolvedValueOnce(
+      signedTransactionResponse([
+        { publicKey: new PublicKey(SIGNER), signature: null },
+      ])
+    );
+
+    await expect(createProposal(params, blockchainParams)).rejects.toThrow(
+      /wallet did not sign the transaction/i
+    );
+    expect(mockSendRawTransaction).not.toHaveBeenCalled();
+  });
+
+  it("reports a returned signature from a different account without submitting", async () => {
+    const otherAccount = new PublicKey(keyFromByte(12));
+    mockSignTransaction.mockResolvedValueOnce(
+      signedTransactionResponse([
+        { publicKey: new PublicKey(SIGNER), signature: null },
+        { publicKey: otherAccount, signature: Buffer.alloc(64) },
+      ])
+    );
+
+    await expect(createProposal(params, blockchainParams)).rejects.toThrow(
+      /signed with a different account/i
+    );
+    expect(mockSendRawTransaction).not.toHaveBeenCalled();
+  });
+
+  it("keeps validating the originally captured signer after an awaited fetch", async () => {
+    // The vote-account lookup happens before signing; switch the connected account during it.
+    // The lookup itself resolves against whichever account is connected at that point, so the
+    // switched-to identity must be present in the response.
+    const switchedAccount = keyFromByte(13);
+    mockGetVoteAccounts.mockImplementationOnce(async () => {
+      walletState.publicKey = new PublicKey(switchedAccount);
+      return {
+        current: [
+          { nodePubkey: SIGNER, votePubkey: VOTE_ACCOUNT },
+          { nodePubkey: switchedAccount, votePubkey: VOTE_ACCOUNT },
+        ],
+        delinquent: [],
+      };
+    });
+
+    await expect(createProposal(params, blockchainParams)).rejects.toThrow(
+      /signed with a different account|did not sign the transaction/i
+    );
+    expect(mockSendRawTransaction).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/chain/instructions/__tests__/modifyVote.test.ts
+++ b/frontend/src/chain/instructions/__tests__/modifyVote.test.ts
@@ -1,0 +1,223 @@
+import { PublicKey, Transaction } from "@solana/web3.js";
+
+// helpers.ts transitively imports EndpointContext -> env.ts (an ESM-only package Jest does not
+// transform). Stub it so the real helpers (including the signTransactionForWallet guard under
+// test) can be required without pulling in the untransformed module.
+jest.mock("@/contexts/EndpointContext", () => ({
+  RPC_URLS: { testnet: "http://localhost:8899" },
+}));
+
+const mockGetVoteAccountProof = jest.fn();
+const mockCreateProgramWithWallet = jest.fn();
+const mockCreateGovV1ProgramWithWallet = jest.fn();
+const mockComputeProofCloseTimestamp = jest.fn();
+const mockGetMetaMerkleProofPda = jest.fn();
+const mockDeriveVotePda = jest.fn();
+
+jest.mock("../helpers", () => {
+  const actual = jest.requireActual("../helpers");
+  return {
+    ...actual,
+    getVoteAccountProof: (...args: unknown[]) =>
+      mockGetVoteAccountProof(...args),
+    createProgramWithWallet: (...args: unknown[]) =>
+      mockCreateProgramWithWallet(...args),
+    createGovV1ProgramWithWallet: (...args: unknown[]) =>
+      mockCreateGovV1ProgramWithWallet(...args),
+    computeProofCloseTimestamp: (...args: unknown[]) =>
+      mockComputeProofCloseTimestamp(...args),
+    getMetaMerkleProofPda: (...args: unknown[]) =>
+      mockGetMetaMerkleProofPda(...args),
+    deriveVotePda: (...args: unknown[]) => mockDeriveVotePda(...args),
+  };
+});
+
+import { BN } from "@coral-xyz/anchor";
+import type { AnchorWallet } from "@solana/wallet-adapter-react";
+
+import { modifyVote } from "../modifyVote";
+import { SVMGOV_PROGRAM_ID } from "../types";
+import type { RPCEndpoint } from "@/types";
+
+const keyFromByte = (b: number): string =>
+  new PublicKey(new Uint8Array(32).fill(b)).toBase58();
+const VOTE_ACCOUNT = keyFromByte(1);
+const CONSENSUS_RESULT = keyFromByte(2);
+const PROPOSAL = keyFromByte(3);
+const SIGNER = keyFromByte(4);
+const BLOCKHASH = keyFromByte(5);
+
+const META_MERKLE_PROOF_PDA = new PublicKey(keyFromByte(20));
+const VALIDATOR_VOTE_PDA = new PublicKey(keyFromByte(21));
+
+describe("modifyVote", () => {
+  const mockFetchProposal = jest.fn();
+  const mockGetVoteAccounts = jest.fn();
+  const mockGetAccountInfo = jest.fn();
+  const mockGetLatestBlockhash = jest.fn();
+  const mockSendRawTransaction = jest.fn();
+
+  function buildFakeProgram() {
+    const fakeIx = {
+      keys: [],
+      programId: SVMGOV_PROGRAM_ID,
+      data: Buffer.alloc(0),
+    };
+    const instruction = jest.fn(async () => fakeIx);
+    const accountsStrict = jest.fn(() => ({ instruction }));
+    const modifyVoteMethod = jest.fn(() => ({ accountsStrict }));
+
+    return {
+      programId: SVMGOV_PROGRAM_ID,
+      provider: {
+        connection: {
+          getVoteAccounts: mockGetVoteAccounts,
+          getAccountInfo: mockGetAccountInfo,
+          getLatestBlockhash: mockGetLatestBlockhash,
+          sendRawTransaction: mockSendRawTransaction,
+        },
+      },
+      account: {
+        proposal: {
+          fetch: mockFetchProposal,
+        },
+      },
+      methods: { modifyVote: modifyVoteMethod },
+    };
+  }
+
+  const mockSignTransaction = jest.fn();
+  const walletState = {
+    publicKey: new PublicKey(SIGNER),
+    signTransaction: mockSignTransaction,
+    signAllTransactions: jest.fn(),
+  };
+  const wallet = walletState as unknown as AnchorWallet;
+
+  function signedTransactionResponse(
+    signatures: { publicKey: PublicKey; signature: Buffer | null }[] = [
+      { publicKey: new PublicKey(SIGNER), signature: Buffer.alloc(64) },
+    ]
+  ): Transaction {
+    return {
+      signatures,
+      verifySignatures: () => true,
+      serialize: () => Buffer.alloc(0),
+    } as unknown as Transaction;
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    walletState.publicKey = new PublicKey(SIGNER);
+    // Emulates a real wallet: whatever account is connected NOW provides the signature.
+    mockSignTransaction.mockImplementation(async () =>
+      signedTransactionResponse([
+        { publicKey: new PublicKey(walletState.publicKey), signature: Buffer.alloc(64) },
+      ])
+    );
+    mockCreateProgramWithWallet.mockReturnValue(buildFakeProgram());
+    mockCreateGovV1ProgramWithWallet.mockReturnValue({
+      methods: { initMetaMerkleProof: jest.fn() },
+    });
+    mockComputeProofCloseTimestamp.mockResolvedValue(2_000_000_000);
+    mockGetVoteAccounts.mockResolvedValue({
+      current: [{ nodePubkey: SIGNER, votePubkey: VOTE_ACCOUNT }],
+      delinquent: [],
+    });
+    mockGetAccountInfo.mockResolvedValue({ data: Buffer.alloc(0) });
+    mockGetLatestBlockhash.mockResolvedValue({
+      blockhash: BLOCKHASH,
+      lastValidBlockHeight: 123,
+    });
+    mockSendRawTransaction.mockResolvedValue("test-signature");
+    mockGetMetaMerkleProofPda.mockReturnValue(META_MERKLE_PROOF_PDA);
+    mockDeriveVotePda.mockReturnValue(VALIDATOR_VOTE_PDA);
+    mockFetchProposal.mockResolvedValue({
+      snapshotSlot: new BN(340_850_340),
+      endEpoch: new BN(100),
+    });
+    mockGetVoteAccountProof.mockResolvedValue({
+      network: "testnet",
+      snapshot_slot: 340_850_340,
+      meta_merkle_leaf: {
+        active_stake: 500,
+        stake_merkle_root: keyFromByte(6),
+        vote_account: VOTE_ACCOUNT,
+        voting_wallet: SIGNER,
+      },
+      meta_merkle_proof: [],
+    });
+  });
+
+  const params = {
+    proposalId: PROPOSAL,
+    forVotesBp: 10_000,
+    againstVotesBp: 0,
+    abstainVotesBp: 0,
+    wallet,
+    consensusResult: new PublicKey(CONSENSUS_RESULT),
+  };
+  const blockchainParams = {
+    network: "testnet" as RPCEndpoint,
+    endpoint: "http://localhost:8899",
+    ncnApiUrl: "http://localhost:9000",
+  };
+
+  it("signs with the connected account and submits the modified vote", async () => {
+    const result = await modifyVote(params, blockchainParams);
+
+    expect(result).toEqual({ signature: "test-signature", success: true });
+    expect(mockSignTransaction).toHaveBeenCalledTimes(1);
+    expect(mockSendRawTransaction).toHaveBeenCalledTimes(1);
+  });
+
+  it("reports an unsigned wallet response without submitting the transaction", async () => {
+    mockSignTransaction.mockResolvedValueOnce(
+      signedTransactionResponse([
+        { publicKey: new PublicKey(SIGNER), signature: null },
+      ])
+    );
+
+    await expect(modifyVote(params, blockchainParams)).rejects.toThrow(
+      /wallet did not sign the transaction/i
+    );
+    expect(mockSendRawTransaction).not.toHaveBeenCalled();
+  });
+
+  it("reports a returned signature from a different account without submitting", async () => {
+    const otherAccount = new PublicKey(keyFromByte(12));
+    mockSignTransaction.mockResolvedValueOnce(
+      signedTransactionResponse([
+        { publicKey: new PublicKey(SIGNER), signature: null },
+        { publicKey: otherAccount, signature: Buffer.alloc(64) },
+      ])
+    );
+
+    await expect(modifyVote(params, blockchainParams)).rejects.toThrow(
+      /signed with a different account/i
+    );
+    expect(mockSendRawTransaction).not.toHaveBeenCalled();
+  });
+
+  it("keeps validating the originally captured signer after an awaited fetch", async () => {
+    mockGetVoteAccountProof.mockImplementationOnce(async () => {
+      walletState.publicKey = new PublicKey(keyFromByte(13));
+      return {
+        network: "testnet",
+        snapshot_slot: 340_850_340,
+        meta_merkle_leaf: {
+          active_stake: 500,
+          stake_merkle_root: keyFromByte(6),
+          vote_account: VOTE_ACCOUNT,
+          voting_wallet: SIGNER,
+        },
+        meta_merkle_proof: [],
+      };
+    });
+
+    await expect(modifyVote(params, blockchainParams)).rejects.toThrow(
+      /signed with a different account|did not sign the transaction/i
+    );
+    expect(mockSendRawTransaction).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/chain/instructions/__tests__/supportProposal.test.ts
+++ b/frontend/src/chain/instructions/__tests__/supportProposal.test.ts
@@ -1,0 +1,217 @@
+import { ComputeBudgetProgram, PublicKey, Transaction } from "@solana/web3.js";
+
+// helpers.ts transitively imports EndpointContext -> env.ts (an ESM-only package Jest does not
+// transform). Stub it so the real helpers (including the signTransactionForWallet guard under
+// test) can be required without pulling in the untransformed module.
+jest.mock("@/contexts/EndpointContext", () => ({
+  RPC_URLS: { testnet: "http://localhost:8899" },
+}));
+
+const mockCreateProgramWithWallet = jest.fn();
+
+jest.mock("../helpers", () => {
+  const actual = jest.requireActual("../helpers");
+  return {
+    ...actual,
+    createProgramWithWallet: (...args: unknown[]) =>
+      mockCreateProgramWithWallet(...args),
+  };
+});
+
+import type { AnchorWallet } from "@solana/wallet-adapter-react";
+
+import { supportProposal } from "../supportProposal";
+import { SVMGOV_PROGRAM_ID } from "../types";
+
+// PublicKey.findProgramAddressSync is unreliable under next/jest's web3.js build (see
+// castVoteOverride.test.ts), and this flow derives PDAs both through helpers and inline. Stub it
+// with a fixed viable nonce; the derived addresses are not what these tests assert.
+jest.spyOn(PublicKey, "findProgramAddressSync").mockImplementation(
+  () => [new PublicKey(new Uint8Array(32).fill(9)), 255]
+);
+
+// ComputeBudgetProgram.setComputeUnitLimit trips over the buffer-layout shim under next/jest;
+// the compute-budget instruction is not what these tests assert.
+jest
+  .spyOn(ComputeBudgetProgram, "setComputeUnitLimit")
+  .mockReturnValue(({
+    keys: [],
+    programId: new PublicKey(new Uint8Array(32).fill(30)),
+    data: Buffer.alloc(0),
+  } as unknown) as ReturnType<typeof ComputeBudgetProgram.setComputeUnitLimit>);
+
+const keyFromByte = (b: number): string =>
+  new PublicKey(new Uint8Array(32).fill(b)).toBase58();
+const VOTE_ACCOUNT = keyFromByte(1);
+const PROPOSAL = keyFromByte(2);
+const SIGNER = keyFromByte(3);
+const BLOCKHASH = keyFromByte(4);
+
+describe("supportProposal", () => {
+  const mockFetchProposal = jest.fn();
+  const mockGetEpochInfo = jest.fn();
+  const mockGetEpochSchedule = jest.fn();
+  const mockGetLatestBlockhash = jest.fn();
+  const mockSendRawTransaction = jest.fn();
+
+  function buildFakeProgram() {
+    const fakeIx = {
+      keys: [],
+      programId: SVMGOV_PROGRAM_ID,
+      data: Buffer.alloc(0),
+    };
+    const instruction = jest.fn(async () => fakeIx);
+    const accountsStrict = jest.fn(() => ({ instruction }));
+    const supportProposalMethod = jest.fn(() => ({ accountsStrict }));
+
+    return {
+      programId: SVMGOV_PROGRAM_ID,
+      provider: {
+        connection: {
+          getEpochInfo: mockGetEpochInfo,
+          getEpochSchedule: mockGetEpochSchedule,
+          getLatestBlockhash: mockGetLatestBlockhash,
+          sendRawTransaction: mockSendRawTransaction,
+        },
+      },
+      account: {
+        proposal: {
+          fetch: mockFetchProposal,
+        },
+      },
+      methods: { supportProposal: supportProposalMethod },
+    };
+  }
+
+  const mockSignTransaction = jest.fn();
+  const walletState = {
+    publicKey: new PublicKey(SIGNER),
+    signTransaction: mockSignTransaction,
+    signAllTransactions: jest.fn(),
+  };
+  const wallet = walletState as unknown as AnchorWallet;
+
+  function signedTransactionResponse(
+    signatures: { publicKey: PublicKey; signature: Buffer | null }[] = [
+      { publicKey: new PublicKey(SIGNER), signature: Buffer.alloc(64) },
+    ]
+  ): Transaction {
+    return {
+      signatures,
+      verifySignatures: () => true,
+      serialize: () => Buffer.alloc(0),
+    } as unknown as Transaction;
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    walletState.publicKey = new PublicKey(SIGNER);
+    // Emulates a real wallet: whatever account is connected NOW provides the signature.
+    mockSignTransaction.mockImplementation(async () =>
+      signedTransactionResponse([
+        { publicKey: new PublicKey(walletState.publicKey), signature: Buffer.alloc(64) },
+      ])
+    );
+    mockCreateProgramWithWallet.mockReturnValue(buildFakeProgram());
+    mockFetchProposal.mockResolvedValue({ numSupporters: 5 });
+    mockGetEpochInfo.mockResolvedValue({ epoch: 700 });
+    mockGetEpochSchedule.mockResolvedValue({
+      getFirstSlotInEpoch: (epoch: number) => epoch * 432_000,
+    });
+    mockGetLatestBlockhash.mockResolvedValue({
+      blockhash: BLOCKHASH,
+      lastValidBlockHeight: 123,
+    });
+    mockSendRawTransaction.mockResolvedValue("test-signature");
+  });
+
+  const params = { proposalId: PROPOSAL, wallet };
+  const blockchainParams = {
+    network: "testnet" as const,
+    endpoint: "http://localhost:8899",
+    ncnApiUrl: "http://localhost:9000",
+  };
+  const validatorVoteAccount = {
+    activeStake: 500_000,
+    voteAccount: VOTE_ACCOUNT,
+    nodePubkey: SIGNER,
+  };
+  const globalConfig = {
+    discussionEpochs: 1,
+    snapshotEpochExtension: 1,
+    snapshotSlotOffset: 100,
+  };
+
+  it("signs with the connected account and submits the support", async () => {
+    const result = await supportProposal(
+      params,
+      blockchainParams,
+      340_850_340,
+      validatorVoteAccount,
+      globalConfig
+    );
+
+    expect(result).toEqual({ signature: "test-signature", success: true });
+    expect(mockSignTransaction).toHaveBeenCalledTimes(1);
+    expect(mockSendRawTransaction).toHaveBeenCalledTimes(1);
+  });
+
+  it("reports an unsigned wallet response without submitting the transaction", async () => {
+    mockSignTransaction.mockResolvedValueOnce(
+      signedTransactionResponse([
+        { publicKey: new PublicKey(SIGNER), signature: null },
+      ])
+    );
+
+    await expect(
+      supportProposal(
+        params,
+        blockchainParams,
+        340_850_340,
+        validatorVoteAccount,
+        globalConfig
+      )
+    ).rejects.toThrow(/wallet did not sign the transaction/i);
+    expect(mockSendRawTransaction).not.toHaveBeenCalled();
+  });
+
+  it("reports a returned signature from a different account without submitting", async () => {
+    const otherAccount = new PublicKey(keyFromByte(12));
+    mockSignTransaction.mockResolvedValueOnce(
+      signedTransactionResponse([
+        { publicKey: new PublicKey(SIGNER), signature: null },
+        { publicKey: otherAccount, signature: Buffer.alloc(64) },
+      ])
+    );
+
+    await expect(
+      supportProposal(
+        params,
+        blockchainParams,
+        340_850_340,
+        validatorVoteAccount,
+        globalConfig
+      )
+    ).rejects.toThrow(/signed with a different account/i);
+    expect(mockSendRawTransaction).not.toHaveBeenCalled();
+  });
+
+  it("keeps validating the originally captured signer after an awaited fetch", async () => {
+    // The proposal fetch happens before signing; switch the connected account during it.
+    mockFetchProposal.mockImplementationOnce(async () => {
+      walletState.publicKey = new PublicKey(keyFromByte(13));
+      return { numSupporters: 5 };
+    });
+
+    await expect(
+      supportProposal(
+        params,
+        blockchainParams,
+        340_850_340,
+        validatorVoteAccount,
+        globalConfig
+      )
+    ).rejects.toThrow(/signed with a different account|did not sign the transaction/i);
+    expect(mockSendRawTransaction).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/chain/instructions/castVote.ts
+++ b/frontend/src/chain/instructions/castVote.ts
@@ -21,6 +21,7 @@ import {
   getMetaMerkleProofPda,
   computeProofCloseTimestamp,
   resolveProposalSnapshotSlot,
+  signTransactionForWallet,
 } from "./helpers";
 
 /**
@@ -42,6 +43,10 @@ export async function castVote(
   if (!wallet || !wallet.publicKey) {
     throw new Error("Wallet not connected");
   }
+
+  // The transaction is built and signed for this account. signTransactionForWallet verifies
+  // that the wallet-returned transaction contains its signature before the vote is submitted.
+  const signer = wallet.publicKey;
 
   if (consensusResult === undefined) {
     throw new Error("Consensus result not defined");
@@ -169,12 +174,12 @@ export async function castVote(
 
   const transaction = new Transaction();
   transaction.add(...instructions);
-  transaction.feePayer = wallet.publicKey;
+  transaction.feePayer = signer;
   transaction.recentBlockhash = (
     await program.provider.connection.getLatestBlockhash("confirmed")
   ).blockhash;
 
-  const tx = await wallet.signTransaction(transaction);
+  const tx = await signTransactionForWallet(wallet, transaction, signer);
 
   const signature = await program.provider.connection.sendRawTransaction(
     tx.serialize()

--- a/frontend/src/chain/instructions/createProposal.ts
+++ b/frontend/src/chain/instructions/createProposal.ts
@@ -9,6 +9,7 @@ import {
   createProgramWithWallet,
   deriveProposalIndexPda,
   deriveGlobalConfigPda,
+  signTransactionForWallet,
 } from "./helpers";
 import { deriveProposalAccount } from "../helpers";
 import { assertValidProposalUrl } from "@/lib/github";
@@ -24,6 +25,10 @@ export async function createProposal(
   if (!wallet || !wallet.publicKey) {
     throw new Error("Wallet not connected");
   }
+
+  // The transaction is built and signed for this account. signTransactionForWallet verifies
+  // that the wallet-returned transaction contains its signature before the proposal is submitted.
+  const signer = wallet.publicKey;
 
   // Enforced here rather than only in the modal so every caller inherits it. The on-chain
   // check accepts anything github.com-shaped, including pull request links, which the
@@ -70,12 +75,12 @@ export async function createProposal(
 
   const transaction = new Transaction();
   transaction.add(proposalInstruction);
-  transaction.feePayer = wallet.publicKey;
+  transaction.feePayer = signer;
   transaction.recentBlockhash = (
     await program.provider.connection.getLatestBlockhash("confirmed")
   ).blockhash;
 
-  const tx = await wallet.signTransaction(transaction);
+  const tx = await signTransactionForWallet(wallet, transaction, signer);
 
   const signature = await program.provider.connection.sendRawTransaction(
     tx.serialize(),

--- a/frontend/src/chain/instructions/modifyVote.ts
+++ b/frontend/src/chain/instructions/modifyVote.ts
@@ -20,6 +20,7 @@ import {
   getMetaMerkleProofPda,
   computeProofCloseTimestamp,
   resolveProposalSnapshotSlot,
+  signTransactionForWallet,
 } from "./helpers";
 
 /**
@@ -41,6 +42,10 @@ export async function modifyVote(
   if (!wallet || !wallet.publicKey) {
     throw new Error("Wallet not connected");
   }
+
+  // The transaction is built and signed for this account. signTransactionForWallet verifies
+  // that the wallet-returned transaction contains its signature before the vote is submitted.
+  const signer = wallet.publicKey;
 
   if (consensusResult === undefined) {
     throw new Error("Consensus result not defined");
@@ -163,12 +168,12 @@ export async function modifyVote(
 
   const transaction = new Transaction();
   transaction.add(...instructions);
-  transaction.feePayer = wallet.publicKey;
+  transaction.feePayer = signer;
   transaction.recentBlockhash = (
     await program.provider.connection.getLatestBlockhash("confirmed")
   ).blockhash;
 
-  const tx = await wallet.signTransaction(transaction);
+  const tx = await signTransactionForWallet(wallet, transaction, signer);
 
   const signature = await program.provider.connection.sendRawTransaction(
     tx.serialize()

--- a/frontend/src/chain/instructions/supportProposal.ts
+++ b/frontend/src/chain/instructions/supportProposal.ts
@@ -19,6 +19,7 @@ import {
   createProgramWithWallet,
   deriveSupportPda,
   deriveGlobalConfigPda,
+  signTransactionForWallet,
 } from "./helpers";
 
 /**
@@ -36,6 +37,10 @@ export async function supportProposal(
   if (!wallet || !wallet.publicKey) {
     throw new Error("Wallet not connected");
   }
+
+  // The transaction is built and signed for this account. signTransactionForWallet verifies
+  // that the wallet-returned transaction contains its signature before the support is submitted.
+  const signer = wallet.publicKey;
 
   if (slot === undefined) {
     throw new Error("Slot is not defined");
@@ -122,12 +127,12 @@ export async function supportProposal(
     }),
   );
   transaction.add(supportProposalInstruction);
-  transaction.feePayer = wallet.publicKey;
+  transaction.feePayer = signer;
   transaction.recentBlockhash = (
     await program.provider.connection.getLatestBlockhash("confirmed")
   ).blockhash;
 
-  const tx = await wallet.signTransaction(transaction);
+  const tx = await signTransactionForWallet(wallet, transaction, signer);
 
   const signature = await program.provider.connection.sendRawTransaction(
     tx.serialize(),


### PR DESCRIPTION
## What

The wallet-signing guard from #179 protects the override flows only. The plain cast vote, modify vote, support, and create proposal paths still send whatever `wallet.signTransaction` returns.

## Why

A wallet can return a transaction signed by a different account than the one that built it, for example when the connected account changes while the proof and blockhash fetches are in flight. The override flows detect this through `signTransactionForWallet` and raise a descriptive `WalletSigningError`. The plain validator flows sign directly on the wallet, so the same switch surfaces later as an opaque missing-signature serialization error after the user has already waited on every RPC round trip.

## Change

Capture the signer when the transaction is built and pass it to `signTransactionForWallet` in all four instruction builders, matching how `castVoteOverride.ts` and `modifyVoteOverride.ts` already work.

Tests for each builder mirror the override suite: an unsigned wallet response and a signature from a different account are rejected before submission, including a case where the account switches during one of the awaited fetches.