### PR TITLE
fix(verifier): name SQL read columns

### DIFF
--- a/ncn/verifier-service/src/database/operations.rs
+++ b/ncn/verifier-service/src/database/operations.rs
@@ -92,7 +92,9 @@ impl VoteAccountRecord {
         snapshot_slot: u64,
     ) -> Result<Option<VoteAccountRecord>> {
         let row_opt = sqlx::query(
-            "SELECT * FROM vote_accounts \
+            "SELECT network, snapshot_slot, vote_account, voting_wallet, \
+                    stake_merkle_root, active_stake, meta_merkle_proof \
+             FROM vote_accounts \
                    WHERE network = ? AND vote_account = ? AND snapshot_slot = ?",
         )
         .bind(network)
@@ -204,7 +206,9 @@ impl StakeAccountRecord {
         snapshot_slot: u64,
     ) -> Result<Option<StakeAccountRecord>> {
         let row_opt = sqlx::query(
-            "SELECT * FROM stake_accounts \
+            "SELECT network, snapshot_slot, stake_account, vote_account, \
+                    voting_wallet, active_stake, stake_merkle_proof \
+             FROM stake_accounts \
                    WHERE network = ? AND stake_account = ? AND snapshot_slot = ?",
         )
         .bind(network)
@@ -270,7 +274,8 @@ impl SnapshotMetaRecord {
         network: &str,
     ) -> Result<Option<SnapshotMetaRecord>> {
         let row_opt = sqlx::query(
-            "SELECT * FROM snapshot_meta
+            "SELECT network, slot, merkle_root, snapshot_hash, created_at, total_active_stake
+             FROM snapshot_meta
              WHERE network = ? ORDER BY slot DESC LIMIT 1",
         )
         .bind(network)


### PR DESCRIPTION
## Summary

- name every column read by the vote-account, stake-account, and snapshot metadata queries
- keep the returned records and filtering behavior unchanged

These reads previously used `SELECT *` and then accessed columns by name. Explicit projections make schema mismatches fail at query execution instead of letting stale row metadata reach infallible `row.get(...)` calls.

Fixes #161.

## Testing

- `rustfmt --edition 2021 --check ncn/verifier-service/src/database/operations.rs`
- `cargo test database` from `ncn/verifier-service` (12 passed)
- `git diff --check`
