### PR TITLE
docs(verifier): Correct the Upload Timeout Guidance

### DIFF
--- a/ncn/verifier-service/DEPLOYMENT.md
+++ b/ncn/verifier-service/DEPLOYMENT.md
@@ -21,7 +21,7 @@ The 40 GB minimum matches the AWS gp3 sizing in step 1; provision more headroom 
 
 ### Non-AWS Deployment Notes
 
-- **SSL/TLS:** If not using Cloudflare or AWS ALB, configure a reverse proxy (nginx or caddy) with [Let's Encrypt](https://letsencrypt.org/) for HTTPS termination
+- **SSL/TLS:** If not using Cloudflare or AWS ALB, configure a reverse proxy (nginx or caddy) with [Let's Encrypt](https://letsencrypt.org/) for HTTPS termination. Raise the proxy's body limit and read timeout for `/upload` — nginx defaults to `client_max_body_size 1m` and rejects a snapshot with 413 before the service sees it. See [Usage Notes](./README.md#usage-notes)
 - **DNS:** Point your verifier domain to your server's public IP via an A record
 - **Firewall:** Open ports 80 (HTTP, required for Let's Encrypt HTTP-01 challenge and HTTP→HTTPS redirects) and 443 (HTTPS) and any custom ports for the verifier API. Restrict SSH (port 22) to known IPs
 - **Process management:** The recommended Docker deployment (`setup.sh`) already uses `--restart unless-stopped`, so Docker handles crash and reboot recovery. A systemd unit is only needed if you run the binary natively
@@ -108,6 +108,10 @@ Example public DNS: `ec2-18-221-54-191.us-east-2.compute.amazonaws.com`
 - Configure Cloudflare rate limiting rules for your paths (e.g., /upload, /proof/\*)
 - Optional: restrict EC2 Security Group 80/443 to Cloudflare IP ranges to block direct-to-origin
 - Decide TLS mode (Full Strict recommended) and set up origin TLS (Nginx/ALB) if using HTTPS
+
+Cloudflare's origin timeout is 100 seconds and is not configurable below Enterprise, so a
+proxied snapshot upload returns 504. Upload over `localhost` from this host instead; see
+[Usage Notes](./README.md#usage-notes) for why, and for the remote-upload alternative.
 
 **In-app rate-limit keying.** The verifier keys its rate-limit buckets on the real client IP
 (`CF-Connecting-IP` / `X-Forwarded-For`), but only honors those headers when the connecting peer is

--- a/ncn/verifier-service/DEPLOYMENT.md
+++ b/ncn/verifier-service/DEPLOYMENT.md
@@ -110,8 +110,9 @@ Example public DNS: `ec2-18-221-54-191.us-east-2.compute.amazonaws.com`
 - Decide TLS mode (Full Strict recommended) and set up origin TLS (Nginx/ALB) if using HTTPS
 
 Cloudflare's origin timeout is 100 seconds and is not configurable below Enterprise, so a
-proxied snapshot upload returns 504. Upload over `localhost` from this host instead; see
-[Usage Notes](./README.md#usage-notes) for why, and for the remote-upload alternative.
+proxied snapshot upload returns 504. Upload from this host against the port the container
+publishes instead; see [Usage Notes](./README.md#usage-notes) for why, and for the
+remote-upload alternative.
 
 **In-app rate-limit keying.** The verifier keys its rate-limit buckets on the real client IP
 (`CF-Connecting-IP` / `X-Forwarded-For`), but only honors those headers when the connecting peer is

--- a/ncn/verifier-service/README.md
+++ b/ncn/verifier-service/README.md
@@ -336,6 +336,8 @@ rejects a snapshot with 413 before the service sees it:
 location /upload {
     client_max_body_size 128m;  # >= UPLOAD_BODY_LIMIT (default 100 MB)
     proxy_read_timeout 600s;
-    proxy_pass http://127.0.0.1:3000;
+    # The host port the container publishes (PORT_HOST in setup.sh), which is
+    # not the container's own 3000.
+    proxy_pass http://127.0.0.1:<PORT_HOST>;
 }
 ```

--- a/ncn/verifier-service/README.md
+++ b/ncn/verifier-service/README.md
@@ -300,26 +300,31 @@ curl -i http://localhost:3000/version
 
 `/upload` does its work inside the request: it decompresses the snapshot, rebuilds a
 stake merkle tree per validator, reconstructs the meta merkle tree, and indexes every
-vote and stake account. That time scales with the number of accounts in the snapshot,
-not with how fast the bytes arrive — on a testnet snapshot with 28k stake accounts,
-receiving the file is under 1% of the request, and indexing is the rest. A mainnet
-snapshot takes considerably longer.
+vote and stake account. That work scales with the number of accounts in the snapshot,
+and it is what makes the request long. Uploading the committed testnet fixture (28k
+stake accounts) to a local instance took 6.5 s, of which reading the request body was
+about 10 ms. A mainnet snapshot has far more accounts and takes considerably longer.
 
 Cloudflare's origin timeout is **100 seconds** and is not configurable below the
-Enterprise plan, so a large upload proxied through it returns 504. Chunking the upload
-does not help: the transfer is not what takes the time.
+Enterprise plan, so a large upload proxied through it returns 504. Splitting the upload
+into chunks does not help: the processing still happens in one request once the last
+chunk lands.
 
-**Upload from the verifier host over `localhost`**, as the `curl` example above does.
-Copy the snapshot to the host first (`scp`) if it was generated elsewhere. This is the
-supported path — it never crosses the proxy, so no timeout applies, and it leaves
-Cloudflare in front of every endpoint that is actually exposed.
+**Upload from the verifier host**, to whatever host port the container publishes
+(`PORT_HOST` in `setup.sh`; the `curl` example above assumes a locally built binary on
+3000). Copy the snapshot across first with `scp` if it was generated elsewhere. This is
+the supported path — it never crosses the proxy, so no origin timeout applies, and it
+leaves Cloudflare in front of every endpoint that is actually exposed.
 
 If you must upload from another machine, publish a **separate hostname with the
 Cloudflare proxy disabled** (grey cloud) and restrict it to your operator IPs at the
-firewall. Do not disable the proxy on the hostname serving `/proof/*` and `/meta`:
-those are the public read paths, and the service's rate limiting depends on
-`CF-Connecting-IP` from a trusted proxy (see `TRUSTED_PROXY_CIDRS` in
-[DEPLOYMENT.md](./DEPLOYMENT.md)). Exposing the origin directly gives that up.
+firewall. Cloudflare does not terminate TLS for a grey-clouded record, so serve that
+hostname with your own certificate.
+
+Do not disable the proxy on the hostname serving `/proof/*` and `/meta`. Those are the
+public read paths, and the service's rate limiting keys on `CF-Connecting-IP` from a
+peer inside `TRUSTED_PROXY_CIDRS` (see [DEPLOYMENT.md](./DEPLOYMENT.md)); exposing the
+origin directly gives that up for every endpoint, not just uploads.
 
 ### Reverse proxy body size
 

--- a/ncn/verifier-service/README.md
+++ b/ncn/verifier-service/README.md
@@ -296,4 +296,41 @@ curl -i http://localhost:3000/version
 
 ## Usage Notes
 
-- If verifier service is used with CloudFlare proxy, there may be a origin timeout limit of 100s that will result in 504 errors for long running /upload requests. If modification on CloudFlare is not possible, it is recommended to bypass the proxy and use the public IP address of the instance.
+### Uploading through a proxy
+
+`/upload` does its work inside the request: it decompresses the snapshot, rebuilds a
+stake merkle tree per validator, reconstructs the meta merkle tree, and indexes every
+vote and stake account. That time scales with the number of accounts in the snapshot,
+not with how fast the bytes arrive — on a testnet snapshot with 28k stake accounts,
+receiving the file is under 1% of the request, and indexing is the rest. A mainnet
+snapshot takes considerably longer.
+
+Cloudflare's origin timeout is **100 seconds** and is not configurable below the
+Enterprise plan, so a large upload proxied through it returns 504. Chunking the upload
+does not help: the transfer is not what takes the time.
+
+**Upload from the verifier host over `localhost`**, as the `curl` example above does.
+Copy the snapshot to the host first (`scp`) if it was generated elsewhere. This is the
+supported path — it never crosses the proxy, so no timeout applies, and it leaves
+Cloudflare in front of every endpoint that is actually exposed.
+
+If you must upload from another machine, publish a **separate hostname with the
+Cloudflare proxy disabled** (grey cloud) and restrict it to your operator IPs at the
+firewall. Do not disable the proxy on the hostname serving `/proof/*` and `/meta`:
+those are the public read paths, and the service's rate limiting depends on
+`CF-Connecting-IP` from a trusted proxy (see `TRUSTED_PROXY_CIDRS` in
+[DEPLOYMENT.md](./DEPLOYMENT.md)). Exposing the origin directly gives that up.
+
+### Reverse proxy body size
+
+If you terminate TLS with your own nginx rather than Cloudflare or an ALB, raise the
+body limit and read timeout — nginx defaults to `client_max_body_size 1m`, which
+rejects a snapshot with 413 before the service sees it:
+
+```nginx
+location /upload {
+    client_max_body_size 128m;  # >= UPLOAD_BODY_LIMIT (default 100 MB)
+    proxy_read_timeout 600s;
+    proxy_pass http://127.0.0.1:3000;
+}
+```


### PR DESCRIPTION
## TLDR

This PR addresses #26. The Usage Note recommended exposing the origin to work around Cloudflare's 100s timeout. This PR replaced it with the path that already works, plus an explanation of why the timeout happens so it doesn't invite the wrong fix

## Problem

The Usage Note said:

> If modification on CloudFlare is not possible, it is recommended to bypass the proxy
> and use the public IP address of the instance.

The service keys rate-limit buckets on `CF-Connecting-IP`, honors that header only from a peer inside `TRUSTED_PROXY_CIDRS`, and refuses to start rather than collapse all clients into one bucket. Bypassing the proxy discards that for every endpoint, and not just `/upload`

#26 also reports nginx returning 413 on an 82 MB snapshot before Cloudflare is even involved. `client_max_body_size` defaults to 1 MB, and `DEPLOYMENT.md` recommends nginx for TLS termination without mentioning it

## Why the request is long

`/upload` does its work inside the request: decompress, rebuild a stake merkle tree per validator, reconstruct the meta merkle tree, index every vote and stake account. That work scales with the number of accounts in the snapshot

Measured against the committed testnet fixture (1.67 MB, 59 vote accounts, 28,008 stake accounts) on a local instance I got 6.5 s total, of which reading the request body was ~10 ms. Server-log breakdown was roughly 15% parse/validate/rebuild and 84% indexing

This rules out chunked uploads, which was the first suggestion on the issue. Once the last chunk lands, the same processing happens in one request regardless of how the bytes arrived. Raising the origin timeout is Enterprise-only, and a Worker still proxies to origin and inherits the same 100s limit

## Changes

**README Usage Notes** — rewritten:

- upload from the verifier host against the port the container publishes, copying the snapshot there first with `scp` if generated elsewhere
- why the request is long, and why chunking cannot fix it
- for genuine remote upload: a separate grey-clouded hostname restricted to operator IPs, served with your own certificate since Cloudflare does not terminate TLS for a DNS-only record
- explicitly not the hostname serving `/proof/*` and `/meta`, which are the public read paths the rate limiting protects
- an nginx snippet with `client_max_body_size` and `proxy_read_timeout`

**DEPLOYMENT.md** — pointers at the two places operators hit this: the reverse-proxy note that suggests nginx, and §7 Cloudflare

## Worth Noting

`DEPLOYMENT.md` is internally inconsistent about the host port. §6 says *"we map host 80 → container 3000"* and §5 verifies against `http://127.0.0.1/healthz`, but `setup.sh` prompts interactively for `PORT_HOST` (its own example is `9090`), and `PORT_HOST` is absent from §6's variable list. This PR words around it rather than picking a side. I'm happy to fix it here or in a separate issue, whichever you prefer