### PR TITLE
fix(frontend): use sampled slot rate for epoch countdowns

### DIFF
--- a/frontend/src/helpers/date.ts
+++ b/frontend/src/helpers/date.ts
@@ -53,7 +53,7 @@ export async function epochToDate(
 
   // Estimate date from observed recent slot production. This automatically
   // follows feature-gated slot-time reductions without hardcoding each stage.
-  const FALLBACK_SLOT_TIME_MS = 400;
+  const FALLBACK_SLOT_TIME_MS = 350;
   const PERFORMANCE_SAMPLE_LIMIT = 20;
   let SLOT_TIME_MS = FALLBACK_SLOT_TIME_MS;
 
@@ -85,7 +85,7 @@ export async function epochToDate(
     }
   } catch {
     console.warn(
-      "Failed to get recent performance samples; using 400ms slot time"
+      "Failed to get recent performance samples; using 350ms slot time"
     );
   }
 

--- a/frontend/src/helpers/date.ts
+++ b/frontend/src/helpers/date.ts
@@ -84,6 +84,7 @@ export async function epochToDate(
       SLOT_TIME_MS = (totalSeconds * 1000) / totalSlots;
     }
   } catch {
+    performanceSamplesByEndpoint.delete(endpoint);
     console.warn(
       "Failed to get recent performance samples; using 350ms slot time"
     );

--- a/frontend/src/helpers/date.ts
+++ b/frontend/src/helpers/date.ts
@@ -84,10 +84,11 @@ export async function epochToDate(
       SLOT_TIME_MS = (totalSeconds * 1000) / totalSlots;
     }
   } catch {
-    performanceSamplesByEndpoint.delete(endpoint);
     console.warn(
       "Failed to get recent performance samples; using 350ms slot time"
     );
+  } finally {
+    performanceSamplesByEndpoint.delete(endpoint);
   }
 
   const slotsUntilTarget = targetSlot - epochInfo.absoluteSlot;

--- a/frontend/src/helpers/date.ts
+++ b/frontend/src/helpers/date.ts
@@ -1,4 +1,8 @@
 import { Connection, EpochInfo, EpochSchedule } from "@solana/web3.js";
+const performanceSamplesByEndpoint = new Map<
+  string,
+  ReturnType<Connection["getRecentPerformanceSamples"]>
+>();
 
 export const getDaysLeft = (futureDate: Date) => {
   const now = new Date();
@@ -54,9 +58,16 @@ export async function epochToDate(
   let SLOT_TIME_MS = FALLBACK_SLOT_TIME_MS;
 
   try {
-    const samples = await connection.getRecentPerformanceSamples(
-      PERFORMANCE_SAMPLE_LIMIT
-    );
+    let samplesPromise = performanceSamplesByEndpoint.get(endpoint);
+
+    if (!samplesPromise) {
+      samplesPromise = connection.getRecentPerformanceSamples(
+        PERFORMANCE_SAMPLE_LIMIT
+      );
+      performanceSamplesByEndpoint.set(endpoint, samplesPromise);
+    }
+
+    const samples = await samplesPromise;
 
     const { totalSlots, totalSeconds } = samples.reduce(
       (totals, sample) => {
@@ -92,7 +103,7 @@ export async function epochToDate(
     );
     currentBlockTime = Date.now();
   }
-  
+
   // Calculate estimated time: current block time + (slots until target * slot time)
   const estimatedTime = currentBlockTime + slotsUntilTarget * SLOT_TIME_MS;
 

--- a/frontend/src/helpers/date.ts
+++ b/frontend/src/helpers/date.ts
@@ -47,12 +47,40 @@ export async function epochToDate(
   // Get the first slot of the target epoch
   const targetSlot = epochSchedule.getFirstSlotInEpoch(targetEpoch);
 
-  // Estimate date based on slot time
-  // Average slot time is ~400ms
-  const SLOT_TIME_MS = 400;
+  // Estimate date from observed recent slot production. This automatically
+  // follows feature-gated slot-time reductions without hardcoding each stage.
+  const FALLBACK_SLOT_TIME_MS = 400;
+  const PERFORMANCE_SAMPLE_LIMIT = 20;
+  let SLOT_TIME_MS = FALLBACK_SLOT_TIME_MS;
+
+  try {
+    const samples = await connection.getRecentPerformanceSamples(
+      PERFORMANCE_SAMPLE_LIMIT
+    );
+
+    const { totalSlots, totalSeconds } = samples.reduce(
+      (totals, sample) => {
+        if (sample.numSlots > 0 && sample.samplePeriodSecs > 0) {
+          totals.totalSlots += sample.numSlots;
+          totals.totalSeconds += sample.samplePeriodSecs;
+        }
+        return totals;
+      },
+      { totalSlots: 0, totalSeconds: 0 }
+    );
+
+    if (totalSlots > 0 && totalSeconds > 0) {
+      SLOT_TIME_MS = (totalSeconds * 1000) / totalSlots;
+    }
+  } catch {
+    console.warn(
+      "Failed to get recent performance samples; using 400ms slot time"
+    );
+  }
+
   const slotsUntilTarget = targetSlot - epochInfo.absoluteSlot;
 
-  // Get current block time to anchor our calculation
+  // Anchor the projection to the current slot's block time.
   let currentBlockTime: number;
   try {
     const blockTime = await connection.getBlockTime(epochInfo.absoluteSlot);
@@ -64,7 +92,7 @@ export async function epochToDate(
     );
     currentBlockTime = Date.now();
   }
-
+  
   // Calculate estimated time: current block time + (slots until target * slot time)
   const estimatedTime = currentBlockTime + slotsUntilTarget * SLOT_TIME_MS;
 


### PR DESCRIPTION
The frontend originally used 400ms slots when estimating epoch boundaries. This update uses the last 20 RPC performance samples to reflect changing slot times, including the reductions described in SIMD-0525. It falls back to 350ms when samples are unavailable.