### PR TITLE
fix(verifier): Name the Columns SQL Reads Select

### DIFF
--- a/ncn/verifier-service/src/database/operations.rs
+++ b/ncn/verifier-service/src/database/operations.rs
@@ -7,6 +7,7 @@ use tracing::debug;
 use tracing::info;
 
 use super::models::*;
+use super::sql::{SNAPSHOT_META_COLUMNS, STAKE_ACCOUNT_COLUMNS, VOTE_ACCOUNT_COLUMNS};
 
 /// Database operations for vote accounts
 impl VoteAccountRecord {
@@ -91,10 +92,10 @@ impl VoteAccountRecord {
         vote_account: &str,
         snapshot_slot: u64,
     ) -> Result<Option<VoteAccountRecord>> {
-        let row_opt = sqlx::query(
-            "SELECT * FROM vote_accounts \
-                   WHERE network = ? AND vote_account = ? AND snapshot_slot = ?",
-        )
+        let row_opt = sqlx::query(&format!(
+            "SELECT {VOTE_ACCOUNT_COLUMNS} FROM vote_accounts \
+             WHERE network = ? AND vote_account = ? AND snapshot_slot = ?"
+        ))
         .bind(network)
         .bind(vote_account)
         .bind(i64::try_from(snapshot_slot)?)
@@ -203,10 +204,10 @@ impl StakeAccountRecord {
         stake_account: &str,
         snapshot_slot: u64,
     ) -> Result<Option<StakeAccountRecord>> {
-        let row_opt = sqlx::query(
-            "SELECT * FROM stake_accounts \
-                   WHERE network = ? AND stake_account = ? AND snapshot_slot = ?",
-        )
+        let row_opt = sqlx::query(&format!(
+            "SELECT {STAKE_ACCOUNT_COLUMNS} FROM stake_accounts \
+             WHERE network = ? AND stake_account = ? AND snapshot_slot = ?"
+        ))
         .bind(network)
         .bind(stake_account)
         .bind(i64::try_from(snapshot_slot)?)
@@ -269,10 +270,10 @@ impl SnapshotMetaRecord {
         pool: &SqlitePool,
         network: &str,
     ) -> Result<Option<SnapshotMetaRecord>> {
-        let row_opt = sqlx::query(
-            "SELECT * FROM snapshot_meta
-             WHERE network = ? ORDER BY slot DESC LIMIT 1",
-        )
+        let row_opt = sqlx::query(&format!(
+            "SELECT {SNAPSHOT_META_COLUMNS} FROM snapshot_meta \
+             WHERE network = ? ORDER BY slot DESC LIMIT 1"
+        ))
         .bind(network)
         .fetch_optional(pool)
         .await?;

--- a/ncn/verifier-service/src/database/sql.rs
+++ b/ncn/verifier-service/src/database/sql.rs
@@ -8,6 +8,18 @@ CREATE TABLE IF NOT EXISTS schema_migrations (
 )
 "#;
 
+/// Columns of `vote_accounts`, in declaration order.
+///
+/// Reads name these rather than using `SELECT *`. A `SELECT *` returns whatever
+/// the connection last saw, so a column added by a migration can leave a read
+/// resolving a name to an index past the end of the row — an out-of-bounds
+/// panic rather than an error. Naming them also means a column this list
+/// forgets fails loudly on the missing name.
+///
+/// `vote_account_columns_match_the_table` keeps this in step with the table.
+pub const VOTE_ACCOUNT_COLUMNS: &str = "network, snapshot_slot, vote_account, voting_wallet, \
+                                        stake_merkle_root, active_stake, meta_merkle_proof";
+
 pub const CREATE_VOTE_ACCOUNTS_TABLE_SQL: &str = r#"
 CREATE TABLE vote_accounts (
     network TEXT NOT NULL,
@@ -21,6 +33,10 @@ CREATE TABLE vote_accounts (
 )
 "#;
 
+/// Columns of `stake_accounts`, in declaration order. See [`VOTE_ACCOUNT_COLUMNS`].
+pub const STAKE_ACCOUNT_COLUMNS: &str = "network, snapshot_slot, stake_account, vote_account, \
+                                         voting_wallet, active_stake, stake_merkle_proof";
+
 pub const CREATE_STAKE_ACCOUNTS_TABLE_SQL: &str = r#"
 CREATE TABLE stake_accounts (
     network TEXT NOT NULL,
@@ -33,6 +49,10 @@ CREATE TABLE stake_accounts (
     PRIMARY KEY (network, stake_account, snapshot_slot)
 )
 "#;
+
+/// Columns of `snapshot_meta`, in declaration order. See [`VOTE_ACCOUNT_COLUMNS`].
+pub const SNAPSHOT_META_COLUMNS: &str = "network, slot, merkle_root, snapshot_hash, created_at, \
+                                         total_active_stake";
 
 pub const CREATE_SNAPSHOT_META_TABLE_SQL: &str = r#"
 CREATE TABLE snapshot_meta (
@@ -62,3 +82,51 @@ pub const CREATE_DB_INDEXES: &[&str] = &[
 /// checks `pragma_table_info` before running this.
 pub const ADD_SNAPSHOT_TOTAL_ACTIVE_STAKE_SQL: &str =
     "ALTER TABLE snapshot_meta ADD COLUMN total_active_stake INTEGER";
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use sqlx::SqlitePool;
+
+    /// Column names SQLite reports for `table`, in declaration order.
+    async fn actual_columns(create_sql: &str, table: &str) -> Vec<String> {
+        let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
+        sqlx::query(create_sql).execute(&pool).await.unwrap();
+        sqlx::query_scalar::<_, String>(&format!(
+            "SELECT name FROM pragma_table_info('{table}') ORDER BY cid"
+        ))
+        .fetch_all(&pool)
+        .await
+        .unwrap()
+    }
+
+    fn listed(columns: &str) -> Vec<String> {
+        columns.split(',').map(|c| c.trim().to_string()).collect()
+    }
+
+    /// A migration that adds a column without extending the list would otherwise
+    /// only surface when a read asks for the missing name at runtime.
+    #[tokio::test]
+    async fn vote_account_columns_match_the_table() {
+        assert_eq!(
+            listed(VOTE_ACCOUNT_COLUMNS),
+            actual_columns(CREATE_VOTE_ACCOUNTS_TABLE_SQL, "vote_accounts").await
+        );
+    }
+
+    #[tokio::test]
+    async fn stake_account_columns_match_the_table() {
+        assert_eq!(
+            listed(STAKE_ACCOUNT_COLUMNS),
+            actual_columns(CREATE_STAKE_ACCOUNTS_TABLE_SQL, "stake_accounts").await
+        );
+    }
+
+    #[tokio::test]
+    async fn snapshot_meta_columns_match_the_table() {
+        assert_eq!(
+            listed(SNAPSHOT_META_COLUMNS),
+            actual_columns(CREATE_SNAPSHOT_META_TABLE_SQL, "snapshot_meta").await
+        );
+    }
+}


### PR DESCRIPTION
## TLDR

This PR closes #161. The three record reads named no columns, so schema skew became an out-of-bounds panic instead of a clean error

## Problem

`VoteAccountRecord::get_by_account`, `StakeAccountRecord::get_by_account` and `SnapshotMetaRecord::get_latest` all used `SELECT *` with `row.get("column_name")`

A `SELECT *` returns whatever column set the connection last saw. After an `ALTER TABLE`, a read can resolve a column name to an index past the end of the row, which is an out-of-bounds panic in the sqlx worker, and not an error

## Changes

- `VOTE_ACCOUNT_COLUMNS`, `STAKE_ACCOUNT_COLUMNS`, `SNAPSHOT_META_COLUMNS` in `sql.rs`, each directly above the `CREATE TABLE` it describes
- the three reads select those columns instead of `*`

## Why constants rather than inline lists

[#182](https://github.com/solana-foundation/solana-governance/pull/182) took the inline approach, which fixes the panic but leaves each list as a second copy of the schema with nothing keeping the two in step. Putting them next to the table definition makes the schema and its reads one source of truth, and lets a test enforce it

## Tests

One per table, asserting the list matches `pragma_table_info` in declaration order. I verified they catch the real mistake by adding a column to a `CREATE TABLE` without extending the list:

```
assertion `left == right` failed
  left:  [..., "created_at", "total_active_stake"]
  right: [..., "created_at", "newly_added_column", "total_active_stake"]
```

Without this, a forgotten column only surfaces when a read asks for the missing name at runtime

`45 passed` (38 unit + 5 e2e + 2), clippy and fmt clean on the touched files. The e2e suite exercises all three reads end to end via `/proof/vote_account`, `/proof/stake_account` and `/meta`