### PR TITLE
fix(frontend): keep proposal countdown accurate

### DIFF
--- a/frontend/src/components/proposals/detail/phase-timeline/index.tsx
+++ b/frontend/src/components/proposals/detail/phase-timeline/index.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Fragment } from "react";
+import { Fragment, useEffect, useState } from "react";
 import type { ProposalRecord } from "@/types";
 import { PHASES } from "./constants";
 import { PhaseNode } from "./PhaseNode";
@@ -44,6 +44,16 @@ export default function PhaseTimeline({
   proposal,
   isLoading,
 }: PhaseTimelineProps) {
+  // Start after hydration so the server and first client render both show the same placeholder,
+  // then update the visible countdown once per minute without additional RPC requests.
+  const [nowMs, setNowMs] = useState<number>();
+  useEffect(() => {
+    const updateNow = () => setNowMs(Date.now());
+    updateNow();
+    const interval = window.setInterval(updateNow, 60_000);
+    return () => window.clearInterval(interval);
+  }, []);
+
   const governanceConfigQuery = useGovernanceConfigContext();
   const { data: epochData } = useEpochInfo();
   const currentPhase = proposal?.status;
@@ -73,8 +83,8 @@ export default function PhaseTimeline({
 
   const { data: activePhaseEndsAt } = useEpochToDate(activePhaseEndEpoch);
   const currentEpoch = epochData?.epochInfo.epoch;
-  const remainingTime = activePhaseEndsAt
-    ? calculateVotingEndsIn(activePhaseEndsAt.toISOString()) ?? "-"
+  const remainingTime = activePhaseEndsAt && nowMs !== undefined
+    ? calculateVotingEndsIn(activePhaseEndsAt.toISOString(), nowMs) ?? "-"
     : "-";
 
   if (isLoading) return <PhaseTimelineSkeleton />;

--- a/frontend/src/helpers/__tests__/date.test.ts
+++ b/frontend/src/helpers/__tests__/date.test.ts
@@ -1,0 +1,44 @@
+import { calculateVotingEndsIn, estimateSlotTimeMs } from "../date";
+
+describe("estimateSlotTimeMs", () => {
+  it("uses the slot-weighted duration from recent performance samples", () => {
+    expect(
+      estimateSlotTimeMs([
+        { numSlots: 170, samplePeriodSecs: 60 },
+        { numSlots: 160, samplePeriodSecs: 60 },
+      ]),
+    ).toBeCloseTo(120_000 / 330);
+  });
+
+  it("ignores empty samples", () => {
+    expect(
+      estimateSlotTimeMs([
+        { numSlots: 0, samplePeriodSecs: 60 },
+        { numSlots: 165, samplePeriodSecs: 60 },
+      ]),
+    ).toBeCloseTo(60_000 / 165);
+  });
+
+  it("falls back to 350ms for missing or implausible samples", () => {
+    expect(estimateSlotTimeMs([])).toBe(350);
+    expect(
+      estimateSlotTimeMs([{ numSlots: 0, samplePeriodSecs: 0 }]),
+    ).toBe(350);
+    expect(
+      estimateSlotTimeMs([{ numSlots: 1, samplePeriodSecs: 60 }]),
+    ).toBe(350);
+  });
+});
+
+describe("calculateVotingEndsIn", () => {
+  it("uses the supplied clock value so countdown renders can update deterministically", () => {
+    const endTime = "2026-08-25T00:00:00.000Z";
+
+    expect(
+      calculateVotingEndsIn(endTime, Date.parse("2026-08-24T21:29:00.000Z")),
+    ).toBe("2h 31m");
+    expect(
+      calculateVotingEndsIn(endTime, Date.parse("2026-08-24T21:30:00.000Z")),
+    ).toBe("2h 30m");
+  });
+});

--- a/frontend/src/helpers/date.ts
+++ b/frontend/src/helpers/date.ts
@@ -1,4 +1,46 @@
-import { Connection, EpochInfo, EpochSchedule } from "@solana/web3.js";
+import {
+  Connection,
+  EpochInfo,
+  EpochSchedule,
+  PerfSample,
+} from "@solana/web3.js";
+
+const DEFAULT_SLOT_TIME_MS = 350;
+const PERFORMANCE_SAMPLE_LIMIT = 60;
+const MIN_PLAUSIBLE_SLOT_TIME_MS = 100;
+const MAX_PLAUSIBLE_SLOT_TIME_MS = 1_000;
+
+/**
+ * Calculates a slot-duration estimate weighted by the number of slots in each RPC sample.
+ * Falls back to the configured 350ms slot time when an RPC omits or returns unusable samples.
+ */
+export function estimateSlotTimeMs(
+  samples: Pick<PerfSample, "numSlots" | "samplePeriodSecs">[],
+): number {
+  const totals = samples.reduce(
+    (acc, sample) => {
+      if (sample.numSlots > 0 && sample.samplePeriodSecs > 0) {
+        acc.slots += sample.numSlots;
+        acc.seconds += sample.samplePeriodSecs;
+      }
+      return acc;
+    },
+    { slots: 0, seconds: 0 },
+  );
+
+  if (totals.slots === 0) return DEFAULT_SLOT_TIME_MS;
+
+  const slotTimeMs = (totals.seconds * 1_000) / totals.slots;
+  if (
+    !Number.isFinite(slotTimeMs) ||
+    slotTimeMs < MIN_PLAUSIBLE_SLOT_TIME_MS ||
+    slotTimeMs > MAX_PLAUSIBLE_SLOT_TIME_MS
+  ) {
+    return DEFAULT_SLOT_TIME_MS;
+  }
+
+  return slotTimeMs;
+}
 
 export const getDaysLeft = (futureDate: Date) => {
   const now = new Date();
@@ -47,26 +89,38 @@ export async function epochToDate(
   // Get the first slot of the target epoch
   const targetSlot = epochSchedule.getFirstSlotInEpoch(targetEpoch);
 
-  // Estimate date based on slot time
-  // Average slot time is ~400ms
-  const SLOT_TIME_MS = 400;
   const slotsUntilTarget = targetSlot - epochInfo.absoluteSlot;
 
-  // Get current block time to anchor our calculation
-  let currentBlockTime: number;
-  try {
-    const blockTime = await connection.getBlockTime(epochInfo.absoluteSlot);
-    currentBlockTime = blockTime ? blockTime * 1000 : Date.now();
-  } catch {
+  // Anchor the projection to chain time and derive the current slot rate from the last hour of
+  // RPC performance samples. Slot production can run materially faster than the 400ms target,
+  // shortening epoch phases by hours; a fixed slot duration makes proposal countdowns stale.
+  const [blockTimeResult, performanceSamplesResult] = await Promise.allSettled([
+    connection.getBlockTime(epochInfo.absoluteSlot),
+    connection.getRecentPerformanceSamples(PERFORMANCE_SAMPLE_LIMIT),
+  ]);
+
+  let currentBlockTime = Date.now();
+  if (blockTimeResult.status === "fulfilled" && blockTimeResult.value !== null) {
+    currentBlockTime = blockTimeResult.value * 1_000;
+  } else {
     console.warn(
       "Failed to get block time for current epoch",
-      epochInfo.absoluteSlot
+      epochInfo.absoluteSlot,
     );
-    currentBlockTime = Date.now();
   }
 
-  // Calculate estimated time: current block time + (slots until target * slot time)
-  const estimatedTime = currentBlockTime + slotsUntilTarget * SLOT_TIME_MS;
+  const slotTimeMs =
+    performanceSamplesResult.status === "fulfilled"
+      ? estimateSlotTimeMs(performanceSamplesResult.value)
+      : DEFAULT_SLOT_TIME_MS;
+
+  if (performanceSamplesResult.status === "rejected") {
+    console.warn(
+      "Failed to get recent performance samples; using the default slot time",
+    );
+  }
+
+  const estimatedTime = currentBlockTime + slotsUntilTarget * slotTimeMs;
 
   return new Date(estimatedTime);
 }
@@ -79,10 +133,13 @@ export const getHoursLeft = (futureDate: Date) => {
   return diffHours;
 };
 
-export function calculateVotingEndsIn(endTime: string | null): string | null {
+export function calculateVotingEndsIn(
+  endTime: string | null,
+  nowMs: number = Date.now(),
+): string | null {
   if (!endTime) return null;
 
-  const now = new Date();
+  const now = new Date(nowMs);
   const end = new Date(endTime);
 
   // Check if the date is valid

--- a/frontend/src/hooks/useEpochInfo.ts
+++ b/frontend/src/hooks/useEpochInfo.ts
@@ -33,6 +33,7 @@ export function useEpochInfo() {
       };
     },
     staleTime: 5 * 60 * 1000, // 5 minutes - epoch info doesn't change frequently
+    refetchInterval: 5 * 60 * 1000,
     refetchOnWindowFocus: false,
   });
 }

--- a/frontend/src/hooks/useEpochToDate.ts
+++ b/frontend/src/hooks/useEpochToDate.ts
@@ -13,7 +13,12 @@ export function useEpochToDate(epoch: number | undefined) {
   const { data: epochData, isLoading: isLoadingEpochInfo } = useEpochInfo();
 
   return useQuery({
-    queryKey: ["epochToDate", epoch, endpointUrl, epochData?.epochInfo.epoch],
+    queryKey: [
+      "epochToDate",
+      epoch,
+      endpointUrl,
+      epochData?.epochInfo.absoluteSlot,
+    ],
     queryFn: async () => {
       if (epoch === undefined || !epochData) return null;
       return epochToDate(


### PR DESCRIPTION
## Summary
- estimate future epoch boundaries from 60 recent RPC performance samples, with a validated 350ms fallback
- refresh epoch data and the projected phase boundary every five minutes
- tick the visible countdown every minute without additional RPC calls
- avoid a server/client hydration mismatch by showing a placeholder until the client clock is available
- add unit coverage for weighted slot estimates, fallback behavior, and countdown ticks

## Context
The previous fixed 400ms estimate overstates phase duration now that mainnet slot production is faster. Recent observed samples were approximately 366ms per slot, enough to shift a multi-epoch proposal deadline by hours.

This is a more complete alternative to #183: that PR retains a 400ms fallback and does not refresh the projection or visible countdown after the initial query.

## Verification
- pnpm test: 29 suites, 387 tests passed
- pnpm exec tsc --noEmit
- ESLint on changed files
- pnpm build