### PR TITLE
Added output of votes to proposal command and statuses to list-proposals

### DIFF
--- a/docs/src/content/ncn/verifier-service/index.mdx
+++ b/docs/src/content/ncn/verifier-service/index.mdx
@@ -169,12 +169,13 @@ curl http://localhost:3000/version
 
 ### `GET /meta`
 
-Returns the latest `SnapshotMetaRecord` for a given network.
+Returns the `SnapshotMetaRecord` for a given network. Omit `slot` for the newest snapshot; pass it to look up a historical one.
 
-**Query params:** `network` (required)
+**Query params:** `network` (required), `slot` (optional — defaults to latest)
 
 ```bash
 curl "http://localhost:3000/meta?network=mainnet"
+curl "http://localhost:3000/meta?network=mainnet&slot=300000000"
 ```
 
 ```json

--- a/docs/src/content/svmgov/validators/list-proposals/index.mdx
+++ b/docs/src/content/svmgov/validators/list-proposals/index.mdx
@@ -60,15 +60,13 @@ svmgov list-proposals --status active --limit 5 --json
 
 | Column | Description |
 |---|---|
-| Index | Sequential proposal number |
-| Title | Proposal title |
-| Author | Validator vote account |
-| Status | `support` / `active` / `finalized` |
-| For | Lamports voted For |
-| Against | Lamports voted Against |
-| Abstain | Lamports voted Abstain |
-| Votes | Total number of votes cast |
-| End Epoch | Epoch when voting closes |
+| ID | Proposal PDA |
+| Title | Proposal title (truncated) |
+| Status | Lifecycle phase (`support` / `voting` / `finalized` / …) |
+| Outcome | SGP-0001 result: `Passing`, `Failing`, `Inconclusive` (quorum not met), or `—` if voting has not started or the snapshot total is unavailable |
+| For / Against / Abstain | Stake voted in each bucket (SOL) |
+
+JSON output includes the same vote totals as lamports plus an `outcome` field: `passing`, `failing`, `inconclusive`, or `unknown`.
 
 ## Related
 

--- a/docs/src/content/svmgov/validators/list-proposals/index.mdx
+++ b/docs/src/content/svmgov/validators/list-proposals/index.mdx
@@ -63,10 +63,10 @@ svmgov list-proposals --status active --limit 5 --json
 | ID | Proposal PDA |
 | Title | Proposal title (truncated) |
 | Status | Lifecycle phase (`support` / `voting` / `finalized` / …) |
-| Outcome | SGP-0001 result: `Passing`, `Failing`, `Inconclusive` (quorum not met), or `—` if voting has not started or the snapshot total is unavailable |
+| Outcome | SGP-0001 result: `Passing` / `Failing` while voting is open; `Passed` / `Failed` once finalized (or the voting window has closed); `Inconclusive` if quorum is not met; `—` if voting has not started or the snapshot total is unavailable |
 | For / Against / Abstain | Stake voted in each bucket (SOL) |
 
-JSON output includes the same vote totals as lamports plus an `outcome` field: `passing`, `failing`, `inconclusive`, or `unknown`.
+JSON output includes the same vote totals as lamports plus an `outcome` field: `passing` / `failing` while voting is open, `passed` / `failed` once settled, or `inconclusive` / `unknown`.
 
 ## Related
 

--- a/docs/src/content/svmgov/validators/proposal/index.mdx
+++ b/docs/src/content/svmgov/validators/proposal/index.mdx
@@ -4,7 +4,7 @@ Display detailed information about a specific governance proposal.
 
 ## Description
 
-Fetches a single `Proposal` account by its PDA address and displays all metadata, vote totals, and lifecycle information.
+Fetches a single `Proposal` account by its PDA address and displays all metadata, vote totals, lifecycle information, and a table of every validator vote and staker override.
 
 ## Usage
 
@@ -55,6 +55,29 @@ The command displays:
 | Vote count | Number of individual votes cast |
 | Snapshot slot | NCN snapshot slot (when active) |
 | Consensus result | NCN ConsensusResult PDA (when active) |
+
+After the proposal fields, the command prints a **Vote breakdown** matching the website card, then a **Votes** table of everyone who has voted, sorted by stake (highest first). Staker overrides appear as their own rows.
+
+### Vote breakdown
+
+| Line | Description |
+|---|---|
+| Snapshot stake | Total active stake in the proposal's snapshot (Art. IV.2). Omitted when `/meta` is for a different slot |
+| Participation | `(For + Against + Abstain) / snapshot stake`. Quorum is **1/3** of snapshot stake (SGP-0001 Art. IV.3) |
+| Supermajority | `For / (For + Against + Abstain)`. A pass needs **2/3** of participating stake For (Art. IV.4 as stated in the FAQ) |
+| Outcome | `Passing`, `Failing`, `Inconclusive (quorum not met)`, or `Unknown` if the snapshot total is unavailable |
+| For / Against / Abstain | Stake in SOL, share of votes cast, and share of snapshot stake |
+
+| Column | Description |
+|---|---|
+| Voter | Validator identity (voting wallet) or staker delegator |
+| Type | `Validator` or `Staker` |
+| Stake Account | Stake account used for an override; `—` for validator votes |
+| Stake | Snapshot stake (SOL) attached to this vote |
+| For / Against / Abstain | Vote split in percent (basis points / 100) |
+| Date | When the vote (or override) was last written |
+
+If no votes have been cast yet, the table is replaced with `No votes have been cast on this proposal.`
 
 ## Related
 

--- a/docs/src/content/svmgov/validators/proposal/index.mdx
+++ b/docs/src/content/svmgov/validators/proposal/index.mdx
@@ -62,10 +62,10 @@ After the proposal fields, the command prints a **Vote breakdown** matching the 
 
 | Line | Description |
 |---|---|
-| Snapshot stake | Total active stake in the proposal's snapshot (Art. IV.2). Omitted when `/meta` is for a different slot |
+| Snapshot stake | Total active stake in the proposal's snapshot (Art. IV.2). The CLI asks `/meta` for that slot. Omitted if the operator no longer stores it |
 | Participation | `(For + Against + Abstain) / snapshot stake`. Quorum is **1/3** of snapshot stake (SGP-0001 Art. IV.3) |
 | Supermajority | `For / (For + Against + Abstain)`. A pass needs **2/3** of participating stake For (Art. IV.4 as stated in the FAQ) |
-| Outcome | `Passing`, `Failing`, `Inconclusive (quorum not met)`, or `Unknown` if the snapshot total is unavailable |
+| Outcome | `Passing` / `Failing` while voting is open; `Passed` / `Failed` once finalized; `Inconclusive (quorum not met)`; or `Unknown` if the snapshot total is unavailable |
 | For / Against / Abstain | Stake in SOL, share of votes cast, and share of snapshot stake |
 
 | Column | Description |
@@ -73,7 +73,7 @@ After the proposal fields, the command prints a **Vote breakdown** matching the 
 | Voter | Validator identity (voting wallet) or staker delegator |
 | Type | `Validator` or `Staker` |
 | Stake Account | Stake account used for an override; `—` for validator votes |
-| Stake | Snapshot stake (SOL) attached to this vote |
+| Stake | Effective voting weight (SOL). For a validator this is snapshot stake minus any staker overrides, so the column does not double-count |
 | For / Against / Abstain | Vote split in percent (basis points / 100) |
 | Date | When the vote (or override) was last written |
 

--- a/ncn/verifier-service/src/database/migrator.rs
+++ b/ncn/verifier-service/src/database/migrator.rs
@@ -272,6 +272,45 @@ CREATE TABLE snapshot_meta (
     }
 
     #[tokio::test]
+    async fn lookup_returns_the_requested_slot_not_only_the_newest() {
+        let pool = pool().await;
+        run_migrations(&pool).await.unwrap();
+
+        for slot in [100_u64, 200] {
+            SnapshotMetaRecord {
+                network: "mainnet".to_string(),
+                slot,
+                merkle_root: format!("root-{slot}"),
+                snapshot_hash: format!("hash-{slot}"),
+                created_at: "2026-01-01T00:00:00Z".to_string(),
+                total_active_stake: Some(slot),
+            }
+            .insert_exec(&pool)
+            .await
+            .unwrap();
+        }
+
+        let latest = SnapshotMetaRecord::get_latest(&pool, "mainnet")
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(latest.slot, 200);
+
+        let older = SnapshotMetaRecord::lookup(&pool, "mainnet", Some(100))
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(older.slot, 100);
+        assert_eq!(older.merkle_root, "root-100");
+        assert_eq!(older.total_active_stake, Some(100));
+
+        assert!(SnapshotMetaRecord::lookup(&pool, "mainnet", Some(999))
+            .await
+            .unwrap()
+            .is_none());
+    }
+
+    #[tokio::test]
     async fn upgrading_backfills_totals_from_legacy_vote_accounts() {
         let pool = legacy_v1_database().await;
         sqlx::query(

--- a/ncn/verifier-service/src/database/operations.rs
+++ b/ncn/verifier-service/src/database/operations.rs
@@ -269,32 +269,55 @@ impl SnapshotMetaRecord {
         pool: &SqlitePool,
         network: &str,
     ) -> Result<Option<SnapshotMetaRecord>> {
-        let row_opt = sqlx::query(
-            "SELECT * FROM snapshot_meta
-             WHERE network = ? ORDER BY slot DESC LIMIT 1",
-        )
-        .bind(network)
-        .fetch_optional(pool)
-        .await?;
+        Self::lookup(pool, network, None).await
+    }
 
-        if let Some(row) = row_opt {
-            Ok(Some(SnapshotMetaRecord {
-                network: row.get("network"),
-                slot: row.get::<i64, _>("slot") as u64,
-                merkle_root: row.get("merkle_root"),
-                snapshot_hash: row.get("snapshot_hash"),
-                created_at: row.get("created_at"),
-                // Checked, mirroring the write side. A negative value cannot
-                // be written, but `as u64` would turn one into an enormous
-                // quorum denominator, silently reporting participation as ~0%.
-                total_active_stake: row
-                    .get::<Option<i64>, _>("total_active_stake")
-                    .map(u64::try_from)
-                    .transpose()?,
-            }))
-        } else {
-            Ok(None)
-        }
+    /// Snapshot metadata for `slot`, or the newest snapshot when `slot` is `None`.
+    pub async fn lookup(
+        pool: &SqlitePool,
+        network: &str,
+        slot: Option<u64>,
+    ) -> Result<Option<SnapshotMetaRecord>> {
+        let row_opt = match slot {
+            Some(slot) => {
+                sqlx::query(
+                    "SELECT * FROM snapshot_meta
+                     WHERE network = ? AND slot = ?",
+                )
+                .bind(network)
+                .bind(i64::try_from(slot)?)
+                .fetch_optional(pool)
+                .await?
+            }
+            None => {
+                sqlx::query(
+                    "SELECT * FROM snapshot_meta
+                     WHERE network = ? ORDER BY slot DESC LIMIT 1",
+                )
+                .bind(network)
+                .fetch_optional(pool)
+                .await?
+            }
+        };
+
+        row_opt.map(Self::from_row).transpose()
+    }
+
+    fn from_row(row: sqlx::sqlite::SqliteRow) -> Result<SnapshotMetaRecord> {
+        Ok(SnapshotMetaRecord {
+            network: row.get("network"),
+            slot: row.get::<i64, _>("slot") as u64,
+            merkle_root: row.get("merkle_root"),
+            snapshot_hash: row.get("snapshot_hash"),
+            created_at: row.get("created_at"),
+            // Checked, mirroring the write side. A negative value cannot
+            // be written, but `as u64` would turn one into an enormous
+            // quorum denominator, silently reporting participation as ~0%.
+            total_active_stake: row
+                .get::<Option<i64>, _>("total_active_stake")
+                .map(u64::try_from)
+                .transpose()?,
+        })
     }
 
     /// Get the latest slot for a network

--- a/ncn/verifier-service/src/main.rs
+++ b/ncn/verifier-service/src/main.rs
@@ -180,7 +180,7 @@ async fn get_meta(
     validate_network(network)?;
 
     let meta_record_option = db_operation(
-        || SnapshotMetaRecord::get_latest(&pool, network),
+        || SnapshotMetaRecord::lookup(&pool, network, params.slot),
         "Failed to get snapshot meta record",
     )
     .await?;
@@ -188,7 +188,10 @@ async fn get_meta(
     if let Some(record) = meta_record_option {
         Ok(Json(record))
     } else {
-        info!("No snapshots found for network: {}", network);
+        match params.slot {
+            Some(slot) => info!("No snapshot for network {} at slot {}", network, slot),
+            None => info!("No snapshots found for network: {}", network),
+        }
         Err(StatusCode::NOT_FOUND)
     }
 }

--- a/ncn/verifier-service/src/types.rs
+++ b/ncn/verifier-service/src/types.rs
@@ -5,6 +5,8 @@ use serde::Deserialize;
 #[derive(Debug, Deserialize)]
 pub struct NetworkQuery {
     pub network: Option<String>,
+    /// When set, return that snapshot instead of the newest one.
+    pub slot: Option<u64>,
 }
 
 #[derive(Debug, Deserialize)]

--- a/ncn/verifier-service/tests/e2e_binary.rs
+++ b/ncn/verifier-service/tests/e2e_binary.rs
@@ -105,6 +105,25 @@ async fn e2e_binary_endpoints() -> anyhow::Result<()> {
     });
     assert_eq!(meta, expected_meta);
 
+    let meta_by_slot: serde_json::Value = client
+        .get(format!("{}/meta?network=testnet&slot={}", base_url, slot))
+        .send()
+        .await?
+        .error_for_status()?
+        .json()
+        .await?;
+    assert_eq!(meta_by_slot, expected_meta);
+
+    let missing_slot = client
+        .get(format!(
+            "{}/meta?network=testnet&slot={}",
+            base_url,
+            slot + 1
+        ))
+        .send()
+        .await?;
+    assert_eq!(missing_slot.status(), StatusCode::NOT_FOUND);
+
     // Test GET /voter
     let voter: serde_json::Value = client
         .get(format!(

--- a/svmgov/cli/src/config.rs
+++ b/svmgov/cli/src/config.rs
@@ -1,7 +1,7 @@
 use std::fs;
 use std::path::PathBuf;
 
-use anyhow::{anyhow, Result};
+use anyhow::{Result, anyhow};
 use dirs::home_dir;
 use serde::{Deserialize, Serialize};
 

--- a/svmgov/cli/src/instructions/cast_vote.rs
+++ b/svmgov/cli/src/instructions/cast_vote.rs
@@ -3,12 +3,15 @@ use std::str::FromStr;
 use anchor_client::solana_sdk::{pubkey::Pubkey, signer::Signer, transaction::Transaction};
 use anchor_lang::system_program;
 use anyhow::{Result, anyhow};
-use ncn_snapshot::{ID as SNAPSHOT_PROGRAM_ID, MetaMerkleLeaf, MetaMerkleProof};
 use log::info;
+use ncn_snapshot::{ID as SNAPSHOT_PROGRAM_ID, MetaMerkleLeaf, MetaMerkleProof};
 
 use crate::{
     constants::*,
-    svmgov_program::{accounts::Proposal, client::{accounts, args}},
+    svmgov_program::{
+        accounts::Proposal,
+        client::{accounts, args},
+    },
     utils::{
         api_helpers::{self, convert_merkle_proof_strings, get_vote_account_proof},
         utils::{
@@ -59,7 +62,8 @@ pub async fn cast_vote(
     // Generate meta_merkle_proof_pda using the consensus_result from proposal
     let vote_account_pubkey = Pubkey::from_str(&proof_response.meta_merkle_leaf.vote_account)
         .map_err(|e| anyhow!("Invalid vote_account pubkey in response: {}", e))?;
-    let meta_merkle_proof_pda = api_helpers::generate_meta_merkle_proof_pda(&consensus_result_pda, &vote_account_pubkey)?;
+    let meta_merkle_proof_pda =
+        api_helpers::generate_meta_merkle_proof_pda(&consensus_result_pda, &vote_account_pubkey)?;
 
     let vote_pda = derive_vote_pda(&proposal_pubkey, &vote_account, &program.id());
     let vote_override_cache_pda =
@@ -101,7 +105,10 @@ pub async fn cast_vote(
             Some(ts) => ts,
             None => compute_vote_expiry_timestamp(&program, proposal.end_epoch).await?,
         };
-        info!("Setting MetaMerkleProof close_timestamp to {}", close_timestamp);
+        info!(
+            "Setting MetaMerkleProof close_timestamp to {}",
+            close_timestamp
+        );
 
         let init_meta_merkle_proof_ix = merkle_proof_program
             .request()
@@ -176,10 +183,7 @@ pub async fn cast_vote(
         .rpc()
         .send_and_confirm_transaction(&transaction)
         .await?;
-    log::debug!(
-        "Cast vote transaction sent successfully: signature={}",
-        sig
-    );
+    log::debug!("Cast vote transaction sent successfully: signature={}", sig);
 
     spinner.finish_with_message(format!(
         "Vote cast successfully. https://explorer.solana.com/tx/{}",

--- a/svmgov/cli/src/instructions/cast_vote_override.rs
+++ b/svmgov/cli/src/instructions/cast_vote_override.rs
@@ -3,8 +3,8 @@ use std::str::FromStr;
 use anchor_client::solana_sdk::{pubkey::Pubkey, signer::Signer};
 use anchor_lang::system_program;
 use anyhow::{Result, anyhow};
-use ncn_snapshot::{ID as SNAPSHOT_PROGRAM_ID, MetaMerkleLeaf, MetaMerkleProof};
 use log::info;
+use ncn_snapshot::{ID as SNAPSHOT_PROGRAM_ID, MetaMerkleLeaf, MetaMerkleProof};
 
 use crate::{
     constants::*,
@@ -17,7 +17,7 @@ use crate::{
             self, convert_merkle_proof_strings, convert_stake_merkle_leaf_data_to_idl_type,
             get_stake_account_proof, get_vote_account_proof,
         },
-        squads::{effective_signer, SquadsCliOpts},
+        squads::{SquadsCliOpts, effective_signer},
         utils::{
             compute_vote_expiry_timestamp, create_spinner, derive_vote_override_cache_pda,
             derive_vote_override_pda, derive_vote_pda, setup_all_with_staker,
@@ -128,7 +128,10 @@ pub async fn cast_vote_override(
             Some(ts) => ts,
             None => compute_vote_expiry_timestamp(&program, proposal.end_epoch).await?,
         };
-        info!("Setting MetaMerkleProof close_timestamp to {}", close_timestamp);
+        info!(
+            "Setting MetaMerkleProof close_timestamp to {}",
+            close_timestamp
+        );
 
         let init_meta_merkle_proof_ix = merkle_proof_program
             .request()

--- a/svmgov/cli/src/instructions/finalize_proposal.rs
+++ b/svmgov/cli/src/instructions/finalize_proposal.rs
@@ -1,7 +1,7 @@
 use std::str::FromStr;
 
 use anchor_client::solana_sdk::{pubkey::Pubkey, signer::Signer};
-use anyhow::{anyhow, Result};
+use anyhow::{Result, anyhow};
 
 use crate::{
     svmgov_program::client::{accounts, args},

--- a/svmgov/cli/src/instructions/modify_vote.rs
+++ b/svmgov/cli/src/instructions/modify_vote.rs
@@ -7,7 +7,10 @@ use ncn_snapshot::ID as SNAPSHOT_PROGRAM_ID;
 
 use crate::{
     constants::*,
-    svmgov_program::{accounts::Proposal, client::{accounts, args}},
+    svmgov_program::{
+        accounts::Proposal,
+        client::{accounts, args},
+    },
     utils::{
         api_helpers::{self, get_vote_account_proof},
         utils::{create_spinner, derive_vote_pda, setup_all},
@@ -53,7 +56,8 @@ pub async fn modify_vote(
     // Generate meta_merkle_proof_pda using the consensus_result from proposal
     let vote_account_pubkey = Pubkey::from_str(&proof_response.meta_merkle_leaf.vote_account)
         .map_err(|e| anyhow!("Invalid vote_account pubkey in response: {}", e))?;
-    let meta_merkle_proof_pda = api_helpers::generate_meta_merkle_proof_pda(&consensus_result_pda, &vote_account_pubkey)?;
+    let meta_merkle_proof_pda =
+        api_helpers::generate_meta_merkle_proof_pda(&consensus_result_pda, &vote_account_pubkey)?;
 
     let vote_pda = derive_vote_pda(&proposal_pubkey, &vote_account, &program.id());
 

--- a/svmgov/cli/src/instructions/modify_vote_override.rs
+++ b/svmgov/cli/src/instructions/modify_vote_override.rs
@@ -16,7 +16,7 @@ use crate::{
             self, convert_merkle_proof_strings, convert_stake_merkle_leaf_data_to_idl_type,
             get_stake_account_proof,
         },
-        squads::{effective_signer, SquadsCliOpts},
+        squads::{SquadsCliOpts, effective_signer},
         utils::{
             create_spinner, derive_vote_override_cache_pda, derive_vote_override_pda,
             derive_vote_pda, setup_all_with_staker,

--- a/svmgov/cli/src/instructions/retally_support.rs
+++ b/svmgov/cli/src/instructions/retally_support.rs
@@ -9,7 +9,7 @@ use anyhow::{Result, anyhow};
 use ncn_snapshot::ID as SNAPSHOT_PROGRAM_ID;
 
 use crate::{
-    constants::{support_compute_unit_limit, MAX_SUPPORTERS_LIMIT},
+    constants::{MAX_SUPPORTERS_LIMIT, support_compute_unit_limit},
     svmgov_program::accounts::Proposal,
     svmgov_program::client::{accounts, args},
     utils::utils::{
@@ -17,7 +17,6 @@ use crate::{
         get_epoch_slot_range, setup_signer_and_program,
     },
 };
-
 
 pub async fn retally_support(
     proposal_id: String,

--- a/svmgov/cli/src/main.rs
+++ b/svmgov/cli/src/main.rs
@@ -267,7 +267,7 @@ enum Commands {
     #[command(
         about = "List all proposals",
         long_about = "This command retrieves and displays all governance proposals from the Solana Validator Governance program. \
-                      Table rows include status, SGP-0001 outcome (Passing / Failing / Inconclusive), and For / Against / Abstain stake. \
+                      Table rows include status, SGP-0001 outcome (Passing / Failing while voting, Passed / Failed once finalized, or Inconclusive), and For / Against / Abstain stake. \
                       An optional RPC URL can be provided to connect to the chain; otherwise, a default URL is used.\n\n\
                       Examples:\n\
                       $ svmgov list-proposals\n\

--- a/svmgov/cli/src/main.rs
+++ b/svmgov/cli/src/main.rs
@@ -124,7 +124,10 @@ enum Commands {
         title: String,
 
         /// Link in solana-foundation/solana-governance-proposals for the proposal description.
-        #[arg(long, help = "Proposal link in https://github.com/solana-foundation/solana-governance-proposals (no .. path segments)")]
+        #[arg(
+            long,
+            help = "Proposal link in https://github.com/solana-foundation/solana-governance-proposals (no .. path segments)"
+        )]
         description: String,
 
         /// Skip the network check that the linked proposal file exists.
@@ -249,8 +252,9 @@ enum Commands {
     },
 
     #[command(
-        about = "Display a proposal and its details",
-        long_about = "This command retrieves and displays a governance proposal and its details from the Solana Validator Governance program. \
+        about = "Display a proposal, its details, and who voted",
+        long_about = "This command retrieves and displays a governance proposal and its details from the Solana Validator Governance program, \
+                      including a table of every validator vote and staker override (who voted, their stake, and the For / Against / Abstain split). \
                       An optional RPC URL can be provided to connect to the chain; otherwise, a default URL is used.\n\n\
                       Examples:\n\
                       $ svmgov --rpc-url https://api.mainnet-beta.solana.com proposal \"4HarXuo8QjE5GSGzuUxHA1cnNM9mFt2th2JQAC5DSNqU\""
@@ -263,6 +267,7 @@ enum Commands {
     #[command(
         about = "List all proposals",
         long_about = "This command retrieves and displays all governance proposals from the Solana Validator Governance program. \
+                      Table rows include status, SGP-0001 outcome (Passing / Failing / Inconclusive), and For / Against / Abstain stake. \
                       An optional RPC URL can be provided to connect to the chain; otherwise, a default URL is used.\n\n\
                       Examples:\n\
                       $ svmgov list-proposals\n\
@@ -427,7 +432,10 @@ enum Commands {
         #[arg(long, help = "Maximum length for proposal descriptions")]
         max_description_length: u16,
 
-        #[arg(long, help = "Maximum epochs allowed for support phase (0 = same epoch as creation)")]
+        #[arg(
+            long,
+            help = "Maximum epochs allowed for support phase (0 = same epoch as creation)"
+        )]
         max_support_epochs: u64,
 
         #[arg(long, help = "Minimum stake in lamports required to create a proposal")]
@@ -445,10 +453,16 @@ enum Commands {
         #[arg(long, help = "Number of extra epochs for snapshot extension")]
         snapshot_epoch_extension: u64,
 
-        #[arg(long, help = "Slot offset from epoch start for snapshot computation (can be negative)")]
+        #[arg(
+            long,
+            help = "Slot offset from epoch start for snapshot computation (can be negative)"
+        )]
         snapshot_slot_offset: i64,
 
-        #[arg(long, help = "Maximum number of validators allowed to support a proposal (1-2000)")]
+        #[arg(
+            long,
+            help = "Maximum number of validators allowed to support a proposal (1-2000)"
+        )]
         max_supporters: u32,
     },
 
@@ -485,10 +499,16 @@ enum Commands {
         #[arg(long, help = "Number of extra epochs for snapshot extension")]
         snapshot_epoch_extension: Option<u64>,
 
-        #[arg(long, help = "Slot offset from epoch start for snapshot computation (can be negative)")]
+        #[arg(
+            long,
+            help = "Slot offset from epoch start for snapshot computation (can be negative)"
+        )]
         snapshot_slot_offset: Option<i64>,
 
-        #[arg(long, help = "Maximum number of validators allowed to support a proposal (1-2000)")]
+        #[arg(
+            long,
+            help = "Maximum number of validators allowed to support a proposal (1-2000)"
+        )]
         max_supporters: Option<u32>,
     },
 
@@ -554,9 +574,7 @@ enum Commands {
 
 fn merge_cli_with_config(cli: Cli, config: &Config) -> Cli {
     // Merge keypair: CLI arg > config (based on user_type) > None
-    let keypair = cli
-        .keypair
-        .or_else(|| config.get_identity_keypair_path());
+    let keypair = cli.keypair.or_else(|| config.get_identity_keypair_path());
 
     // Merge rpc_url: CLI arg > config rpc_url > config network default > constants default
     let rpc_url = cli.rpc_url.or_else(|| {
@@ -693,9 +711,7 @@ async fn handle_command(cli: Cli) -> Result<()> {
             )
             .await?;
         }
-        Commands::SupportProposal {
-            proposal_id,
-        } => {
+        Commands::SupportProposal { proposal_id } => {
             instructions::support_proposal(
                 proposal_id.to_string(),
                 cli.keypair,
@@ -750,27 +766,27 @@ async fn handle_command(cli: Cli) -> Result<()> {
             .await?;
         }
         Commands::FinalizeProposal { proposal_id } => {
-            instructions::finalize_proposal(
-                proposal_id.to_string(),
-                cli.keypair,
-                cli.rpc_url,
-            )
-            .await?;
+            instructions::finalize_proposal(proposal_id.to_string(), cli.keypair, cli.rpc_url)
+                .await?;
         }
         Commands::Proposal { proposal_id } => {
-            commands::get_proposal(cli.rpc_url.clone(), proposal_id).await?;
+            commands::get_proposal(cli.rpc_url.clone(), proposal_id, network.clone()).await?;
         }
         Commands::ListProposals {
             status,
             limit,
             json,
         } => {
-            let json_bool = json.as_ref().map(|s| s.parse::<bool>().unwrap_or(true)).unwrap_or(false);
+            let json_bool = json
+                .as_ref()
+                .map(|s| s.parse::<bool>().unwrap_or(true))
+                .unwrap_or(false);
             commands::list_proposals(
                 cli.rpc_url.clone(),
                 status.clone(),
                 *limit,
                 json_bool,
+                network.clone(),
             )
             .await?;
         }
@@ -888,18 +904,15 @@ async fn handle_command(cli: Cli) -> Result<()> {
         }
         Commands::NominateAdmin { new_admin } => {
             instructions::nominate_admin(
-                cli.keypair, 
-                new_admin.clone(), 
-                cli.rpc_url, 
-                squads_opts.clone()
-            ).await?;
+                cli.keypair,
+                new_admin.clone(),
+                cli.rpc_url,
+                squads_opts.clone(),
+            )
+            .await?;
         }
         Commands::AcceptAdmin => {
-            instructions::accept_admin(
-                cli.keypair, 
-                cli.rpc_url, 
-                squads_opts.clone()
-            ).await?;
+            instructions::accept_admin(cli.keypair, cli.rpc_url, squads_opts.clone()).await?;
         }
         Commands::Init => {
             init::run_init().await?;

--- a/svmgov/cli/src/utils/api_helpers.rs
+++ b/svmgov/cli/src/utils/api_helpers.rs
@@ -2,7 +2,7 @@ use std::{str::FromStr, time::Duration};
 
 use anchor_lang::prelude::Pubkey;
 use anyhow::{Result, anyhow};
-use log::{info, warn};
+use log::{debug, warn};
 use ncn_snapshot::{MetaMerkleLeaf, MetaMerkleProof, StakeMerkleLeaf};
 use serde::{Deserialize, Serialize, de::DeserializeOwned};
 
@@ -321,6 +321,41 @@ pub async fn get_stake_account_proof(
     Ok(proof)
 }
 
+/// Snapshot metadata from `GET /meta?network=...`.
+///
+/// `/meta` serves only the newest snapshot. A proposal votes against the slot
+/// frozen at activation, so callers must refuse a total whose `slot` does not
+/// match the proposal's `snapshot_slot`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SnapshotMetaResponse {
+    pub network: String,
+    pub slot: u64,
+    pub merkle_root: String,
+    pub snapshot_hash: String,
+    pub created_at: String,
+    /// Lamports across every leaf — the quorum denominator. `null` for
+    /// snapshots uploaded before the verifier recorded it.
+    #[serde(default)]
+    pub total_active_stake: Option<u64>,
+}
+
+/// Fetch the newest snapshot meta for `network`.
+pub async fn get_snapshot_meta(network: &str) -> Result<SnapshotMetaResponse> {
+    let base_url = get_api_base_url()?;
+    let url = format!("{}/meta?network={}", base_url, network);
+
+    log::debug!("Fetching snapshot meta from: {}", url);
+
+    fetch_json_with_retry(
+        &http_client()?,
+        &url,
+        "snapshot meta",
+        &base_url,
+        DEFAULT_RETRY_POLICY,
+    )
+    .await
+}
+
 /// Get the base API URL from config
 fn get_api_base_url() -> anyhow::Result<String> {
     let config = crate::config::Config::load()?;
@@ -329,7 +364,7 @@ fn get_api_base_url() -> anyhow::Result<String> {
         return Ok(crate::constants::DEFAULT_OPERATOR_API_URL.to_string());
     }
 
-    info!("API base URL (from config): {}", config.operator_api_url);
+    debug!("API base URL (from config): {}", config.operator_api_url);
     Ok(config.operator_api_url)
 }
 

--- a/svmgov/cli/src/utils/api_helpers.rs
+++ b/svmgov/cli/src/utils/api_helpers.rs
@@ -321,11 +321,11 @@ pub async fn get_stake_account_proof(
     Ok(proof)
 }
 
-/// Snapshot metadata from `GET /meta?network=...`.
+/// Snapshot metadata from `GET /meta?network=...` (newest) or
+/// `GET /meta?network=...&slot=...` (that snapshot).
 ///
-/// `/meta` serves only the newest snapshot. A proposal votes against the slot
-/// frozen at activation, so callers must refuse a total whose `slot` does not
-/// match the proposal's `snapshot_slot`.
+/// A proposal votes against the slot frozen at activation, so callers must
+/// refuse a total whose `slot` does not match the proposal's `snapshot_slot`.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SnapshotMetaResponse {
     pub network: String,
@@ -339,10 +339,14 @@ pub struct SnapshotMetaResponse {
     pub total_active_stake: Option<u64>,
 }
 
-/// Fetch the newest snapshot meta for `network`.
-pub async fn get_snapshot_meta(network: &str) -> Result<SnapshotMetaResponse> {
+/// Fetch snapshot meta for `network`. `slot` selects a historical snapshot;
+/// `None` is the newest.
+pub async fn get_snapshot_meta(network: &str, slot: Option<u64>) -> Result<SnapshotMetaResponse> {
     let base_url = get_api_base_url()?;
-    let url = format!("{}/meta?network={}", base_url, network);
+    let url = match slot {
+        Some(slot) => format!("{base_url}/meta?network={network}&slot={slot}"),
+        None => format!("{base_url}/meta?network={network}"),
+    };
 
     log::debug!("Fetching snapshot meta from: {}", url);
 

--- a/svmgov/cli/src/utils/commands.rs
+++ b/svmgov/cli/src/utils/commands.rs
@@ -1,4 +1,4 @@
-use std::{str::FromStr, sync::Arc};
+use std::{collections::HashMap, str::FromStr, sync::Arc};
 
 use anchor_client::solana_account_decoder::UiAccountEncoding;
 use anchor_client::solana_client::rpc_config::{RpcAccountInfoConfig, RpcProgramAccountsConfig};
@@ -90,12 +90,18 @@ pub async fn get_proposal(
     let proposal_acc = program.account::<Proposal>(proposal_pubkey).await?;
     let global_config = fetch_global_config(&program).await?;
     let vote_records = fetch_vote_records(&rpc, &program.id(), &proposal_pubkey).await;
-    let snapshot_source = load_snapshot_source(&network).await;
+    let snapshots =
+        load_snapshot_sources(&network, std::iter::once(proposal_acc.snapshot_slot)).await;
 
     print_proposal_detail(proposal_id, &proposal_acc, current_epoch, &global_config);
 
     let width = detect_terminal_width().unwrap_or(200);
-    print_vote_breakdown(&vote_tally(&proposal_acc, snapshot_source.as_ref()), width);
+    let settled = ProposalPhase::new(
+        &PhaseInputs::new(&proposal_acc, &global_config),
+        current_epoch,
+    )
+    .vote_is_settled();
+    print_vote_breakdown(&vote_tally(&proposal_acc, &snapshots), width, settled);
 
     match vote_records {
         Ok(mut records) => {
@@ -279,7 +285,8 @@ struct ProposalOutput {
     voting: bool,
     finalized: bool,
     creation_timestamp: i64,
-    /// SGP-0001 outcome: `passing`, `failing`, `inconclusive`, or `unknown`.
+    /// SGP-0001 outcome. While voting is open: `passing` / `failing`.
+    /// Once settled: `passed` / `failed`. Also `inconclusive` or `unknown`.
     outcome: String,
 }
 
@@ -384,21 +391,26 @@ pub async fn list_proposals(
         return Ok(());
     }
 
-    let snapshot_source = load_snapshot_source(&network).await;
+    let snapshots = load_snapshot_sources(
+        &network,
+        proposals.iter().map(|(_, proposal)| proposal.snapshot_slot),
+    )
+    .await;
 
     // Output in JSON format if requested
     if json_output {
         let json_proposals: Vec<ProposalOutput> = proposals
             .iter()
             .map(|(pubkey, proposal)| {
-                let tally = vote_tally(proposal, snapshot_source.as_ref());
+                let tally = vote_tally(proposal, &snapshots);
+                let phase =
+                    ProposalPhase::new(&PhaseInputs::new(proposal, &global_config), current_epoch);
                 ProposalOutput {
                     id: pubkey.to_string(),
                     title: proposal.title.clone(),
                     description: proposal.description.clone(),
                     author: proposal.author.to_string(),
-                    status: get_proposal_status(proposal, current_epoch, &global_config)
-                        .to_string(),
+                    status: phase.id().to_string(),
                     index: proposal.index,
                     creation_epoch: proposal.creation_epoch,
                     start_epoch: proposal.start_epoch,
@@ -413,42 +425,60 @@ pub async fn list_proposals(
                     voting: proposal.voting,
                     finalized: proposal.finalized,
                     creation_timestamp: proposal.creation_timestamp,
-                    outcome: compute_outcome(&tally).id().to_string(),
+                    outcome: compute_outcome(&tally)
+                        .id(phase.vote_is_settled())
+                        .to_string(),
                 }
             })
             .collect();
         println!("{}", serde_json::to_string_pretty(&json_proposals)?);
     } else {
-        print_proposals_table(
-            &proposals,
-            current_epoch,
-            &global_config,
-            snapshot_source.as_ref(),
-        );
+        print_proposals_table(&proposals, current_epoch, &global_config, &snapshots);
     }
 
     Ok(())
 }
 
-async fn load_snapshot_source(network: &str) -> Option<SnapshotTotalSource> {
-    match api_helpers::get_snapshot_meta(network).await {
-        Ok(meta) => Some(SnapshotTotalSource {
-            slot: meta.slot,
-            total_active_stake: meta.total_active_stake,
-        }),
-        Err(e) => {
-            log::warn!("Could not load snapshot meta for quorum: {e}");
-            None
+async fn load_snapshot_sources(
+    network: &str,
+    slots: impl IntoIterator<Item = u64>,
+) -> HashMap<u64, SnapshotTotalSource> {
+    let mut sources = HashMap::new();
+    let mut needed: Vec<u64> = slots.into_iter().filter(|slot| *slot != 0).collect();
+    needed.sort_unstable();
+    needed.dedup();
+
+    for slot in needed {
+        match api_helpers::get_snapshot_meta(network, Some(slot)).await {
+            Ok(meta) => {
+                // Keyed by the slot the API actually returned, never the one
+                // we asked for, so an operator that ignores `?slot=` cannot
+                // attach the newest total to an older proposal.
+                sources.insert(
+                    meta.slot,
+                    SnapshotTotalSource {
+                        slot: meta.slot,
+                        total_active_stake: meta.total_active_stake,
+                    },
+                );
+            }
+            Err(e) => {
+                log::debug!("Could not load snapshot meta for slot {slot}: {e}");
+            }
         }
     }
+    sources
 }
 
-fn vote_tally(proposal: &Proposal, snapshot: Option<&SnapshotTotalSource>) -> VoteTally {
+fn vote_tally(proposal: &Proposal, snapshots: &HashMap<u64, SnapshotTotalSource>) -> VoteTally {
     VoteTally {
         for_lamports: proposal.for_votes_lamports,
         against_lamports: proposal.against_votes_lamports,
         abstain_lamports: proposal.abstain_votes_lamports,
-        total_active_stake: resolve_quorum_denominator(snapshot, proposal.snapshot_slot),
+        total_active_stake: resolve_quorum_denominator(
+            snapshots.get(&proposal.snapshot_slot),
+            proposal.snapshot_slot,
+        ),
     }
 }
 
@@ -456,7 +486,7 @@ fn print_proposals_table(
     proposals: &[(Pubkey, Proposal)],
     current_epoch: u64,
     config: &GlobalConfig,
-    snapshot: Option<&SnapshotTotalSource>,
+    snapshots: &HashMap<u64, SnapshotTotalSource>,
 ) {
     let mut table = Table::new();
     table
@@ -477,8 +507,8 @@ fn print_proposals_table(
     }
 
     for (pubkey, proposal) in proposals {
-        let status = ProposalPhase::new(&PhaseInputs::new(proposal, config), current_epoch).label();
-        let votes = list_vote_summary(&vote_tally(proposal, snapshot));
+        let phase = ProposalPhase::new(&PhaseInputs::new(proposal, config), current_epoch);
+        let votes = list_vote_summary(&vote_tally(proposal, snapshots));
 
         // Truncate title if too long
         let title = if proposal.title.chars().count() > 32 {
@@ -491,8 +521,8 @@ fn print_proposals_table(
         table.add_row(vec![
             Cell::new(pubkey.to_string()),
             Cell::new(title),
-            Cell::new(status),
-            Cell::new(votes.outcome.short_label()),
+            Cell::new(phase.label()),
+            Cell::new(votes.outcome.short_label(phase.vote_is_settled())),
             Cell::new(&votes.for_stake).set_alignment(CellAlignment::Right),
             Cell::new(&votes.against_stake).set_alignment(CellAlignment::Right),
             Cell::new(&votes.abstain_stake).set_alignment(CellAlignment::Right),

--- a/svmgov/cli/src/utils/commands.rs
+++ b/svmgov/cli/src/utils/commands.rs
@@ -1,22 +1,28 @@
 use std::{str::FromStr, sync::Arc};
 
+use anchor_client::solana_account_decoder::UiAccountEncoding;
 use anchor_client::solana_client::rpc_config::{RpcAccountInfoConfig, RpcProgramAccountsConfig};
 use anchor_client::solana_client::rpc_filter::{Memcmp, RpcFilterType};
-use anchor_client::solana_account_decoder::UiAccountEncoding;
 use anchor_client::solana_sdk::commitment_config::CommitmentConfig;
 use anchor_client::solana_sdk::signature::Keypair;
 
-use anchor_lang::{prelude::Pubkey, AccountDeserialize, Discriminator};
+use anchor_lang::{AccountDeserialize, Discriminator, prelude::Pubkey};
 use anyhow::{Result, anyhow};
 use comfy_table::modifiers::UTF8_ROUND_CORNERS;
-use comfy_table::{Cell, Table, presets::UTF8_FULL};
+use comfy_table::{Cell, CellAlignment, Table, presets::UTF8_FULL};
 use serde::{Deserialize, Serialize};
 
 use crate::{
     anchor_client_setup,
     svmgov_program::accounts::{GlobalConfig, Proposal},
+    utils::api_helpers,
     utils::phase::{PhaseInputs, PhaseTimeline, ProposalPhase},
+    utils::quorum::{
+        SnapshotTotalSource, VoteTally, compute_outcome, list_vote_summary, print_vote_breakdown,
+        resolve_quorum_denominator,
+    },
     utils::utils::fetch_global_config,
+    utils::votes::{fetch_vote_records, print_votes_table, sort_vote_records},
 };
 
 /// Detect terminal width using various methods
@@ -60,7 +66,11 @@ fn detect_terminal_width() -> Option<u16> {
     None
 }
 
-pub async fn get_proposal(rpc_url: Option<String>, proposal_id: &String) -> Result<()> {
+pub async fn get_proposal(
+    rpc_url: Option<String>,
+    proposal_id: &String,
+    network: String,
+) -> Result<()> {
     // Parse the proposal ID into a Pubkey
     let proposal_pubkey = Pubkey::from_str(proposal_id)
         .map_err(|_| anyhow!("Invalid proposal ID: {}", proposal_id))?;
@@ -79,13 +89,33 @@ pub async fn get_proposal(rpc_url: Option<String>, proposal_id: &String) -> Resu
 
     let proposal_acc = program.account::<Proposal>(proposal_pubkey).await?;
     let global_config = fetch_global_config(&program).await?;
+    let vote_records = fetch_vote_records(&rpc, &program.id(), &proposal_pubkey).await;
+    let snapshot_source = load_snapshot_source(&network).await;
 
     print_proposal_detail(proposal_id, &proposal_acc, current_epoch, &global_config);
+
+    let width = detect_terminal_width().unwrap_or(200);
+    print_vote_breakdown(&vote_tally(&proposal_acc, snapshot_source.as_ref()), width);
+
+    match vote_records {
+        Ok(mut records) => {
+            sort_vote_records(&mut records);
+            print_votes_table(&records, width);
+        }
+        Err(e) => {
+            eprintln!("\nCould not load votes: {e}");
+        }
+    }
 
     Ok(())
 }
 
-fn print_proposal_detail(proposal_id: &str, proposal: &Proposal, current_epoch: u64, config: &GlobalConfig) {
+fn print_proposal_detail(
+    proposal_id: &str,
+    proposal: &Proposal,
+    current_epoch: u64,
+    config: &GlobalConfig,
+) {
     let mut table = Table::new();
     table
         .load_preset(UTF8_FULL)
@@ -249,9 +279,15 @@ struct ProposalOutput {
     voting: bool,
     finalized: bool,
     creation_timestamp: i64,
+    /// SGP-0001 outcome: `passing`, `failing`, `inconclusive`, or `unknown`.
+    outcome: String,
 }
 
-fn get_proposal_status(proposal: &Proposal, current_epoch: u64, config: &GlobalConfig) -> &'static str {
+fn get_proposal_status(
+    proposal: &Proposal,
+    current_epoch: u64,
+    config: &GlobalConfig,
+) -> &'static str {
     ProposalPhase::new(&PhaseInputs::new(proposal, config), current_epoch).id()
 }
 
@@ -260,6 +296,7 @@ pub async fn list_proposals(
     status_filter: Option<String>,
     limit: Option<usize>,
     json_output: bool,
+    network: String,
 ) -> Result<()> {
     // Create a mock Payer
     let mock_payer = Arc::new(Keypair::new());
@@ -347,41 +384,80 @@ pub async fn list_proposals(
         return Ok(());
     }
 
+    let snapshot_source = load_snapshot_source(&network).await;
+
     // Output in JSON format if requested
     if json_output {
         let json_proposals: Vec<ProposalOutput> = proposals
             .iter()
-            .map(|(pubkey, proposal)| ProposalOutput {
-                id: pubkey.to_string(),
-                title: proposal.title.clone(),
-                description: proposal.description.clone(),
-                author: proposal.author.to_string(),
-                status: get_proposal_status(proposal, current_epoch, &global_config).to_string(),
-                index: proposal.index,
-                creation_epoch: proposal.creation_epoch,
-                start_epoch: proposal.start_epoch,
-                end_epoch: proposal.end_epoch,
-                snapshot_slot: proposal.snapshot_slot,
-                proposer_stake_weight_bp: proposal.proposer_stake_weight_bp,
-                cluster_support_lamports: proposal.cluster_support_lamports,
-                for_votes_lamports: proposal.for_votes_lamports,
-                against_votes_lamports: proposal.against_votes_lamports,
-                abstain_votes_lamports: proposal.abstain_votes_lamports,
-                vote_count: proposal.vote_count,
-                voting: proposal.voting,
-                finalized: proposal.finalized,
-                creation_timestamp: proposal.creation_timestamp,
+            .map(|(pubkey, proposal)| {
+                let tally = vote_tally(proposal, snapshot_source.as_ref());
+                ProposalOutput {
+                    id: pubkey.to_string(),
+                    title: proposal.title.clone(),
+                    description: proposal.description.clone(),
+                    author: proposal.author.to_string(),
+                    status: get_proposal_status(proposal, current_epoch, &global_config)
+                        .to_string(),
+                    index: proposal.index,
+                    creation_epoch: proposal.creation_epoch,
+                    start_epoch: proposal.start_epoch,
+                    end_epoch: proposal.end_epoch,
+                    snapshot_slot: proposal.snapshot_slot,
+                    proposer_stake_weight_bp: proposal.proposer_stake_weight_bp,
+                    cluster_support_lamports: proposal.cluster_support_lamports,
+                    for_votes_lamports: proposal.for_votes_lamports,
+                    against_votes_lamports: proposal.against_votes_lamports,
+                    abstain_votes_lamports: proposal.abstain_votes_lamports,
+                    vote_count: proposal.vote_count,
+                    voting: proposal.voting,
+                    finalized: proposal.finalized,
+                    creation_timestamp: proposal.creation_timestamp,
+                    outcome: compute_outcome(&tally).id().to_string(),
+                }
             })
             .collect();
         println!("{}", serde_json::to_string_pretty(&json_proposals)?);
     } else {
-        print_proposals_table(&proposals, current_epoch, &global_config);
+        print_proposals_table(
+            &proposals,
+            current_epoch,
+            &global_config,
+            snapshot_source.as_ref(),
+        );
     }
 
     Ok(())
 }
 
-fn print_proposals_table(proposals: &[(Pubkey, Proposal)], current_epoch: u64, config: &GlobalConfig) {
+async fn load_snapshot_source(network: &str) -> Option<SnapshotTotalSource> {
+    match api_helpers::get_snapshot_meta(network).await {
+        Ok(meta) => Some(SnapshotTotalSource {
+            slot: meta.slot,
+            total_active_stake: meta.total_active_stake,
+        }),
+        Err(e) => {
+            log::warn!("Could not load snapshot meta for quorum: {e}");
+            None
+        }
+    }
+}
+
+fn vote_tally(proposal: &Proposal, snapshot: Option<&SnapshotTotalSource>) -> VoteTally {
+    VoteTally {
+        for_lamports: proposal.for_votes_lamports,
+        against_lamports: proposal.against_votes_lamports,
+        abstain_lamports: proposal.abstain_votes_lamports,
+        total_active_stake: resolve_quorum_denominator(snapshot, proposal.snapshot_slot),
+    }
+}
+
+fn print_proposals_table(
+    proposals: &[(Pubkey, Proposal)],
+    current_epoch: u64,
+    config: &GlobalConfig,
+    snapshot: Option<&SnapshotTotalSource>,
+) {
     let mut table = Table::new();
     table
         .load_preset(UTF8_FULL)
@@ -391,7 +467,9 @@ fn print_proposals_table(proposals: &[(Pubkey, Proposal)], current_epoch: u64, c
     let terminal_width = detect_terminal_width().unwrap_or(200);
     table.set_width(terminal_width);
 
-    table.set_header(vec!["ID", "Title", "Status"]);
+    table.set_header(vec![
+        "ID", "Title", "Status", "Outcome", "For", "Against", "Abstain",
+    ]);
 
     // Set ContentWidth constraint for ID column to prevent wrapping
     if let Some(column) = table.column_mut(0) {
@@ -400,21 +478,24 @@ fn print_proposals_table(proposals: &[(Pubkey, Proposal)], current_epoch: u64, c
 
     for (pubkey, proposal) in proposals {
         let status = ProposalPhase::new(&PhaseInputs::new(proposal, config), current_epoch).label();
+        let votes = list_vote_summary(&vote_tally(proposal, snapshot));
 
         // Truncate title if too long
-        let title = if proposal.title.chars().count() > 40 {
-            let truncated: String = proposal.title.chars().take(37).collect();
+        let title = if proposal.title.chars().count() > 32 {
+            let truncated: String = proposal.title.chars().take(29).collect();
             format!("{truncated}...")
         } else {
             proposal.title.clone()
         };
 
-        let pubkey_str = pubkey.to_string();
-
         table.add_row(vec![
-            Cell::new(pubkey_str),
+            Cell::new(pubkey.to_string()),
             Cell::new(title),
             Cell::new(status),
+            Cell::new(votes.outcome.short_label()),
+            Cell::new(&votes.for_stake).set_alignment(CellAlignment::Right),
+            Cell::new(&votes.against_stake).set_alignment(CellAlignment::Right),
+            Cell::new(&votes.abstain_stake).set_alignment(CellAlignment::Right),
         ]);
     }
 

--- a/svmgov/cli/src/utils/config_command.rs
+++ b/svmgov/cli/src/utils/config_command.rs
@@ -1,7 +1,7 @@
 use anchor_lang::Id;
-use anyhow::{anyhow, Result};
+use anyhow::{Result, anyhow};
 
-use crate::config::{get_default_rpc_url, Config, UserType};
+use crate::config::{Config, UserType, get_default_rpc_url};
 use crate::constants::DEFAULT_OPERATOR_API_URL;
 use crate::svmgov_program::program::SvmgovProgram;
 

--- a/svmgov/cli/src/utils/mod.rs
+++ b/svmgov/cli/src/utils/mod.rs
@@ -4,5 +4,7 @@ pub mod config_command;
 pub mod init;
 pub mod phase;
 pub mod proposal_link;
+pub mod quorum;
 pub mod squads;
 pub mod utils;
+pub mod votes;

--- a/svmgov/cli/src/utils/phase.rs
+++ b/svmgov/cli/src/utils/phase.rs
@@ -136,6 +136,13 @@ impl ProposalPhase {
         }
     }
 
+    /// Voting is over, so an SGP-0001 pass/fail is past tense (`Passed` /
+    /// `Failed`). `Finalized` is the on-chain lock; `Ended` is the same result
+    /// waiting for that lock. Inconclusive does not change tense.
+    pub fn vote_is_settled(self) -> bool {
+        matches!(self, Self::Finalized | Self::Ended)
+    }
+
     /// Lowercase identifier used by `--status` filters and JSON output.
     pub fn id(self) -> &'static str {
         match self {
@@ -346,7 +353,9 @@ mod tests {
         assert_eq!(ProposalPhase::new(&p, 1020), ProposalPhase::Snapshot);
         assert_eq!(ProposalPhase::new(&p, 1021), ProposalPhase::Voting);
         assert_eq!(ProposalPhase::new(&p, 1023), ProposalPhase::Voting);
+        assert!(!ProposalPhase::new(&p, 1023).vote_is_settled());
         assert_eq!(ProposalPhase::new(&p, 1024), ProposalPhase::Ended);
+        assert!(ProposalPhase::new(&p, 1024).vote_is_settled());
     }
 
     #[test]
@@ -400,6 +409,7 @@ mod tests {
             ..double_disinflation()
         };
         assert_eq!(ProposalPhase::new(&p, 1012), ProposalPhase::Finalized);
+        assert!(ProposalPhase::new(&p, 1012).vote_is_settled());
         assert_eq!(p.epochs_remaining(1012), None);
     }
 

--- a/svmgov/cli/src/utils/proposal_link.rs
+++ b/svmgov/cli/src/utils/proposal_link.rs
@@ -524,7 +524,9 @@ mod tests {
             "https://github.com/solana-foundation/solana-governance-proposals/blob/main/proposals/sgp-0001-café.md",
             "https://github.com/solana-foundation/solana-governance-proposals/blob/main/proposals/sgp-0001-测试.md",
         ] {
-            let error = validate_description_structure(link).unwrap_err().to_string();
+            let error = validate_description_structure(link)
+                .unwrap_err()
+                .to_string();
             assert!(error.contains("on-chain program rejects"), "got: {error}");
         }
     }

--- a/svmgov/cli/src/utils/quorum.rs
+++ b/svmgov/cli/src/utils/quorum.rs
@@ -7,8 +7,8 @@
 //! If quorum is not met the outcome is inconclusive, not a fail.
 //!
 //! The snapshot total is required for quorum. It is taken from the proposal's
-//! own snapshot (Art. IV.2), never a live cluster sum. `/meta` only serves the
-//! newest snapshot, so a total from a different slot is refused.
+//! own snapshot (Art. IV.2), never a live cluster sum. `/meta?slot=` returns
+//! that snapshot's total; a total from a different slot is refused.
 
 use anchor_client::solana_sdk::native_token::LAMPORTS_PER_SOL;
 use comfy_table::modifiers::UTF8_ROUND_CORNERS;
@@ -61,9 +61,8 @@ impl DenominatorError {
 
 /// The total to measure quorum against, or why it cannot be established.
 ///
-/// `/meta` serves only the newest snapshot. A proposal votes against the one
-/// frozen at activation, so a total from any other slot is a different stake
-/// distribution and must not be used.
+/// `/meta?slot=` is the proposal's own snapshot. A total from any other slot
+/// is a different stake distribution and must not be used.
 pub fn resolve_quorum_denominator(
     meta: Option<&SnapshotTotalSource>,
     proposal_snapshot_slot: u64,
@@ -141,32 +140,42 @@ pub enum ProposalOutcome {
 }
 
 impl ProposalOutcome {
-    pub fn label(self) -> &'static str {
-        match self {
-            ProposalOutcome::Unknown => "Unknown (snapshot total unavailable)",
-            ProposalOutcome::Inconclusive => "Inconclusive (quorum not met)",
-            ProposalOutcome::Passing => "Passing",
-            ProposalOutcome::Failing => "Failing",
+    /// `settled` is true once voting can no longer change the result
+    /// (finalized, or the voting window has closed). SGP-0001's results are
+    /// then Passed / Failed; while the vote is open they are Passing / Failing.
+    /// Inconclusive is the quorum miss in either case — it is not a fail.
+    pub fn label(self, settled: bool) -> &'static str {
+        match (self, settled) {
+            (ProposalOutcome::Unknown, _) => "Unknown (snapshot total unavailable)",
+            (ProposalOutcome::Inconclusive, _) => "Inconclusive (quorum not met)",
+            (ProposalOutcome::Passing, false) => "Passing",
+            (ProposalOutcome::Passing, true) => "Passed",
+            (ProposalOutcome::Failing, false) => "Failing",
+            (ProposalOutcome::Failing, true) => "Failed",
         }
     }
 
     /// Compact label for `list-proposals`. Unknown is a dash so a support-phase
     /// row does not look like a failed vote.
-    pub fn short_label(self) -> &'static str {
-        match self {
-            ProposalOutcome::Unknown => "—",
-            ProposalOutcome::Inconclusive => "Inconclusive",
-            ProposalOutcome::Passing => "Passing",
-            ProposalOutcome::Failing => "Failing",
+    pub fn short_label(self, settled: bool) -> &'static str {
+        match (self, settled) {
+            (ProposalOutcome::Unknown, _) => "—",
+            (ProposalOutcome::Inconclusive, _) => "Inconclusive",
+            (ProposalOutcome::Passing, false) => "Passing",
+            (ProposalOutcome::Passing, true) => "Passed",
+            (ProposalOutcome::Failing, false) => "Failing",
+            (ProposalOutcome::Failing, true) => "Failed",
         }
     }
 
-    pub fn id(self) -> &'static str {
-        match self {
-            ProposalOutcome::Unknown => "unknown",
-            ProposalOutcome::Inconclusive => "inconclusive",
-            ProposalOutcome::Passing => "passing",
-            ProposalOutcome::Failing => "failing",
+    pub fn id(self, settled: bool) -> &'static str {
+        match (self, settled) {
+            (ProposalOutcome::Unknown, _) => "unknown",
+            (ProposalOutcome::Inconclusive, _) => "inconclusive",
+            (ProposalOutcome::Passing, false) => "passing",
+            (ProposalOutcome::Passing, true) => "passed",
+            (ProposalOutcome::Failing, false) => "failing",
+            (ProposalOutcome::Failing, true) => "failed",
         }
     }
 }
@@ -273,7 +282,7 @@ fn participation_bar(participation_percent: f64) -> String {
 
 /// Lines above the For/Against/Abstain table. Unit-tested so the website card
 /// and the CLI stay aligned without an RPC.
-pub fn breakdown_summary_lines(tally: &VoteTally) -> Vec<String> {
+pub fn breakdown_summary_lines(tally: &VoteTally, settled: bool) -> Vec<String> {
     let quorum = compute_quorum(tally);
     let outcome = compute_outcome(tally);
     let participating = tally.participating_lamports();
@@ -310,13 +319,16 @@ pub fn breakdown_summary_lines(tally: &VoteTally) -> Vec<String> {
             format_percent(percent(tally.for_lamports, participating))
         ));
     }
-    lines.push(format!("Outcome:                     {}", outcome.label()));
+    lines.push(format!(
+        "Outcome:                     {}",
+        outcome.label(settled)
+    ));
     lines
 }
 
-pub fn print_vote_breakdown(tally: &VoteTally, terminal_width: u16) {
+pub fn print_vote_breakdown(tally: &VoteTally, terminal_width: u16, settled: bool) {
     println!("\nVote breakdown (SGP-0001)");
-    for line in breakdown_summary_lines(tally) {
+    for line in breakdown_summary_lines(tally, settled) {
         println!("  {line}");
     }
 
@@ -583,12 +595,15 @@ mod tests {
 
     #[test]
     fn summary_names_quorum_and_outcome() {
-        let lines = breakdown_summary_lines(&tally(
-            NETWORK_STAKE / 2,
-            NETWORK_STAKE / 10,
-            0,
-            known(NETWORK_STAKE),
-        ));
+        let lines = breakdown_summary_lines(
+            &tally(
+                NETWORK_STAKE / 2,
+                NETWORK_STAKE / 10,
+                0,
+                known(NETWORK_STAKE),
+            ),
+            false,
+        );
         assert!(lines.iter().any(|l| l.contains("quorum met")));
         assert!(lines.iter().any(|l| l.contains("Passing")));
         assert!(lines.iter().any(|l| l.contains("1/3 needed")));
@@ -596,8 +611,23 @@ mod tests {
     }
 
     #[test]
+    fn settled_summary_uses_past_tense() {
+        let lines = breakdown_summary_lines(
+            &tally(
+                NETWORK_STAKE / 2,
+                NETWORK_STAKE / 10,
+                0,
+                known(NETWORK_STAKE),
+            ),
+            true,
+        );
+        assert!(lines.iter().any(|l| l.contains("Passed")));
+        assert!(!lines.iter().any(|l| l.contains("Passing")));
+    }
+
+    #[test]
     fn summary_without_a_total_does_not_pretend_quorum_failed() {
-        let lines = breakdown_summary_lines(&tally(1, 0, 0, Err(DenominatorError::NoMeta)));
+        let lines = breakdown_summary_lines(&tally(1, 0, 0, Err(DenominatorError::NoMeta)), false);
         assert!(
             lines
                 .iter()
@@ -616,17 +646,30 @@ mod tests {
             0,
             known(NETWORK_STAKE),
         ));
-        assert_eq!(passing.outcome.short_label(), "Passing");
-        assert_eq!(passing.outcome.id(), "passing");
+        assert_eq!(passing.outcome.short_label(false), "Passing");
+        assert_eq!(passing.outcome.id(false), "passing");
+        assert_eq!(passing.outcome.short_label(true), "Passed");
+        assert_eq!(passing.outcome.id(true), "passed");
         assert_eq!(passing.for_stake, "200.00M SOL");
         assert_eq!(passing.against_stake, "40.00M SOL");
         assert_eq!(passing.abstain_stake, "0.00 SOL");
 
         let unknown = list_vote_summary(&tally(1, 0, 0, Err(DenominatorError::Unactivated)));
-        assert_eq!(unknown.outcome.short_label(), "—");
-        assert_eq!(unknown.outcome.id(), "unknown");
+        assert_eq!(unknown.outcome.short_label(false), "—");
+        assert_eq!(unknown.outcome.id(false), "unknown");
 
         let no_quorum = list_vote_summary(&tally(NETWORK_STAKE / 10, 0, 0, known(NETWORK_STAKE)));
-        assert_eq!(no_quorum.outcome.short_label(), "Inconclusive");
+        assert_eq!(no_quorum.outcome.short_label(true), "Inconclusive");
+        assert_eq!(no_quorum.outcome.id(true), "inconclusive");
+
+        let failing = list_vote_summary(&tally(
+            NETWORK_STAKE * 2 / 3 - ONE_SOL,
+            NETWORK_STAKE / 3 + ONE_SOL,
+            0,
+            known(NETWORK_STAKE),
+        ));
+        assert_eq!(failing.outcome.short_label(false), "Failing");
+        assert_eq!(failing.outcome.short_label(true), "Failed");
+        assert_eq!(failing.outcome.id(true), "failed");
     }
 }

--- a/svmgov/cli/src/utils/quorum.rs
+++ b/svmgov/cli/src/utils/quorum.rs
@@ -1,0 +1,632 @@
+//! Vote breakdown and SGP-0001 outcome, for display by the CLI.
+//!
+//! Mirrors the website's Vote Breakdown card: participation against snapshot
+//! stake (Art. IV.3, one third), For / Against / Abstain as a share of votes
+//! cast, and a pass/fail reading of Art. IV.4 as the product FAQ states it —
+//! two thirds of participating stake (`For + Against + Abstain`) must vote For.
+//! If quorum is not met the outcome is inconclusive, not a fail.
+//!
+//! The snapshot total is required for quorum. It is taken from the proposal's
+//! own snapshot (Art. IV.2), never a live cluster sum. `/meta` only serves the
+//! newest snapshot, so a total from a different slot is refused.
+
+use anchor_client::solana_sdk::native_token::LAMPORTS_PER_SOL;
+use comfy_table::modifiers::UTF8_ROUND_CORNERS;
+use comfy_table::{Cell, CellAlignment, Table, presets::UTF8_FULL};
+
+/// The `/meta` fields quorum needs. Kept separate from the HTTP response type
+/// so this module stays RPC-free and unit-testable.
+#[derive(Debug, Clone)]
+pub struct SnapshotTotalSource {
+    pub slot: u64,
+    pub total_active_stake: Option<u64>,
+}
+
+pub const QUORUM_NUMERATOR: u64 = 1;
+pub const QUORUM_DENOMINATOR: u64 = 3;
+pub const SUPERMAJORITY_NUMERATOR: u64 = 2;
+pub const SUPERMAJORITY_DENOMINATOR: u64 = 3;
+
+const BAR_WIDTH: usize = 30;
+
+/// Why the snapshot total could not be used as a quorum denominator.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DenominatorError {
+    NoMeta,
+    /// `snapshot_slot` is 0 until voting activates.
+    Unactivated,
+    SlotMismatch {
+        meta_slot: u64,
+        proposal_slot: u64,
+    },
+    MissingTotal,
+}
+
+impl DenominatorError {
+    pub fn hint(&self) -> String {
+        match self {
+            DenominatorError::NoMeta | DenominatorError::MissingTotal => {
+                "snapshot total unavailable".to_string()
+            }
+            DenominatorError::Unactivated => "voting has not started (no snapshot yet)".to_string(),
+            DenominatorError::SlotMismatch {
+                meta_slot,
+                proposal_slot,
+            } => format!(
+                "snapshot total unavailable (/meta is slot {meta_slot}, proposal is slot {proposal_slot})"
+            ),
+        }
+    }
+}
+
+/// The total to measure quorum against, or why it cannot be established.
+///
+/// `/meta` serves only the newest snapshot. A proposal votes against the one
+/// frozen at activation, so a total from any other slot is a different stake
+/// distribution and must not be used.
+pub fn resolve_quorum_denominator(
+    meta: Option<&SnapshotTotalSource>,
+    proposal_snapshot_slot: u64,
+) -> Result<u64, DenominatorError> {
+    if proposal_snapshot_slot == 0 {
+        return Err(DenominatorError::Unactivated);
+    }
+    let meta = meta.ok_or(DenominatorError::NoMeta)?;
+    if meta.slot != proposal_snapshot_slot {
+        return Err(DenominatorError::SlotMismatch {
+            meta_slot: meta.slot,
+            proposal_slot: proposal_snapshot_slot,
+        });
+    }
+    match meta.total_active_stake {
+        Some(total) if total > 0 => Ok(total),
+        _ => Err(DenominatorError::MissingTotal),
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct VoteTally {
+    pub for_lamports: u64,
+    pub against_lamports: u64,
+    pub abstain_lamports: u64,
+    pub total_active_stake: Result<u64, DenominatorError>,
+}
+
+impl VoteTally {
+    pub fn participating_lamports(&self) -> u64 {
+        self.for_lamports
+            .saturating_add(self.against_lamports)
+            .saturating_add(self.abstain_lamports)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum QuorumStatus {
+    Unknown {
+        hint: String,
+    },
+    Known {
+        total_active_stake: u64,
+        /// 0–100, for display only. Quorum itself is decided in lamports.
+        participation_percent: f64,
+        is_met: bool,
+    },
+}
+
+/// Art. IV.3: participating stake (`For + Against + Abstain`) must be at least
+/// one third of snapshot stake. Compared in integer lamports so a displayed
+/// `33.33%` cannot decide a borderline vote.
+pub fn compute_quorum(tally: &VoteTally) -> QuorumStatus {
+    match tally.total_active_stake {
+        Err(ref err) => QuorumStatus::Unknown { hint: err.hint() },
+        Ok(total) => {
+            let participating = tally.participating_lamports();
+            QuorumStatus::Known {
+                total_active_stake: total,
+                participation_percent: percent(participating, total),
+                is_met: meets_fraction(participating, total, QUORUM_NUMERATOR, QUORUM_DENOMINATOR),
+            }
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ProposalOutcome {
+    /// Snapshot total unknown, so quorum (and therefore pass/fail) cannot be judged.
+    Unknown,
+    /// Quorum not met. SGP-0001: does not pass, does not fail.
+    Inconclusive,
+    Passing,
+    Failing,
+}
+
+impl ProposalOutcome {
+    pub fn label(self) -> &'static str {
+        match self {
+            ProposalOutcome::Unknown => "Unknown (snapshot total unavailable)",
+            ProposalOutcome::Inconclusive => "Inconclusive (quorum not met)",
+            ProposalOutcome::Passing => "Passing",
+            ProposalOutcome::Failing => "Failing",
+        }
+    }
+
+    /// Compact label for `list-proposals`. Unknown is a dash so a support-phase
+    /// row does not look like a failed vote.
+    pub fn short_label(self) -> &'static str {
+        match self {
+            ProposalOutcome::Unknown => "—",
+            ProposalOutcome::Inconclusive => "Inconclusive",
+            ProposalOutcome::Passing => "Passing",
+            ProposalOutcome::Failing => "Failing",
+        }
+    }
+
+    pub fn id(self) -> &'static str {
+        match self {
+            ProposalOutcome::Unknown => "unknown",
+            ProposalOutcome::Inconclusive => "inconclusive",
+            ProposalOutcome::Passing => "passing",
+            ProposalOutcome::Failing => "failing",
+        }
+    }
+}
+
+/// FAQ reading of SGP-0001: quorum of one third of snapshot stake, then two
+/// thirds of participating stake For. Abstain counts toward quorum and sits in
+/// the supermajority denominator, so a large abstain can block a pass even
+/// with no Against votes.
+pub fn compute_outcome(tally: &VoteTally) -> ProposalOutcome {
+    match compute_quorum(tally) {
+        QuorumStatus::Unknown { .. } => ProposalOutcome::Unknown,
+        QuorumStatus::Known { is_met: false, .. } => ProposalOutcome::Inconclusive,
+        QuorumStatus::Known { is_met: true, .. } => {
+            let participating = tally.participating_lamports();
+            if meets_fraction(
+                tally.for_lamports,
+                participating,
+                SUPERMAJORITY_NUMERATOR,
+                SUPERMAJORITY_DENOMINATOR,
+            ) {
+                ProposalOutcome::Passing
+            } else {
+                ProposalOutcome::Failing
+            }
+        }
+    }
+}
+
+/// Compact For / Against / Abstain plus SGP-0001 outcome for `list-proposals`.
+pub fn list_vote_summary(tally: &VoteTally) -> ListVoteSummary {
+    ListVoteSummary {
+        outcome: compute_outcome(tally),
+        for_stake: format_sol_display(tally.for_lamports),
+        against_stake: format_sol_display(tally.against_lamports),
+        abstain_stake: format_sol_display(tally.abstain_lamports),
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ListVoteSummary {
+    pub outcome: ProposalOutcome,
+    pub for_stake: String,
+    pub against_stake: String,
+    pub abstain_stake: String,
+}
+
+/// `numerator >= (denominator * num) / den`, in u128 so mainnet stake cannot
+/// wrap. Matches the website: compared in lamports, using truncating division
+/// the same way `(total * 1) / 3` is written in `frontend/src/chain/quorum.ts`.
+fn meets_fraction(numerator: u64, denominator: u64, num: u64, den: u64) -> bool {
+    if denominator == 0 {
+        return false;
+    }
+    (numerator as u128) >= (denominator as u128) * (num as u128) / (den as u128)
+}
+
+fn percent(part: u64, whole: u64) -> f64 {
+    if whole == 0 {
+        0.0
+    } else {
+        (part as f64 / whole as f64) * 100.0
+    }
+}
+
+pub fn format_sol_display(lamports: u64) -> String {
+    let sol = lamports as f64 / LAMPORTS_PER_SOL as f64;
+    if sol >= 1_000_000_000.0 {
+        format!("{:.2}B SOL", sol / 1_000_000_000.0)
+    } else if sol >= 10_000_000.0 {
+        format!("{:.2}M SOL", sol / 1_000_000.0)
+    } else {
+        format!("{} SOL", with_thousands(sol))
+    }
+}
+
+fn with_thousands(sol: f64) -> String {
+    let formatted = format!("{sol:.2}");
+    let (whole, frac) = formatted
+        .split_once('.')
+        .expect("format!.2 always has a dot");
+    format!("{}.{}", group_thousands(whole), frac)
+}
+
+fn group_thousands(whole: &str) -> String {
+    let mut grouped = String::new();
+    for (i, c) in whole.chars().rev().enumerate() {
+        if i > 0 && i % 3 == 0 {
+            grouped.push(',');
+        }
+        grouped.push(c);
+    }
+    grouped.chars().rev().collect()
+}
+
+fn format_percent(value: f64) -> String {
+    format!("{value:.2}%")
+}
+
+fn participation_bar(participation_percent: f64) -> String {
+    let frac = (participation_percent / 100.0).clamp(0.0, 1.0);
+    let filled = ((frac * BAR_WIDTH as f64).round() as usize).min(BAR_WIDTH);
+    format!("{}{}", "█".repeat(filled), "░".repeat(BAR_WIDTH - filled))
+}
+
+/// Lines above the For/Against/Abstain table. Unit-tested so the website card
+/// and the CLI stay aligned without an RPC.
+pub fn breakdown_summary_lines(tally: &VoteTally) -> Vec<String> {
+    let quorum = compute_quorum(tally);
+    let outcome = compute_outcome(tally);
+    let participating = tally.participating_lamports();
+
+    let mut lines = Vec::new();
+    match &quorum {
+        QuorumStatus::Known {
+            total_active_stake,
+            participation_percent,
+            is_met,
+        } => {
+            lines.push(format!(
+                "Snapshot stake:              {}",
+                format_sol_display(*total_active_stake)
+            ));
+            let met = if *is_met { " — quorum met" } else { "" };
+            lines.push(format!(
+                "Participation (1/3 needed):  {}  {}{}",
+                format_percent(*participation_percent),
+                participation_bar(*participation_percent),
+                met
+            ));
+        }
+        QuorumStatus::Unknown { hint } => {
+            lines.push(format!("Participation (1/3 needed):  — ({hint})"));
+        }
+    }
+
+    if participating == 0 {
+        lines.push("Supermajority (2/3 needed):  — (no votes yet)".to_string());
+    } else {
+        lines.push(format!(
+            "Supermajority (2/3 needed):  {} For",
+            format_percent(percent(tally.for_lamports, participating))
+        ));
+    }
+    lines.push(format!("Outcome:                     {}", outcome.label()));
+    lines
+}
+
+pub fn print_vote_breakdown(tally: &VoteTally, terminal_width: u16) {
+    println!("\nVote breakdown (SGP-0001)");
+    for line in breakdown_summary_lines(tally) {
+        println!("  {line}");
+    }
+
+    let participating = tally.participating_lamports();
+    let of_votes = |part: u64| {
+        if participating == 0 {
+            "—".to_string()
+        } else {
+            format_percent(percent(part, participating))
+        }
+    };
+    let of_snapshot = |part: u64| match tally.total_active_stake {
+        Ok(total) => format_percent(percent(part, total)),
+        Err(_) => "—".to_string(),
+    };
+
+    let mut table = Table::new();
+    table
+        .load_preset(UTF8_FULL)
+        .apply_modifier(UTF8_ROUND_CORNERS)
+        .set_width(terminal_width);
+    table.set_header(vec!["Choice", "Stake", "Of votes", "Of snapshot"]);
+
+    for (label, lamports) in [
+        ("For", tally.for_lamports),
+        ("Against", tally.against_lamports),
+        ("Abstain", tally.abstain_lamports),
+    ] {
+        table.add_row(vec![
+            Cell::new(label),
+            Cell::new(format_sol_display(lamports)).set_alignment(CellAlignment::Right),
+            Cell::new(of_votes(lamports)).set_alignment(CellAlignment::Right),
+            Cell::new(of_snapshot(lamports)).set_alignment(CellAlignment::Right),
+        ]);
+    }
+
+    println!("{table}");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const NETWORK_STAKE: u64 = 400_000_000 * LAMPORTS_PER_SOL;
+    const ONE_THIRD: u64 = NETWORK_STAKE / 3;
+    const ONE_SOL: u64 = LAMPORTS_PER_SOL;
+
+    fn tally(f: u64, a: u64, ab: u64, total: Result<u64, DenominatorError>) -> VoteTally {
+        VoteTally {
+            for_lamports: f,
+            against_lamports: a,
+            abstain_lamports: ab,
+            total_active_stake: total,
+        }
+    }
+
+    fn known(total: u64) -> Result<u64, DenominatorError> {
+        Ok(total)
+    }
+
+    fn meta(slot: u64, total: Option<u64>) -> SnapshotTotalSource {
+        SnapshotTotalSource {
+            slot,
+            total_active_stake: total,
+        }
+    }
+
+    #[test]
+    fn quorum_is_one_third() {
+        assert_eq!(QUORUM_NUMERATOR, 1);
+        assert_eq!(QUORUM_DENOMINATOR, 3);
+    }
+
+    #[test]
+    fn missing_or_zero_total_is_unknown_not_zero() {
+        let unknown = compute_quorum(&tally(1, 2, 3, Err(DenominatorError::NoMeta)));
+        assert!(matches!(unknown, QuorumStatus::Unknown { .. }));
+        assert_eq!(
+            compute_outcome(&tally(1, 2, 3, Err(DenominatorError::NoMeta))),
+            ProposalOutcome::Unknown
+        );
+
+        let zero = compute_quorum(&tally(1, 0, 0, Err(DenominatorError::MissingTotal)));
+        assert!(matches!(zero, QuorumStatus::Unknown { .. }));
+    }
+
+    #[test]
+    fn no_votes_is_known_and_not_met() {
+        let status = compute_quorum(&tally(0, 0, 0, known(NETWORK_STAKE)));
+        match status {
+            QuorumStatus::Known {
+                participation_percent,
+                is_met,
+                ..
+            } => {
+                assert_eq!(participation_percent, 0.0);
+                assert!(!is_met);
+            }
+            QuorumStatus::Unknown { .. } => panic!("expected known"),
+        }
+        assert_eq!(
+            compute_outcome(&tally(0, 0, 0, known(NETWORK_STAKE))),
+            ProposalOutcome::Inconclusive
+        );
+    }
+
+    #[test]
+    fn abstain_counts_toward_quorum() {
+        let status = compute_quorum(&tally(0, 0, ONE_THIRD, known(NETWORK_STAKE)));
+        assert!(matches!(status, QuorumStatus::Known { is_met: true, .. }));
+    }
+
+    #[test]
+    fn quorum_is_met_exactly_at_one_third_and_not_just_below() {
+        let at = compute_quorum(&tally(ONE_THIRD, 0, 0, known(NETWORK_STAKE)));
+        let below = compute_quorum(&tally(ONE_THIRD - ONE_SOL, 0, 0, known(NETWORK_STAKE)));
+        assert!(matches!(at, QuorumStatus::Known { is_met: true, .. }));
+        assert!(matches!(below, QuorumStatus::Known { is_met: false, .. }));
+    }
+
+    #[test]
+    fn display_rounding_does_not_decide_a_borderline_vote() {
+        let below = compute_quorum(&tally(ONE_THIRD - ONE_SOL, 0, 0, known(NETWORK_STAKE)));
+        match below {
+            QuorumStatus::Known {
+                participation_percent,
+                is_met,
+                ..
+            } => {
+                assert_eq!(format!("{participation_percent:.2}"), "33.33");
+                assert!(!is_met);
+            }
+            QuorumStatus::Unknown { .. } => panic!("expected known"),
+        }
+    }
+
+    #[test]
+    fn all_three_buckets_count_as_participation() {
+        let status = compute_quorum(&tally(
+            NETWORK_STAKE / 2,
+            NETWORK_STAKE / 4,
+            NETWORK_STAKE / 8,
+            known(NETWORK_STAKE),
+        ));
+        match status {
+            QuorumStatus::Known {
+                participation_percent,
+                is_met,
+                ..
+            } => {
+                assert!((participation_percent - 87.5).abs() < 1e-9);
+                assert!(is_met);
+            }
+            QuorumStatus::Unknown { .. } => panic!("expected known"),
+        }
+    }
+
+    #[test]
+    fn two_thirds_of_participating_for_is_a_pass() {
+        // Quorum: all of network votes. Supermajority: exactly 2/3 For.
+        let passing = tally(
+            NETWORK_STAKE * 2 / 3,
+            NETWORK_STAKE / 3,
+            0,
+            known(NETWORK_STAKE),
+        );
+        assert_eq!(compute_outcome(&passing), ProposalOutcome::Passing);
+
+        let failing = tally(
+            NETWORK_STAKE * 2 / 3 - ONE_SOL,
+            NETWORK_STAKE / 3 + ONE_SOL,
+            0,
+            known(NETWORK_STAKE),
+        );
+        assert_eq!(compute_outcome(&failing), ProposalOutcome::Failing);
+    }
+
+    #[test]
+    fn abstain_sits_in_the_supermajority_denominator() {
+        // 60% For, 40% Abstain, no Against: would pass if Abstain were ignored,
+        // fails under the FAQ reading (2/3 of participating).
+        let tally = tally(
+            NETWORK_STAKE * 6 / 10,
+            0,
+            NETWORK_STAKE * 4 / 10,
+            known(NETWORK_STAKE),
+        );
+        assert!(matches!(
+            compute_quorum(&tally),
+            QuorumStatus::Known { is_met: true, .. }
+        ));
+        assert_eq!(compute_outcome(&tally), ProposalOutcome::Failing);
+    }
+
+    #[test]
+    fn unanimous_for_without_quorum_is_inconclusive_not_passing() {
+        // 100% For of a 10% turnout.
+        let tally = tally(NETWORK_STAKE / 10, 0, 0, known(NETWORK_STAKE));
+        assert_eq!(compute_outcome(&tally), ProposalOutcome::Inconclusive);
+    }
+
+    #[test]
+    fn screenshot_percentages_are_share_of_votes_cast() {
+        // From governance.solana.com/proposal/4aFA8K65zYZjmx16qaXhMLW9QY7URRvwyk4KQo2zLz8k
+        let for_lamports = 155_220_000 * LAMPORTS_PER_SOL;
+        let against_lamports = 367_701_08 * LAMPORTS_PER_SOL / 100; // 367,701.08 SOL
+        let abstain_lamports = 7_251_964_70 * LAMPORTS_PER_SOL / 100; // 7,251,964.70 SOL
+        let participating = for_lamports + against_lamports + abstain_lamports;
+        assert_eq!(
+            format!("{:.2}", percent(for_lamports, participating)),
+            "95.32"
+        );
+        assert_eq!(
+            format!("{:.2}", percent(against_lamports, participating)),
+            "0.23"
+        );
+        assert_eq!(
+            format!("{:.2}", percent(abstain_lamports, participating)),
+            "4.45"
+        );
+    }
+
+    #[test]
+    fn compact_sol_matches_the_website_thresholds() {
+        assert_eq!(
+            format_sol_display(433_490_000 * LAMPORTS_PER_SOL),
+            "433.49M SOL"
+        );
+        assert_eq!(
+            format_sol_display(155_220_000 * LAMPORTS_PER_SOL),
+            "155.22M SOL"
+        );
+        assert_eq!(
+            format_sol_display(367_701 * LAMPORTS_PER_SOL + LAMPORTS_PER_SOL * 8 / 100),
+            "367,701.08 SOL"
+        );
+        assert_eq!(format_sol_display(LAMPORTS_PER_SOL), "1.00 SOL");
+    }
+
+    #[test]
+    fn resolve_uses_the_total_only_when_the_slot_matches() {
+        let m = meta(500, Some(NETWORK_STAKE));
+        assert_eq!(resolve_quorum_denominator(Some(&m), 500), Ok(NETWORK_STAKE));
+        assert_eq!(
+            resolve_quorum_denominator(Some(&m), 499),
+            Err(DenominatorError::SlotMismatch {
+                meta_slot: 500,
+                proposal_slot: 499,
+            })
+        );
+        assert_eq!(
+            resolve_quorum_denominator(Some(&meta(500, None)), 500),
+            Err(DenominatorError::MissingTotal)
+        );
+        assert_eq!(
+            resolve_quorum_denominator(None, 500),
+            Err(DenominatorError::NoMeta)
+        );
+        assert_eq!(
+            resolve_quorum_denominator(Some(&meta(0, Some(1))), 0),
+            Err(DenominatorError::Unactivated)
+        );
+    }
+
+    #[test]
+    fn summary_names_quorum_and_outcome() {
+        let lines = breakdown_summary_lines(&tally(
+            NETWORK_STAKE / 2,
+            NETWORK_STAKE / 10,
+            0,
+            known(NETWORK_STAKE),
+        ));
+        assert!(lines.iter().any(|l| l.contains("quorum met")));
+        assert!(lines.iter().any(|l| l.contains("Passing")));
+        assert!(lines.iter().any(|l| l.contains("1/3 needed")));
+        assert!(lines.iter().any(|l| l.contains("2/3 needed")));
+    }
+
+    #[test]
+    fn summary_without_a_total_does_not_pretend_quorum_failed() {
+        let lines = breakdown_summary_lines(&tally(1, 0, 0, Err(DenominatorError::NoMeta)));
+        assert!(
+            lines
+                .iter()
+                .any(|l| l.contains("snapshot total unavailable"))
+        );
+        assert!(lines.iter().any(|l| l.contains("Unknown")));
+        assert!(!lines.iter().any(|l| l.contains("quorum met")));
+        assert!(!lines.iter().any(|l| l.contains("Failing")));
+    }
+
+    #[test]
+    fn list_summary_is_compact_outcome_and_stake() {
+        let passing = list_vote_summary(&tally(
+            NETWORK_STAKE / 2,
+            NETWORK_STAKE / 10,
+            0,
+            known(NETWORK_STAKE),
+        ));
+        assert_eq!(passing.outcome.short_label(), "Passing");
+        assert_eq!(passing.outcome.id(), "passing");
+        assert_eq!(passing.for_stake, "200.00M SOL");
+        assert_eq!(passing.against_stake, "40.00M SOL");
+        assert_eq!(passing.abstain_stake, "0.00 SOL");
+
+        let unknown = list_vote_summary(&tally(1, 0, 0, Err(DenominatorError::Unactivated)));
+        assert_eq!(unknown.outcome.short_label(), "—");
+        assert_eq!(unknown.outcome.id(), "unknown");
+
+        let no_quorum = list_vote_summary(&tally(NETWORK_STAKE / 10, 0, 0, known(NETWORK_STAKE)));
+        assert_eq!(no_quorum.outcome.short_label(), "Inconclusive");
+    }
+}

--- a/svmgov/cli/src/utils/utils.rs
+++ b/svmgov/cli/src/utils/utils.rs
@@ -72,8 +72,7 @@ pub async fn setup_all(
     Program<Arc<Keypair>>,
 )> {
     // Step 1: Signer, cluster and svmgov program
-    let (identity_keypair_arc, program, client) =
-        setup_signer_and_program(keypair_path, rpc_url)?;
+    let (identity_keypair_arc, program, client) = setup_signer_and_program(keypair_path, rpc_url)?;
 
     // Step 2: The merkle-proof (ncn-snapshot) program
     let merkle_proof_program = client.program(ncn_snapshot::id())?;

--- a/svmgov/cli/src/utils/votes.rs
+++ b/svmgov/cli/src/utils/votes.rs
@@ -58,6 +58,9 @@ pub struct VoteRecord {
     pub for_votes_bp: u64,
     pub against_votes_bp: u64,
     pub abstain_votes_bp: u64,
+    /// Snapshot stake attached to this vote. For validators this is
+    /// `Vote.stake` minus `Vote.override_lamports`, matching the weight that
+    /// actually votes with the validator's split.
     pub stake_lamports: u64,
     pub timestamp: i64,
 }
@@ -71,7 +74,7 @@ impl VoteRecord {
             for_votes_bp: vote.for_votes_bp,
             against_votes_bp: vote.against_votes_bp,
             abstain_votes_bp: vote.abstain_votes_bp,
-            stake_lamports: vote.stake,
+            stake_lamports: vote.stake.saturating_sub(vote.override_lamports),
             timestamp: vote.vote_timestamp,
         }
     }
@@ -369,6 +372,14 @@ mod tests {
         assert_eq!(record.abstain_votes_bp, 1_000);
         assert_eq!(record.stake_lamports, 42);
         assert_eq!(record.timestamp, 1_700_000_000);
+    }
+
+    #[test]
+    fn from_vote_excludes_overridden_stake() {
+        let mut vote = sample_vote(pubkey(7));
+        vote.stake = 100;
+        vote.override_lamports = 30;
+        assert_eq!(VoteRecord::from_vote(&vote).stake_lamports, 70);
     }
 
     #[test]

--- a/svmgov/cli/src/utils/votes.rs
+++ b/svmgov/cli/src/utils/votes.rs
@@ -1,0 +1,473 @@
+//! Individual votes on a proposal, for display by the CLI.
+//!
+//! The proposal detail view (`svmgov proposal`) only had aggregate For / Against
+//! / Abstain totals. Who cast those votes lives on `Vote` (validator) and
+//! `VoteOverride` (staker) accounts, filtered on-chain by the proposal pubkey.
+//! This module maps those accounts into plain [`VoteRecord`]s and renders them
+//! as a table — the mapping is unit-testable without an RPC.
+
+use std::cmp::Ordering;
+
+use anchor_client::solana_account_decoder::UiAccountEncoding;
+use anchor_client::solana_client::nonblocking::rpc_client::RpcClient;
+use anchor_client::solana_client::rpc_config::{RpcAccountInfoConfig, RpcProgramAccountsConfig};
+use anchor_client::solana_client::rpc_filter::{Memcmp, RpcFilterType};
+use anchor_client::solana_sdk::commitment_config::CommitmentConfig;
+use anchor_client::solana_sdk::native_token::LAMPORTS_PER_SOL;
+use anchor_lang::{AccountDeserialize, Discriminator, prelude::Pubkey};
+use anyhow::{Result, anyhow};
+use chrono::TimeZone;
+use chrono::Utc;
+use comfy_table::modifiers::UTF8_ROUND_CORNERS;
+use comfy_table::{Cell, CellAlignment, Table, presets::UTF8_FULL};
+
+use crate::svmgov_program::accounts::{Vote, VoteOverride};
+
+/// Byte offset of `Vote.proposal`: 8-byte discriminator + 32-byte validator.
+pub const VOTE_PROPOSAL_OFFSET: usize = 40;
+
+/// Byte offset of `VoteOverride.proposal`: 8-byte discriminator + three pubkeys
+/// (delegator, stake_account, validator).
+pub const VOTE_OVERRIDE_PROPOSAL_OFFSET: usize = 104;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum VoterKind {
+    Validator,
+    Staker,
+}
+
+impl VoterKind {
+    pub fn label(self) -> &'static str {
+        match self {
+            VoterKind::Validator => "Validator",
+            VoterKind::Staker => "Staker",
+        }
+    }
+}
+
+/// One row in the proposal votes table. Copied off the on-chain account so
+/// formatting and sorting do not depend on the generated types.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct VoteRecord {
+    /// Validator identity (voting wallet) for validator votes; delegator for
+    /// staker overrides.
+    pub voter: String,
+    pub kind: VoterKind,
+    /// Present only for staker overrides: the stake account that voted.
+    pub stake_account: Option<String>,
+    pub for_votes_bp: u64,
+    pub against_votes_bp: u64,
+    pub abstain_votes_bp: u64,
+    pub stake_lamports: u64,
+    pub timestamp: i64,
+}
+
+impl VoteRecord {
+    pub fn from_vote(vote: &Vote) -> Self {
+        Self {
+            voter: vote.validator.to_string(),
+            kind: VoterKind::Validator,
+            stake_account: None,
+            for_votes_bp: vote.for_votes_bp,
+            against_votes_bp: vote.against_votes_bp,
+            abstain_votes_bp: vote.abstain_votes_bp,
+            stake_lamports: vote.stake,
+            timestamp: vote.vote_timestamp,
+        }
+    }
+
+    pub fn from_override(vote: &VoteOverride) -> Self {
+        Self {
+            voter: vote.delegator.to_string(),
+            kind: VoterKind::Staker,
+            stake_account: Some(vote.stake_account.to_string()),
+            for_votes_bp: vote.for_votes_bp,
+            against_votes_bp: vote.against_votes_bp,
+            abstain_votes_bp: vote.abstain_votes_bp,
+            stake_lamports: vote.stake_amount,
+            timestamp: vote.vote_override_timestamp,
+        }
+    }
+}
+
+pub fn format_basis_points(bp: u64) -> String {
+    format!("{:.2}%", bp as f64 / 100.0)
+}
+
+pub fn format_stake_sol(lamports: u64) -> String {
+    format!("{:.2} SOL", lamports as f64 / LAMPORTS_PER_SOL as f64)
+}
+
+pub fn format_vote_timestamp(ts: i64) -> String {
+    Utc.timestamp_opt(ts, 0)
+        .single()
+        .map(|dt| dt.format("%Y-%m-%d %H:%M UTC").to_string())
+        .unwrap_or_else(|| ts.to_string())
+}
+
+/// Highest stake first, then voter, then stake account so equal-stake rows are
+/// stable across runs.
+pub fn sort_vote_records(records: &mut [VoteRecord]) {
+    records.sort_by(|a, b| {
+        b.stake_lamports
+            .cmp(&a.stake_lamports)
+            .then_with(|| a.voter.cmp(&b.voter))
+            .then_with(|| match (&a.stake_account, &b.stake_account) {
+                (None, None) => Ordering::Equal,
+                (None, Some(_)) => Ordering::Less,
+                (Some(_), None) => Ordering::Greater,
+                (Some(x), Some(y)) => x.cmp(y),
+            })
+    });
+}
+
+pub fn votes_summary(records: &[VoteRecord]) -> String {
+    let validators = records
+        .iter()
+        .filter(|r| r.kind == VoterKind::Validator)
+        .count();
+    let stakers = records.len().saturating_sub(validators);
+    match (validators, stakers) {
+        (0, 0) => "No votes have been cast on this proposal.".to_string(),
+        (v, 0) => format!("Votes ({} validator{}):", v, plural(v)),
+        (0, s) => format!("Votes ({} staker override{}):", s, plural(s)),
+        (v, s) => format!(
+            "Votes ({} validator{}, {} staker override{}):",
+            v,
+            plural(v),
+            s,
+            plural(s)
+        ),
+    }
+}
+
+fn plural(n: usize) -> &'static str {
+    if n == 1 { "" } else { "s" }
+}
+
+pub fn vote_row_cells(record: &VoteRecord) -> [String; 8] {
+    [
+        record.voter.clone(),
+        record.kind.label().to_string(),
+        record
+            .stake_account
+            .clone()
+            .unwrap_or_else(|| "—".to_string()),
+        format_stake_sol(record.stake_lamports),
+        format_basis_points(record.for_votes_bp),
+        format_basis_points(record.against_votes_bp),
+        format_basis_points(record.abstain_votes_bp),
+        format_vote_timestamp(record.timestamp),
+    ]
+}
+
+pub fn print_votes_table(records: &[VoteRecord], terminal_width: u16) {
+    println!("\n{}", votes_summary(records));
+    if records.is_empty() {
+        return;
+    }
+
+    let mut table = Table::new();
+    table
+        .load_preset(UTF8_FULL)
+        .apply_modifier(UTF8_ROUND_CORNERS)
+        .set_width(terminal_width);
+
+    table.set_header(vec![
+        "Voter",
+        "Type",
+        "Stake Account",
+        "Stake",
+        "For",
+        "Against",
+        "Abstain",
+        "Date",
+    ]);
+
+    // Full pubkeys wrap into unreadable fragments unless the columns keep
+    // content width, matching the proposal-list ID column.
+    for column in [0, 2] {
+        if let Some(col) = table.column_mut(column) {
+            col.set_constraint(comfy_table::ColumnConstraint::ContentWidth);
+        }
+    }
+
+    for record in records {
+        let cells = vote_row_cells(record);
+        table.add_row(vec![
+            Cell::new(&cells[0]),
+            Cell::new(&cells[1]),
+            Cell::new(&cells[2]),
+            Cell::new(&cells[3]).set_alignment(CellAlignment::Right),
+            Cell::new(&cells[4]).set_alignment(CellAlignment::Right),
+            Cell::new(&cells[5]).set_alignment(CellAlignment::Right),
+            Cell::new(&cells[6]).set_alignment(CellAlignment::Right),
+            Cell::new(&cells[7]),
+        ]);
+    }
+
+    println!("{}", table);
+}
+
+/// Fetch validator votes and staker overrides for `proposal`, mapped into
+/// [`VoteRecord`]s. Does not sort — call [`sort_vote_records`] before display.
+pub async fn fetch_vote_records(
+    rpc: &RpcClient,
+    program_id: &Pubkey,
+    proposal: &Pubkey,
+) -> Result<Vec<VoteRecord>> {
+    let votes = fetch_program_accounts::<Vote>(rpc, program_id, VOTE_PROPOSAL_OFFSET, proposal)
+        .await?
+        .into_iter()
+        .map(|(_, vote)| VoteRecord::from_vote(&vote));
+
+    let overrides = fetch_program_accounts::<VoteOverride>(
+        rpc,
+        program_id,
+        VOTE_OVERRIDE_PROPOSAL_OFFSET,
+        proposal,
+    )
+    .await?
+    .into_iter()
+    .map(|(_, vote)| VoteRecord::from_override(&vote));
+
+    Ok(votes.chain(overrides).collect())
+}
+
+async fn fetch_program_accounts<T: AccountDeserialize + Discriminator>(
+    rpc: &RpcClient,
+    program_id: &Pubkey,
+    proposal_offset: usize,
+    proposal: &Pubkey,
+) -> Result<Vec<(Pubkey, T)>> {
+    let config = RpcProgramAccountsConfig {
+        filters: Some(vec![
+            RpcFilterType::Memcmp(Memcmp::new_raw_bytes(0, T::DISCRIMINATOR.to_vec())),
+            RpcFilterType::Memcmp(Memcmp::new_raw_bytes(
+                proposal_offset,
+                proposal.to_bytes().to_vec(),
+            )),
+        ]),
+        account_config: RpcAccountInfoConfig {
+            encoding: Some(UiAccountEncoding::Base64),
+            commitment: Some(CommitmentConfig::confirmed()),
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+
+    let accounts = rpc
+        .get_program_accounts_with_config(program_id, config)
+        .await
+        .map_err(|e| anyhow!("Failed to fetch vote accounts: {}", e))?;
+
+    Ok(accounts
+        .into_iter()
+        .filter_map(
+            |(pubkey, account)| match T::try_deserialize(&mut account.data.as_slice()) {
+                Ok(parsed) => Some((pubkey, parsed)),
+                Err(e) => {
+                    log::warn!("Failed to deserialize vote account {}: {}", pubkey, e);
+                    None
+                }
+            },
+        )
+        .collect())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use anchor_lang::AnchorSerialize;
+
+    fn pubkey(byte: u8) -> Pubkey {
+        Pubkey::new_from_array([byte; 32])
+    }
+
+    fn record(voter: &str, kind: VoterKind, stake: u64) -> VoteRecord {
+        VoteRecord {
+            voter: voter.to_string(),
+            kind,
+            stake_account: None,
+            for_votes_bp: 10_000,
+            against_votes_bp: 0,
+            abstain_votes_bp: 0,
+            stake_lamports: stake,
+            timestamp: 1_700_000_000,
+        }
+    }
+
+    fn sample_vote(proposal: Pubkey) -> Vote {
+        Vote {
+            validator: pubkey(1),
+            proposal,
+            for_votes_bp: 6_000,
+            against_votes_bp: 3_000,
+            abstain_votes_bp: 1_000,
+            for_votes_lamports: 6,
+            against_votes_lamports: 3,
+            abstain_votes_lamports: 1,
+            stake: 42,
+            override_lamports: 0,
+            vote_timestamp: 1_700_000_000,
+            bump: 255,
+        }
+    }
+
+    fn sample_override(proposal: Pubkey) -> VoteOverride {
+        VoteOverride {
+            delegator: pubkey(2),
+            stake_account: pubkey(3),
+            validator: pubkey(4),
+            proposal,
+            vote_account_validator: pubkey(5),
+            for_votes_bp: 10_000,
+            against_votes_bp: 0,
+            abstain_votes_bp: 0,
+            for_votes_lamports: 10,
+            against_votes_lamports: 0,
+            abstain_votes_lamports: 0,
+            stake_amount: 7,
+            vote_override_timestamp: 1_700_000_100,
+            bump: 254,
+        }
+    }
+
+    #[test]
+    fn vote_proposal_offset_matches_serialized_account() {
+        let proposal = pubkey(7);
+        let vote = sample_vote(proposal);
+        let mut data = Vote::DISCRIMINATOR.to_vec();
+        vote.serialize(&mut data).unwrap();
+        assert_eq!(
+            &data[VOTE_PROPOSAL_OFFSET..VOTE_PROPOSAL_OFFSET + 32],
+            proposal.as_ref()
+        );
+    }
+
+    #[test]
+    fn vote_override_proposal_offset_matches_serialized_account() {
+        let proposal = pubkey(9);
+        let vote = sample_override(proposal);
+        let mut data = VoteOverride::DISCRIMINATOR.to_vec();
+        vote.serialize(&mut data).unwrap();
+        assert_eq!(
+            &data[VOTE_OVERRIDE_PROPOSAL_OFFSET..VOTE_OVERRIDE_PROPOSAL_OFFSET + 32],
+            proposal.as_ref()
+        );
+    }
+
+    #[test]
+    fn from_vote_maps_validator_identity_and_split() {
+        let vote = sample_vote(pubkey(7));
+        let record = VoteRecord::from_vote(&vote);
+        assert_eq!(record.voter, pubkey(1).to_string());
+        assert_eq!(record.kind, VoterKind::Validator);
+        assert_eq!(record.stake_account, None);
+        assert_eq!(record.for_votes_bp, 6_000);
+        assert_eq!(record.against_votes_bp, 3_000);
+        assert_eq!(record.abstain_votes_bp, 1_000);
+        assert_eq!(record.stake_lamports, 42);
+        assert_eq!(record.timestamp, 1_700_000_000);
+    }
+
+    #[test]
+    fn from_override_maps_delegator_and_stake_account() {
+        let vote = sample_override(pubkey(9));
+        let record = VoteRecord::from_override(&vote);
+        assert_eq!(record.voter, pubkey(2).to_string());
+        assert_eq!(record.kind, VoterKind::Staker);
+        assert_eq!(record.stake_account, Some(pubkey(3).to_string()));
+        assert_eq!(record.for_votes_bp, 10_000);
+        assert_eq!(record.stake_lamports, 7);
+        assert_eq!(record.timestamp, 1_700_000_100);
+    }
+
+    #[test]
+    fn basis_points_render_as_percentages() {
+        assert_eq!(format_basis_points(0), "0.00%");
+        assert_eq!(format_basis_points(6_000), "60.00%");
+        assert_eq!(format_basis_points(10_000), "100.00%");
+        assert_eq!(format_basis_points(1), "0.01%");
+    }
+
+    #[test]
+    fn stake_renders_in_sol() {
+        assert_eq!(format_stake_sol(0), "0.00 SOL");
+        assert_eq!(format_stake_sol(LAMPORTS_PER_SOL), "1.00 SOL");
+        assert_eq!(format_stake_sol(1_500_000_000), "1.50 SOL");
+    }
+
+    #[test]
+    fn timestamp_renders_in_utc() {
+        assert_eq!(format_vote_timestamp(0), "1970-01-01 00:00 UTC");
+        assert_eq!(format_vote_timestamp(1_700_000_000), "2023-11-14 22:13 UTC");
+    }
+
+    #[test]
+    fn sort_puts_highest_stake_first_and_breaks_ties_by_voter() {
+        let mut records = vec![
+            record("b", VoterKind::Validator, 100),
+            record("a", VoterKind::Validator, 100),
+            record("c", VoterKind::Staker, 500),
+            record("d", VoterKind::Validator, 50),
+        ];
+        sort_vote_records(&mut records);
+        let order: Vec<&str> = records.iter().map(|r| r.voter.as_str()).collect();
+        assert_eq!(order, vec!["c", "a", "b", "d"]);
+    }
+
+    #[test]
+    fn summary_names_validators_and_staker_overrides() {
+        assert_eq!(
+            votes_summary(&[]),
+            "No votes have been cast on this proposal."
+        );
+        assert_eq!(
+            votes_summary(&[record("a", VoterKind::Validator, 1)]),
+            "Votes (1 validator):"
+        );
+        assert_eq!(
+            votes_summary(&[
+                record("a", VoterKind::Validator, 1),
+                record("b", VoterKind::Validator, 2),
+            ]),
+            "Votes (2 validators):"
+        );
+        assert_eq!(
+            votes_summary(&[record("a", VoterKind::Staker, 1)]),
+            "Votes (1 staker override):"
+        );
+        assert_eq!(
+            votes_summary(&[
+                record("a", VoterKind::Validator, 1),
+                record("b", VoterKind::Staker, 2),
+                record("c", VoterKind::Staker, 3),
+            ]),
+            "Votes (1 validator, 2 staker overrides):"
+        );
+    }
+
+    #[test]
+    fn row_cells_show_who_voted_and_the_split() {
+        let vote = VoteRecord::from_vote(&sample_vote(pubkey(7)));
+        let cells = vote_row_cells(&vote);
+        assert_eq!(cells[0], pubkey(1).to_string());
+        assert_eq!(cells[1], "Validator");
+        assert_eq!(cells[2], "—");
+        assert_eq!(cells[3], "0.00 SOL");
+        assert_eq!(cells[4], "60.00%");
+        assert_eq!(cells[5], "30.00%");
+        assert_eq!(cells[6], "10.00%");
+        assert_eq!(cells[7], "2023-11-14 22:13 UTC");
+
+        let staker = VoteRecord::from_override(&sample_override(pubkey(9)));
+        let cells = vote_row_cells(&staker);
+        assert_eq!(cells[0], pubkey(2).to_string());
+        assert_eq!(cells[1], "Staker");
+        assert_eq!(cells[2], pubkey(3).to_string());
+        assert_eq!(cells[4], "100.00%");
+        assert_eq!(cells[5], "0.00%");
+        assert_eq!(cells[6], "0.00%");
+    }
+}


### PR DESCRIPTION
I clanked CLI output of votes and vote status:
<img width="2700" height="1308" alt="image" src="https://github.com/user-attachments/assets/127317f8-a1eb-4042-a2ef-7e9e9f3fd224" />

The `list-proposal` command also shows proposal status:
<img width="1169" height="260" alt="image" src="https://github.com/user-attachments/assets/1f9caa5f-05e4-4946-8933-ed7878e80947" />

LMK if this is something we would like to see and if you have any feedback. Open to making changes to improve the CLI output.