### PR TITLE
fix(frontend): Key `epochToDate` on the Epoch and Not the Slot

### DIFF
--- a/frontend/src/hooks/__tests__/useEpochToDate.test.tsx
+++ b/frontend/src/hooks/__tests__/useEpochToDate.test.tsx
@@ -1,0 +1,103 @@
+import * as React from "react";
+import { renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+
+const mockEpochToDate = jest.fn();
+const mockUseEpochInfo = jest.fn();
+
+// EndpointContext reaches env.ts, an ESM-only package Jest does not transform.
+jest.mock("@/contexts/EndpointContext", () => ({
+  useEndpoint: () => ({ endpointUrl: "http://localhost:8899" }),
+}));
+jest.mock("@/helpers/date", () => ({
+  epochToDate: (...args: unknown[]) => mockEpochToDate(...args),
+}));
+jest.mock("../useEpochInfo", () => ({
+  useEpochInfo: () => mockUseEpochInfo(),
+}));
+
+import { useEpochToDate } from "../useEpochToDate";
+
+const TARGET_EPOCH = 1024;
+
+function epochInfo(epoch: number, absoluteSlot: number) {
+  return {
+    data: {
+      epochInfo: { epoch, absoluteSlot, slotIndex: 0, slotsInEpoch: 432_000 },
+      epochSchedule: { getFirstSlotInEpoch: () => absoluteSlot + 1_000 },
+    },
+    isLoading: false,
+  };
+}
+
+/** One client for the whole render, so the cache survives rerenders. */
+function makeWrapper() {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return (
+      <QueryClientProvider client={client}>{children}</QueryClientProvider>
+    );
+  };
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockEpochToDate.mockResolvedValue(new Date("2026-09-01T00:00:00Z"));
+});
+
+describe("useEpochToDate", () => {
+  it("does not recompute when only the slot advances", async () => {
+    // The reported bug: absoluteSlot was in the query key, so every refresh of
+    // useEpochInfo produced a new cache entry instead of reusing one. Each was a
+    // fresh miss, so staleTime never applied and epochToDate — which makes one
+    // or two RPC calls — ran again for an answer that had not changed.
+    mockUseEpochInfo.mockReturnValue(epochInfo(1020, 500_000_000));
+
+    const { rerender } = renderHook(() => useEpochToDate(TARGET_EPOCH), {
+      wrapper: makeWrapper(),
+    });
+
+    await waitFor(() => expect(mockEpochToDate).toHaveBeenCalledTimes(1));
+
+    // Same epoch, later slot — what a useEpochInfo refetch looks like.
+    mockUseEpochInfo.mockReturnValue(epochInfo(1020, 500_000_750));
+    rerender();
+    mockUseEpochInfo.mockReturnValue(epochInfo(1020, 500_001_500));
+    rerender();
+
+    await waitFor(() => expect(mockEpochToDate).toHaveBeenCalledTimes(1));
+  });
+
+  it("recomputes when the epoch rolls over", async () => {
+    // The projection reads the epoch's actual block time once the target is no
+    // longer in the future, so a rollover must not wait for the interval.
+    mockUseEpochInfo.mockReturnValue(epochInfo(1020, 500_000_000));
+
+    const { rerender } = renderHook(() => useEpochToDate(TARGET_EPOCH), {
+      wrapper: makeWrapper(),
+    });
+
+    await waitFor(() => expect(mockEpochToDate).toHaveBeenCalledTimes(1));
+
+    mockUseEpochInfo.mockReturnValue(epochInfo(1021, 500_432_000));
+    rerender();
+
+    await waitFor(() => expect(mockEpochToDate).toHaveBeenCalledTimes(2));
+  });
+
+  it("computes separately for each target epoch", async () => {
+    // A proposal detail page mounts three of these, one per phase boundary.
+    mockUseEpochInfo.mockReturnValue(epochInfo(1020, 500_000_000));
+    const wrapper = makeWrapper();
+
+    renderHook(() => useEpochToDate(1021), { wrapper });
+    renderHook(() => useEpochToDate(1024), { wrapper });
+
+    await waitFor(() => expect(mockEpochToDate).toHaveBeenCalledTimes(2));
+    expect(mockEpochToDate.mock.calls.map((call) => call[0])).toEqual([
+      1021, 1024,
+    ]);
+  });
+});

--- a/frontend/src/hooks/useEpochToDate.ts
+++ b/frontend/src/hooks/useEpochToDate.ts
@@ -3,6 +3,9 @@ import { useEndpoint } from "@/contexts/EndpointContext";
 import { epochToDate } from "@/helpers/date";
 import { useEpochInfo } from "./useEpochInfo";
 
+/** How often the projection is redone to pick up a changed slot rate. */
+const EPOCH_TO_DATE_REFRESH_MS = 5 * 60 * 1000;
+
 /**
  * Hook to convert a Solana epoch number to a Date
  * @param epoch - The epoch number to convert
@@ -13,23 +16,32 @@ export function useEpochToDate(epoch: number | undefined) {
   const { data: epochData, isLoading: isLoadingEpochInfo } = useEpochInfo();
 
   return useQuery({
-    queryKey: [
-      "epochToDate",
-      epoch,
-      endpointUrl,
-      epochData?.epochInfo.absoluteSlot,
-    ],
+    // Keyed on the current epoch, not the current slot. `absoluteSlot` advances
+    // constantly, so keying on it made every refresh a new cache entry rather
+    // than a refetch: `staleTime` never applied, remounts always re-fetched, and
+    // superseded entries piled up until garbage collection.
+    //
+    // The projection still has to be redone periodically — that is what
+    // `refetchInterval` is for, and it recomputes in place. Including the epoch
+    // covers the one input change the interval should not wait for: once the
+    // target epoch is no longer in the future, `epochToDate` switches from
+    // projecting to reading the epoch's actual block time.
+    queryKey: ["epochToDate", epoch, endpointUrl, epochData?.epochInfo.epoch],
     queryFn: async () => {
       if (epoch === undefined || !epochData) return null;
       return epochToDate(
         epoch,
         epochData.epochInfo,
         epochData.epochSchedule,
-        endpointUrl
+        endpointUrl,
       );
     },
     enabled: epoch !== undefined && !isLoadingEpochInfo && !!epochData,
-    staleTime: 5 * 60 * 1000, // 5 minutes - epoch info doesn't change frequently
+    // Matches the cadence the slot-keyed version refreshed at in practice, since
+    // it re-ran whenever useEpochInfo refetched. Each run re-reads the recent
+    // slot rate, which is what keeps a multi-day countdown from drifting.
+    staleTime: EPOCH_TO_DATE_REFRESH_MS,
+    refetchInterval: EPOCH_TO_DATE_REFRESH_MS,
     refetchOnWindowFocus: false,
   });
 }

--- a/frontend/src/hooks/useEpochToDate.ts
+++ b/frontend/src/hooks/useEpochToDate.ts
@@ -16,16 +16,11 @@ export function useEpochToDate(epoch: number | undefined) {
   const { data: epochData, isLoading: isLoadingEpochInfo } = useEpochInfo();
 
   return useQuery({
-    // Keyed on the current epoch, not the current slot. `absoluteSlot` advances
-    // constantly, so keying on it made every refresh a new cache entry rather
-    // than a refetch: `staleTime` never applied, remounts always re-fetched, and
-    // superseded entries piled up until garbage collection.
-    //
-    // The projection still has to be redone periodically — that is what
-    // `refetchInterval` is for, and it recomputes in place. Including the epoch
-    // covers the one input change the interval should not wait for: once the
-    // target epoch is no longer in the future, `epochToDate` switches from
-    // projecting to reading the epoch's actual block time.
+    // The epoch, not `absoluteSlot`: a key that moves every refresh makes each
+    // one a new cache entry rather than a refetch, so `staleTime` never applies.
+    // The epoch still belongs here because `epochToDate` switches from
+    // projecting to reading actual block time once the target is no longer
+    // ahead, which should not wait for the interval below.
     queryKey: ["epochToDate", epoch, endpointUrl, epochData?.epochInfo.epoch],
     queryFn: async () => {
       if (epoch === undefined || !epochData) return null;
@@ -37,9 +32,8 @@ export function useEpochToDate(epoch: number | undefined) {
       );
     },
     enabled: epoch !== undefined && !isLoadingEpochInfo && !!epochData,
-    // Matches the cadence the slot-keyed version refreshed at in practice, since
-    // it re-ran whenever useEpochInfo refetched. Each run re-reads the recent
-    // slot rate, which is what keeps a multi-day countdown from drifting.
+    // Refetching in place keeps the cadence the slot-keyed version reached by
+    // accident, without minting an entry each time.
     staleTime: EPOCH_TO_DATE_REFRESH_MS,
     refetchInterval: EPOCH_TO_DATE_REFRESH_MS,
     refetchOnWindowFocus: false,

--- a/frontend/src/hooks/useEpochToDate.ts
+++ b/frontend/src/hooks/useEpochToDate.ts
@@ -16,11 +16,6 @@ export function useEpochToDate(epoch: number | undefined) {
   const { data: epochData, isLoading: isLoadingEpochInfo } = useEpochInfo();
 
   return useQuery({
-    // The epoch, not `absoluteSlot`: a key that moves every refresh makes each
-    // one a new cache entry rather than a refetch, so `staleTime` never applies.
-    // The epoch still belongs here because `epochToDate` switches from
-    // projecting to reading actual block time once the target is no longer
-    // ahead, which should not wait for the interval below.
     queryKey: ["epochToDate", epoch, endpointUrl, epochData?.epochInfo.epoch],
     queryFn: async () => {
       if (epoch === undefined || !epochData) return null;
@@ -32,8 +27,6 @@ export function useEpochToDate(epoch: number | undefined) {
       );
     },
     enabled: epoch !== undefined && !isLoadingEpochInfo && !!epochData,
-    // Refetching in place keeps the cadence the slot-keyed version reached by
-    // accident, without minting an entry each time.
     staleTime: EPOCH_TO_DATE_REFRESH_MS,
     refetchInterval: EPOCH_TO_DATE_REFRESH_MS,
     refetchOnWindowFocus: false,


### PR DESCRIPTION
## TLDR

This PR closes #189. `absoluteSlot` in the query key meant every refresh created a new cache entry instead of reusing one, so `staleTime` never applied and `epochToDate` re-ran its RPC calls for an unchanged answer. This PR

## Problem

`useEpochInfo` has `refetchInterval: 5 * 60 * 1000`, so `absoluteSlot` changes every five minutes, and with it in the key every change is a new cache entry rather than a refetch:

- **`staleTime` was dead code.** A new key has no cached data, so it can never be served stale. The five-minute `staleTime` protected nothing
- **`epochToDate` is not cheap** — one or two RPC calls (`getBlockTime`, `getRecentPerformanceSamples`)
- A proposal detail page mounts **three** of these hooks (one in `phase-timeline`, two in `support-phase-progress`), so up to six RPC calls every five minutes
- Remounting always missed, since the slot had moved on
- Superseded entries accumulated until garbage collection

## Why this isn't just a revert

The key was `epochInfo.epoch` until #184 deliberately changed it:

```diff
-    queryKey: ["epochToDate", epoch, endpointUrl, epochData?.epochInfo.epoch],
+    queryKey: [..., epochData?.epochInfo.absoluteSlot],
```

Epochs last about two days, and each run re-reads the live slot rate — `date.ts` is explicit that "slot production can run materially faster than the 400ms target, shortening epoch phases by hours". Going back to the epoch alone would
recompute twice a week and reintroduce the stale countdown #184 fixed

The two issues pull in opposite directions, so the fix has to serve both

## Changes

```ts
queryKey: ["epochToDate", epoch, endpointUrl, epochData?.epochInfo.epoch],
staleTime: EPOCH_TO_DATE_REFRESH_MS,
refetchInterval: EPOCH_TO_DATE_REFRESH_MS,
```

`refetchInterval` recomputes in place rather than minting a new entry, so the refresh cadence #184 achieved as a side effect of the churn is preserved—now deliberate rather than accidental—while the cache stops churning and remounts serve from it

`epochInfo.epoch` stays in the key on purpose: once the target epoch is no longer in the future, `epochToDate` switches from projecting to reading the epoch's actual block time. That branch flip should not wait up to five minutes

## Tests

Three, in a new `useEpochToDate.test.tsx`:

- a slot advance alone does not recompute
- an epoch rollover recomputes immediately
- separate target epochs cache separately (the three-per-page case)

Regarding the other tests: `395 passed`, types clean, eslint clean, and prettier clean