### PR TITLE
fix(frontend): Read Quorum From Each Proposal's Own Snapshot

### DIFF
--- a/frontend/src/components/proposals/detail/VoteBreakdown.tsx
+++ b/frontend/src/components/proposals/detail/VoteBreakdown.tsx
@@ -48,7 +48,9 @@ const VoteBreakdown = ({
 
   // The proposal's own snapshot total, not a live cluster sum: Art. IV.2 fixes
   // the distribution for the voting period, so a live total drifts.
-  const { data: meta, isLoading: isLoadingMeta } = useSnapshotMeta();
+  const { data: meta, isLoading: isLoadingMeta } = useSnapshotMeta(
+    proposal?.snapshotSlot,
+  );
   const totalActiveStake = resolveQuorumDenominator(
     meta,
     proposal?.snapshotSlot,

--- a/frontend/src/components/proposals/proposals-table/Columns.tsx
+++ b/frontend/src/components/proposals/proposals-table/Columns.tsx
@@ -9,26 +9,23 @@ import { SortableHeaderButton } from "@/components/SortableHeaderButton";
 import { ProposalRefLabel } from "@/components/proposals/ProposalRefLabel";
 import { ProposalRecord } from "@/types";
 import type { NetworkMetaResponse } from "@/chain";
-import {
-  computeProposalVoteStats,
-  resolveQuorumDenominator,
-} from "@/chain";
+import { computeProposalVoteStats, resolveQuorumDenominator } from "@/chain";
 
 interface ProposalColumnsOptions {
-  snapshotMeta: NetworkMetaResponse | undefined;
+  snapshotMetasBySlot: Map<number, NetworkMetaResponse>;
   isLoadingSnapshotMeta: boolean;
 }
 
 function getVoteStats(
   proposal: ProposalRecord,
-  snapshotMeta: NetworkMetaResponse | undefined,
+  snapshotMetasBySlot: Map<number, NetworkMetaResponse>,
 ) {
   return computeProposalVoteStats({
     forLamports: proposal.forVotesLamports,
     againstLamports: proposal.againstVotesLamports,
     abstainLamports: proposal.abstainVotesLamports,
     totalActiveStake: resolveQuorumDenominator(
-      snapshotMeta,
+      snapshotMetasBySlot.get(proposal.snapshotSlot),
       proposal.snapshotSlot,
     ),
   });
@@ -36,22 +33,20 @@ function getVoteStats(
 
 function VoteStatsLoadingCell({ width }: { width: string }) {
   return (
-    <div
-      className={`mx-auto h-4 animate-pulse rounded bg-white/10 ${width}`}
-    />
+    <div className={`mx-auto h-4 animate-pulse rounded bg-white/10 ${width}`} />
   );
 }
 
 function ParticipationCell({
   proposal,
-  snapshotMeta,
+  snapshotMetasBySlot,
   isLoadingSnapshotMeta,
 }: ProposalColumnsOptions & { proposal: ProposalRecord }) {
   if (isLoadingSnapshotMeta) {
     return <VoteStatsLoadingCell width="w-16" />;
   }
 
-  const stats = getVoteStats(proposal, snapshotMeta);
+  const stats = getVoteStats(proposal, snapshotMetasBySlot);
   const { quorum } = stats;
 
   if (!quorum.known) {
@@ -102,11 +97,11 @@ const VOTE_SEGMENTS = [
 
 function VoteBreakdownCell({
   proposal,
-  snapshotMeta,
-}: Pick<ProposalColumnsOptions, "snapshotMeta"> & {
+  snapshotMetasBySlot,
+}: Pick<ProposalColumnsOptions, "snapshotMetasBySlot"> & {
   proposal: ProposalRecord;
 }) {
-  const stats = getVoteStats(proposal, snapshotMeta);
+  const stats = getVoteStats(proposal, snapshotMetasBySlot);
   const { voteShare } = stats;
 
   if (!voteShare.known) {
@@ -165,7 +160,7 @@ function VoteBreakdownCell({
 // }
 
 export function getProposalColumns({
-  snapshotMeta,
+  snapshotMetasBySlot,
   isLoadingSnapshotMeta,
 }: ProposalColumnsOptions): ColumnDef<ProposalRecord>[] {
   return [
@@ -219,10 +214,8 @@ export function getProposalColumns({
     {
       id: "participation",
       accessorFn: (row) => {
-        const stats = getVoteStats(row, snapshotMeta);
-        return stats.quorum.known
-          ? stats.quorum.participationPercent
-          : null;
+        const stats = getVoteStats(row, snapshotMetasBySlot);
+        return stats.quorum.known ? stats.quorum.participationPercent : null;
       },
       header: ({ column }) => (
         <SortableHeaderButton column={column} label="Participation" />
@@ -230,7 +223,7 @@ export function getProposalColumns({
       cell: ({ row }) => (
         <ParticipationCell
           proposal={row.original}
-          snapshotMeta={snapshotMeta}
+          snapshotMetasBySlot={snapshotMetasBySlot}
           isLoadingSnapshotMeta={isLoadingSnapshotMeta}
         />
       ),
@@ -241,7 +234,7 @@ export function getProposalColumns({
       cell: ({ row }) => (
         <VoteBreakdownCell
           proposal={row.original}
-          snapshotMeta={snapshotMeta}
+          snapshotMetasBySlot={snapshotMetasBySlot}
         />
       ),
     },

--- a/frontend/src/components/proposals/proposals-table/ProposalsTable.tsx
+++ b/frontend/src/components/proposals/proposals-table/ProposalsTable.tsx
@@ -35,7 +35,7 @@ import { AppButton } from "@/components/ui/AppButton";
 import ExternalProposalPanel from "./ExternalProposalPanel";
 import { ProposalStatus } from "@/types";
 import { useProposals } from "@/hooks";
-import { useSnapshotMeta } from "@/hooks/useSnapshotMeta";
+import { useSnapshotMetas } from "@/hooks/useSnapshotMeta";
 import {
   Fragment,
   useCallback,
@@ -76,14 +76,21 @@ export default function ProposalsTable({ title }: { title: string }) {
   const [showEligibleOnly, setShowEligibleOnly] = useState(false);
 
   const { data: proposalsData, isLoading: isLoadingProposals } = useProposals();
-  const { data: snapshotMeta, isLoading: isLoadingSnapshotMeta } =
-    useSnapshotMeta();
 
   const data = useMemo(() => proposalsData || [], [proposalsData]);
+
+  // Each proposal votes against its own snapshot, so every row needs the
+  // metadata for its own slot.
+  const snapshotSlots = useMemo(
+    () => data.map((proposal) => proposal.snapshotSlot),
+    [data],
+  );
+  const { bySlot: snapshotMetasBySlot, isLoading: isLoadingSnapshotMeta } =
+    useSnapshotMetas(snapshotSlots);
+
   const tableColumns = useMemo(
-    () =>
-      getProposalColumns({ snapshotMeta, isLoadingSnapshotMeta }),
-    [snapshotMeta, isLoadingSnapshotMeta],
+    () => getProposalColumns({ snapshotMetasBySlot, isLoadingSnapshotMeta }),
+    [snapshotMetasBySlot, isLoadingSnapshotMeta],
   );
 
   // Rows expand independently: opening one leaves the others as they are.
@@ -240,7 +247,7 @@ export default function ProposalsTable({ title }: { title: string }) {
                       ? null
                       : flexRender(
                           header.column.columnDef.header,
-                          header.getContext()
+                          header.getContext(),
                         )}
                   </TableHead>
                 ))}
@@ -309,7 +316,7 @@ export default function ProposalsTable({ title }: { title: string }) {
                       >
                         {flexRender(
                           cell.column.columnDef.cell,
-                          cell.getContext()
+                          cell.getContext(),
                         )}
                       </TableCell>
                     ))}

--- a/frontend/src/hooks/__tests__/useSnapshotMeta.test.tsx
+++ b/frontend/src/hooks/__tests__/useSnapshotMeta.test.tsx
@@ -17,6 +17,9 @@ jest.mock("@/lib/ncnApi", () => ({
 
 import { useSnapshotMeta, useSnapshotMetas } from "../useSnapshotMeta";
 
+/** Every slot resolves except 700, standing in for one the cleanup job pruned. */
+const PRUNED_SLOT = 700;
+
 function metaFor(slot: number) {
   return { network: "mainnet", slot, total_active_stake: slot * 10 };
 }
@@ -32,14 +35,27 @@ function makeWrapper() {
   };
 }
 
-function requestedSlot(url: string) {
-  return new URL(url).searchParams.get("slot");
+function lastUrl() {
+  return new URL(mockFetchNcnJson.mock.calls.at(-1)?.[0]);
 }
 
 beforeEach(() => {
   jest.clearAllMocks();
   mockFetchNcnJson.mockImplementation((url: string) => {
-    const slot = requestedSlot(url);
+    const params = new URL(url).searchParams;
+    const slots = params.get("slots");
+
+    if (slots !== null) {
+      return Promise.resolve(
+        slots
+          .split(",")
+          .map(Number)
+          .filter((slot) => slot !== PRUNED_SLOT)
+          .map(metaFor),
+      );
+    }
+
+    const slot = params.get("slot");
     return Promise.resolve(metaFor(slot === null ? 999 : Number(slot)));
   });
 });
@@ -51,7 +67,7 @@ describe("useSnapshotMeta", () => {
     });
 
     await waitFor(() => expect(result.current.data).toBeDefined());
-    expect(requestedSlot(mockFetchNcnJson.mock.calls[0][0])).toBeNull();
+    expect(lastUrl().searchParams.get("slot")).toBeNull();
   });
 
   it("asks for one snapshot when given its slot", async () => {
@@ -60,7 +76,7 @@ describe("useSnapshotMeta", () => {
     });
 
     await waitFor(() => expect(result.current.data).toBeDefined());
-    expect(requestedSlot(mockFetchNcnJson.mock.calls[0][0])).toBe("500");
+    expect(lastUrl().searchParams.get("slot")).toBe("500");
     expect(result.current.data?.slot).toBe(500);
   });
 });
@@ -78,13 +94,26 @@ describe("useSnapshotMetas", () => {
     expect(result.current.bySlot.get(600)?.total_active_stake).toBe(6_000);
   });
 
-  it("fetches a repeated slot once", async () => {
-    const { result } = renderHook(() => useSnapshotMetas([500, 600, 500]), {
+  it("asks for every slot in a single request", async () => {
+    // One request per row would exhaust the verifier's burst limit on a page
+    // holding more proposals than the limit allows.
+    const { result } = renderHook(
+      () => useSnapshotMetas([500, 600, 500, 800]),
+      { wrapper: makeWrapper() },
+    );
+
+    await waitFor(() => expect(result.current.bySlot.size).toBe(3));
+    expect(mockFetchNcnJson).toHaveBeenCalledTimes(1);
+    expect(lastUrl().searchParams.get("slots")).toBe("500,600,800");
+  });
+
+  it("omits a slot the response does not carry", async () => {
+    const { result } = renderHook(() => useSnapshotMetas([500, PRUNED_SLOT]), {
       wrapper: makeWrapper(),
     });
 
-    await waitFor(() => expect(result.current.bySlot.size).toBe(2));
-    expect(mockFetchNcnJson).toHaveBeenCalledTimes(2);
+    await waitFor(() => expect(result.current.bySlot.size).toBe(1));
+    expect(result.current.bySlot.has(PRUNED_SLOT)).toBe(false);
   });
 
   it("skips proposals with no snapshot slot", async () => {
@@ -94,17 +123,16 @@ describe("useSnapshotMetas", () => {
     });
 
     await waitFor(() => expect(result.current.bySlot.size).toBe(1));
-    expect(mockFetchNcnJson).toHaveBeenCalledTimes(1);
-    expect(requestedSlot(mockFetchNcnJson.mock.calls[0][0])).toBe("500");
+    expect(lastUrl().searchParams.get("slots")).toBe("500");
   });
 
-  it("shares its cache with useSnapshotMeta for the same slot", async () => {
-    // The detail page and the table must not fetch the same snapshot twice.
-    const wrapper = makeWrapper();
-    renderHook(() => useSnapshotMetas([500]), { wrapper });
-    const { result } = renderHook(() => useSnapshotMeta(500), { wrapper });
+  it("makes no request when nothing has a snapshot yet", async () => {
+    const { result } = renderHook(() => useSnapshotMetas([0, undefined]), {
+      wrapper: makeWrapper(),
+    });
 
-    await waitFor(() => expect(result.current.data).toBeDefined());
-    expect(mockFetchNcnJson).toHaveBeenCalledTimes(1);
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(mockFetchNcnJson).not.toHaveBeenCalled();
+    expect(result.current.bySlot.size).toBe(0);
   });
 });

--- a/frontend/src/hooks/__tests__/useSnapshotMeta.test.tsx
+++ b/frontend/src/hooks/__tests__/useSnapshotMeta.test.tsx
@@ -1,0 +1,110 @@
+import * as React from "react";
+import { renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+
+const mockFetchNcnJson = jest.fn();
+
+// EndpointContext reaches env.ts, an ESM-only package Jest does not transform.
+jest.mock("@/contexts/EndpointContext", () => ({
+  useEndpoint: () => ({ network: "mainnet" }),
+}));
+jest.mock("@/contexts/NcnApiContext", () => ({
+  useNcnApi: () => ({ ncnApiUrl: "https://ncn.example" }),
+}));
+jest.mock("@/lib/ncnApi", () => ({
+  fetchNcnJson: (url: string) => mockFetchNcnJson(url),
+}));
+
+import { useSnapshotMeta, useSnapshotMetas } from "../useSnapshotMeta";
+
+function metaFor(slot: number) {
+  return { network: "mainnet", slot, total_active_stake: slot * 10 };
+}
+
+function makeWrapper() {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return (
+      <QueryClientProvider client={client}>{children}</QueryClientProvider>
+    );
+  };
+}
+
+function requestedSlot(url: string) {
+  return new URL(url).searchParams.get("slot");
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockFetchNcnJson.mockImplementation((url: string) => {
+    const slot = requestedSlot(url);
+    return Promise.resolve(metaFor(slot === null ? 999 : Number(slot)));
+  });
+});
+
+describe("useSnapshotMeta", () => {
+  it("asks for the newest snapshot when given no slot", async () => {
+    const { result } = renderHook(() => useSnapshotMeta(), {
+      wrapper: makeWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.data).toBeDefined());
+    expect(requestedSlot(mockFetchNcnJson.mock.calls[0][0])).toBeNull();
+  });
+
+  it("asks for one snapshot when given its slot", async () => {
+    const { result } = renderHook(() => useSnapshotMeta(500), {
+      wrapper: makeWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.data).toBeDefined());
+    expect(requestedSlot(mockFetchNcnJson.mock.calls[0][0])).toBe("500");
+    expect(result.current.data?.slot).toBe(500);
+  });
+});
+
+describe("useSnapshotMetas", () => {
+  it("keys each proposal's snapshot by its own slot", async () => {
+    // The reported bug: every row was measured against whichever snapshot was
+    // newest, so quorum resolved for at most one proposal.
+    const { result } = renderHook(() => useSnapshotMetas([500, 600]), {
+      wrapper: makeWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.bySlot.size).toBe(2));
+    expect(result.current.bySlot.get(500)?.total_active_stake).toBe(5_000);
+    expect(result.current.bySlot.get(600)?.total_active_stake).toBe(6_000);
+  });
+
+  it("fetches a repeated slot once", async () => {
+    const { result } = renderHook(() => useSnapshotMetas([500, 600, 500]), {
+      wrapper: makeWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.bySlot.size).toBe(2));
+    expect(mockFetchNcnJson).toHaveBeenCalledTimes(2);
+  });
+
+  it("skips proposals with no snapshot slot", async () => {
+    // snapshot_slot is 0 until activate_voting sets it.
+    const { result } = renderHook(() => useSnapshotMetas([0, undefined, 500]), {
+      wrapper: makeWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.bySlot.size).toBe(1));
+    expect(mockFetchNcnJson).toHaveBeenCalledTimes(1);
+    expect(requestedSlot(mockFetchNcnJson.mock.calls[0][0])).toBe("500");
+  });
+
+  it("shares its cache with useSnapshotMeta for the same slot", async () => {
+    // The detail page and the table must not fetch the same snapshot twice.
+    const wrapper = makeWrapper();
+    renderHook(() => useSnapshotMetas([500]), { wrapper });
+    const { result } = renderHook(() => useSnapshotMeta(500), { wrapper });
+
+    await waitFor(() => expect(result.current.data).toBeDefined());
+    expect(mockFetchNcnJson).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/hooks/__tests__/useSnapshotMeta.test.tsx
+++ b/frontend/src/hooks/__tests__/useSnapshotMeta.test.tsx
@@ -107,6 +107,23 @@ describe("useSnapshotMetas", () => {
     expect(lastUrl().searchParams.get("slots")).toBe("500,600,800");
   });
 
+  it("splits a history longer than one request accepts", async () => {
+    // The verifier rejects an over-long slot list, and a rejected batch would
+    // leave every row without a denominator rather than just the overflow.
+    const slots = Array.from({ length: 250 }, (_, index) => 1_000 + index);
+
+    const { result } = renderHook(() => useSnapshotMetas(slots), {
+      wrapper: makeWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.bySlot.size).toBe(250));
+    expect(mockFetchNcnJson).toHaveBeenCalledTimes(3);
+    for (const call of mockFetchNcnJson.mock.calls) {
+      const requested = new URL(call[0]).searchParams.get("slots")!.split(",");
+      expect(requested.length).toBeLessThanOrEqual(100);
+    }
+  });
+
   it("omits a slot the response does not carry", async () => {
     const { result } = renderHook(() => useSnapshotMetas([500, PRUNED_SLOT]), {
       wrapper: makeWrapper(),

--- a/frontend/src/hooks/useSnapshotMeta.ts
+++ b/frontend/src/hooks/useSnapshotMeta.ts
@@ -2,13 +2,14 @@ import { NetworkMetaResponse } from "@/chain";
 import { useEndpoint } from "@/contexts/EndpointContext";
 import { useNcnApi } from "@/contexts/NcnApiContext";
 import { fetchNcnJson } from "@/lib/ncnApi";
-import { queryOptions, useQueries, useQuery } from "@tanstack/react-query";
+import { queryOptions, useQuery } from "@tanstack/react-query";
 import { useMemo } from "react";
 
-/** Shared so the table and a detail page reuse one cache entry per slot. */
+const SNAPSHOT_META_STALE_TIME_MS = 1000 * 120;
+
 function snapshotMetaQuery(ncnApiUrl: string, network: string, slot?: number) {
   return queryOptions({
-    staleTime: 1000 * 120, // 2 minutes
+    staleTime: SNAPSHOT_META_STALE_TIME_MS,
     queryKey: ["snapshot_meta", network, ncnApiUrl, slot],
     queryFn: ({ signal }) => {
       const url =
@@ -40,31 +41,18 @@ export const useSnapshotMeta = (slot?: number) => {
 };
 
 /**
- * Declared here rather than inline: `useQueries` caches the combined result
- * against this function's identity, so a new closure each render would rebuild
- * the map every time.
+ * Metadata for several snapshots, keyed by slot.
+ *
+ * One request rather than one per slot: a page listing proposals would
+ * otherwise open a connection per row and can exhaust the verifier's request
+ * burst before it has finished rendering.
  */
-function combineSnapshotMetas(
-  results: { data?: NetworkMetaResponse; isLoading: boolean }[],
-) {
-  const bySlot = new Map<number, NetworkMetaResponse>();
-  for (const { data } of results) {
-    // Keyed by the slot the response reports, so a verifier that does not
-    // support the parameter files its newest snapshot under its own slot rather
-    // than under the one that was asked for.
-    if (data) bySlot.set(data.slot, data);
-  }
-
-  return { bySlot, isLoading: results.some((result) => result.isLoading) };
-}
-
-/** Metadata for several snapshots, keyed by slot. */
 export const useSnapshotMetas = (slots: (number | undefined)[]) => {
   const { network } = useEndpoint();
   const { ncnApiUrl } = useNcnApi();
 
   // Sorted and de-duplicated so reordering the proposals does not change the
-  // query list.
+  // query key.
   const uniqueSlots = useMemo(
     () =>
       Array.from(
@@ -73,10 +61,24 @@ export const useSnapshotMetas = (slots: (number | undefined)[]) => {
     [slots],
   );
 
-  return useQueries({
-    queries: uniqueSlots.map((slot) =>
-      snapshotMetaQuery(ncnApiUrl, network, slot),
-    ),
-    combine: combineSnapshotMetas,
+  const { data, isLoading } = useQuery({
+    staleTime: SNAPSHOT_META_STALE_TIME_MS,
+    enabled: uniqueSlots.length > 0,
+    queryKey: ["snapshot_metas", network, ncnApiUrl, uniqueSlots],
+    queryFn: ({ signal }) =>
+      fetchNcnJson<NetworkMetaResponse[]>(
+        `${ncnApiUrl}/metas?network=${network}&slots=${uniqueSlots.join(",")}`,
+        { signal, label: "snapshot meta info", resource: "snapshot-meta" },
+      ),
   });
+
+  return useMemo(
+    () => ({
+      // Keyed by the slot each record reports, so a slot the verifier has
+      // pruned is simply absent rather than mapped to another snapshot.
+      bySlot: new Map((data ?? []).map((meta) => [meta.slot, meta])),
+      isLoading,
+    }),
+    [data, isLoading],
+  );
 };

--- a/frontend/src/hooks/useSnapshotMeta.ts
+++ b/frontend/src/hooks/useSnapshotMeta.ts
@@ -7,15 +7,19 @@ import { useMemo } from "react";
 
 const SNAPSHOT_META_STALE_TIME_MS = 1000 * 120;
 
-function snapshotMetaQuery(ncnApiUrl: string, network: string, slot?: number) {
+function snapshotMetaQuery(
+  ncnApiUrl: string,
+  network: string,
+  snapshotSlot?: number,
+) {
   return queryOptions({
     staleTime: SNAPSHOT_META_STALE_TIME_MS,
-    queryKey: ["snapshot_meta", network, ncnApiUrl, slot],
+    queryKey: ["snapshot_meta", network, ncnApiUrl, snapshotSlot],
     queryFn: ({ signal }) => {
       const url =
-        slot === undefined
+        snapshotSlot === undefined
           ? `${ncnApiUrl}/meta?network=${network}`
-          : `${ncnApiUrl}/meta?network=${network}&slot=${slot}`;
+          : `${ncnApiUrl}/meta?network=${network}&slot=${snapshotSlot}`;
 
       return fetchNcnJson<NetworkMetaResponse>(url, {
         signal,
@@ -27,17 +31,17 @@ function snapshotMetaQuery(ncnApiUrl: string, network: string, slot?: number) {
 }
 
 /**
- * Metadata for one snapshot; the newest when `slot` is omitted.
+ * Metadata for one snapshot; the newest when `snapshotSlot` is omitted.
  *
  * Anything measured against a proposal takes that proposal's `snapshotSlot`: it
  * votes against the snapshot frozen at activation, which stops being the newest
  * as soon as another is uploaded.
  */
-export const useSnapshotMeta = (slot?: number) => {
+export const useSnapshotMeta = (snapshotSlot?: number) => {
   const { network } = useEndpoint();
   const { ncnApiUrl } = useNcnApi();
 
-  return useQuery(snapshotMetaQuery(ncnApiUrl, network, slot));
+  return useQuery(snapshotMetaQuery(ncnApiUrl, network, snapshotSlot));
 };
 
 /** Kept at or below `MAX_METAS_SLOTS` in `ncn/verifier-service/src/main.rs`. */
@@ -46,14 +50,14 @@ const MAX_SLOTS_PER_REQUEST = 100;
 function snapshotMetasQuery(
   ncnApiUrl: string,
   network: string,
-  slots: number[],
+  snapshotSlots: number[],
 ) {
   return queryOptions({
     staleTime: SNAPSHOT_META_STALE_TIME_MS,
-    queryKey: ["snapshot_metas", network, ncnApiUrl, slots],
+    queryKey: ["snapshot_metas", network, ncnApiUrl, snapshotSlots],
     queryFn: ({ signal }) =>
       fetchNcnJson<NetworkMetaResponse[]>(
-        `${ncnApiUrl}/metas?network=${network}&slots=${slots.join(",")}`,
+        `${ncnApiUrl}/metas?network=${network}&slots=${snapshotSlots.join(",")}`,
         { signal, label: "snapshot meta info", resource: "snapshot-meta" },
       ),
   });
@@ -78,7 +82,7 @@ function combineSnapshotMetas(
 }
 
 /**
- * Metadata for several snapshots, keyed by slot.
+ * Metadata for several snapshots, keyed by snapshot slot.
  *
  * Batched rather than one request per slot, which on a page listing proposals
  * would open a connection per row and exhaust the verifier's request burst.
@@ -86,7 +90,7 @@ function combineSnapshotMetas(
  * so a long proposal history degrades to a few requests instead of a rejected
  * one that would leave every row without a denominator.
  */
-export const useSnapshotMetas = (slots: (number | undefined)[]) => {
+export const useSnapshotMetas = (snapshotSlots: (number | undefined)[]) => {
   const { network } = useEndpoint();
   const { ncnApiUrl } = useNcnApi();
 
@@ -94,7 +98,7 @@ export const useSnapshotMetas = (slots: (number | undefined)[]) => {
   // query keys.
   const batches = useMemo(() => {
     const unique = Array.from(
-      new Set(slots.filter((slot): slot is number => Boolean(slot))),
+      new Set(snapshotSlots.filter((slot): slot is number => Boolean(slot))),
     ).sort((a, b) => a - b);
 
     const chunks: number[][] = [];
@@ -102,7 +106,7 @@ export const useSnapshotMetas = (slots: (number | undefined)[]) => {
       chunks.push(unique.slice(i, i + MAX_SLOTS_PER_REQUEST));
     }
     return chunks;
-  }, [slots]);
+  }, [snapshotSlots]);
 
   return useQueries({
     queries: batches.map((batch) =>

--- a/frontend/src/hooks/useSnapshotMeta.ts
+++ b/frontend/src/hooks/useSnapshotMeta.ts
@@ -2,17 +2,19 @@ import { NetworkMetaResponse } from "@/chain";
 import { useEndpoint } from "@/contexts/EndpointContext";
 import { useNcnApi } from "@/contexts/NcnApiContext";
 import { fetchNcnJson } from "@/lib/ncnApi";
-import { useQuery } from "@tanstack/react-query";
+import { queryOptions, useQueries, useQuery } from "@tanstack/react-query";
+import { useMemo } from "react";
 
-export const useSnapshotMeta = () => {
-  const { network } = useEndpoint();
-  const { ncnApiUrl } = useNcnApi();
-
-  return useQuery({
+/** Shared so the table and a detail page reuse one cache entry per slot. */
+function snapshotMetaQuery(ncnApiUrl: string, network: string, slot?: number) {
+  return queryOptions({
     staleTime: 1000 * 120, // 2 minutes
-    queryKey: ["snapshot_meta", network, ncnApiUrl],
-    queryFn: ({ signal }): Promise<NetworkMetaResponse> => {
-      const url = `${ncnApiUrl}/meta?network=${network}`;
+    queryKey: ["snapshot_meta", network, ncnApiUrl, slot],
+    queryFn: ({ signal }) => {
+      const url =
+        slot === undefined
+          ? `${ncnApiUrl}/meta?network=${network}`
+          : `${ncnApiUrl}/meta?network=${network}&slot=${slot}`;
 
       return fetchNcnJson<NetworkMetaResponse>(url, {
         signal,
@@ -20,5 +22,61 @@ export const useSnapshotMeta = () => {
         resource: "snapshot-meta",
       });
     },
+  });
+}
+
+/**
+ * Metadata for one snapshot; the newest when `slot` is omitted.
+ *
+ * Anything measured against a proposal takes that proposal's `snapshotSlot`: it
+ * votes against the snapshot frozen at activation, which stops being the newest
+ * as soon as another is uploaded.
+ */
+export const useSnapshotMeta = (slot?: number) => {
+  const { network } = useEndpoint();
+  const { ncnApiUrl } = useNcnApi();
+
+  return useQuery(snapshotMetaQuery(ncnApiUrl, network, slot));
+};
+
+/**
+ * Declared here rather than inline: `useQueries` caches the combined result
+ * against this function's identity, so a new closure each render would rebuild
+ * the map every time.
+ */
+function combineSnapshotMetas(
+  results: { data?: NetworkMetaResponse; isLoading: boolean }[],
+) {
+  const bySlot = new Map<number, NetworkMetaResponse>();
+  for (const { data } of results) {
+    // Keyed by the slot the response reports, so a verifier that does not
+    // support the parameter files its newest snapshot under its own slot rather
+    // than under the one that was asked for.
+    if (data) bySlot.set(data.slot, data);
+  }
+
+  return { bySlot, isLoading: results.some((result) => result.isLoading) };
+}
+
+/** Metadata for several snapshots, keyed by slot. */
+export const useSnapshotMetas = (slots: (number | undefined)[]) => {
+  const { network } = useEndpoint();
+  const { ncnApiUrl } = useNcnApi();
+
+  // Sorted and de-duplicated so reordering the proposals does not change the
+  // query list.
+  const uniqueSlots = useMemo(
+    () =>
+      Array.from(
+        new Set(slots.filter((slot): slot is number => Boolean(slot))),
+      ).sort((a, b) => a - b),
+    [slots],
+  );
+
+  return useQueries({
+    queries: uniqueSlots.map((slot) =>
+      snapshotMetaQuery(ncnApiUrl, network, slot),
+    ),
+    combine: combineSnapshotMetas,
   });
 };

--- a/frontend/src/hooks/useSnapshotMeta.ts
+++ b/frontend/src/hooks/useSnapshotMeta.ts
@@ -2,7 +2,7 @@ import { NetworkMetaResponse } from "@/chain";
 import { useEndpoint } from "@/contexts/EndpointContext";
 import { useNcnApi } from "@/contexts/NcnApiContext";
 import { fetchNcnJson } from "@/lib/ncnApi";
-import { queryOptions, useQuery } from "@tanstack/react-query";
+import { queryOptions, useQueries, useQuery } from "@tanstack/react-query";
 import { useMemo } from "react";
 
 const SNAPSHOT_META_STALE_TIME_MS = 1000 * 120;
@@ -40,45 +40,74 @@ export const useSnapshotMeta = (slot?: number) => {
   return useQuery(snapshotMetaQuery(ncnApiUrl, network, slot));
 };
 
+/** Kept at or below `MAX_METAS_SLOTS` in `ncn/verifier-service/src/main.rs`. */
+const MAX_SLOTS_PER_REQUEST = 100;
+
+function snapshotMetasQuery(
+  ncnApiUrl: string,
+  network: string,
+  slots: number[],
+) {
+  return queryOptions({
+    staleTime: SNAPSHOT_META_STALE_TIME_MS,
+    queryKey: ["snapshot_metas", network, ncnApiUrl, slots],
+    queryFn: ({ signal }) =>
+      fetchNcnJson<NetworkMetaResponse[]>(
+        `${ncnApiUrl}/metas?network=${network}&slots=${slots.join(",")}`,
+        { signal, label: "snapshot meta info", resource: "snapshot-meta" },
+      ),
+  });
+}
+
+/**
+ * Declared here rather than inline: `useQueries` caches the combined result
+ * against this function's identity, so a new closure each render would rebuild
+ * the map every time.
+ */
+function combineSnapshotMetas(
+  results: { data?: NetworkMetaResponse[]; isLoading: boolean }[],
+) {
+  const bySlot = new Map<number, NetworkMetaResponse>();
+  for (const { data } of results) {
+    // Keyed by the slot each record reports, so a slot the verifier has pruned
+    // is simply absent rather than mapped to another snapshot.
+    for (const meta of data ?? []) bySlot.set(meta.slot, meta);
+  }
+
+  return { bySlot, isLoading: results.some((result) => result.isLoading) };
+}
+
 /**
  * Metadata for several snapshots, keyed by slot.
  *
- * One request rather than one per slot: a page listing proposals would
- * otherwise open a connection per row and can exhaust the verifier's request
- * burst before it has finished rendering.
+ * Batched rather than one request per slot, which on a page listing proposals
+ * would open a connection per row and exhaust the verifier's request burst.
+ * Split across requests only when there are more slots than one request accepts,
+ * so a long proposal history degrades to a few requests instead of a rejected
+ * one that would leave every row without a denominator.
  */
 export const useSnapshotMetas = (slots: (number | undefined)[]) => {
   const { network } = useEndpoint();
   const { ncnApiUrl } = useNcnApi();
 
   // Sorted and de-duplicated so reordering the proposals does not change the
-  // query key.
-  const uniqueSlots = useMemo(
-    () =>
-      Array.from(
-        new Set(slots.filter((slot): slot is number => Boolean(slot))),
-      ).sort((a, b) => a - b),
-    [slots],
-  );
+  // query keys.
+  const batches = useMemo(() => {
+    const unique = Array.from(
+      new Set(slots.filter((slot): slot is number => Boolean(slot))),
+    ).sort((a, b) => a - b);
 
-  const { data, isLoading } = useQuery({
-    staleTime: SNAPSHOT_META_STALE_TIME_MS,
-    enabled: uniqueSlots.length > 0,
-    queryKey: ["snapshot_metas", network, ncnApiUrl, uniqueSlots],
-    queryFn: ({ signal }) =>
-      fetchNcnJson<NetworkMetaResponse[]>(
-        `${ncnApiUrl}/metas?network=${network}&slots=${uniqueSlots.join(",")}`,
-        { signal, label: "snapshot meta info", resource: "snapshot-meta" },
-      ),
+    const chunks: number[][] = [];
+    for (let i = 0; i < unique.length; i += MAX_SLOTS_PER_REQUEST) {
+      chunks.push(unique.slice(i, i + MAX_SLOTS_PER_REQUEST));
+    }
+    return chunks;
+  }, [slots]);
+
+  return useQueries({
+    queries: batches.map((batch) =>
+      snapshotMetasQuery(ncnApiUrl, network, batch),
+    ),
+    combine: combineSnapshotMetas,
   });
-
-  return useMemo(
-    () => ({
-      // Keyed by the slot each record reports, so a slot the verifier has
-      // pruned is simply absent rather than mapped to another snapshot.
-      bySlot: new Map((data ?? []).map((meta) => [meta.slot, meta])),
-      isLoading,
-    }),
-    [data, isLoading],
-  );
 };

--- a/ncn/verifier-service/src/database/operations.rs
+++ b/ncn/verifier-service/src/database/operations.rs
@@ -324,6 +324,38 @@ impl SnapshotMetaRecord {
         row_opt.as_ref().map(Self::from_row).transpose()
     }
 
+    /// Get the metadata for several snapshots in one query.
+    ///
+    /// Slots that have no snapshot are absent from the result rather than being
+    /// an error, so a caller listing proposals gets whatever is retained
+    /// alongside the ones the cleanup job has already pruned.
+    pub async fn get_by_slots(
+        pool: &SqlitePool,
+        network: &str,
+        slots: &[u64],
+    ) -> Result<Vec<SnapshotMetaRecord>> {
+        if slots.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let placeholders = vec!["?"; slots.len()].join(", ");
+        let sql = format!(
+            "SELECT {SNAPSHOT_META_COLUMNS} FROM snapshot_meta \
+             WHERE network = ? AND slot IN ({placeholders}) ORDER BY slot"
+        );
+        let mut query = sqlx::query(&sql).bind(network);
+        for slot in slots {
+            query = query.bind(i64::try_from(*slot)?);
+        }
+
+        query
+            .fetch_all(pool)
+            .await?
+            .iter()
+            .map(Self::from_row)
+            .collect()
+    }
+
     /// Get the latest slot for a network
     pub async fn get_latest_slot(pool: &SqlitePool, network: &str) -> Result<Option<u64>> {
         let row_opt = sqlx::query(

--- a/ncn/verifier-service/src/database/operations.rs
+++ b/ncn/verifier-service/src/database/operations.rs
@@ -1,7 +1,10 @@
 use anyhow::Result;
 use axum::http::StatusCode;
 use serde_json;
-use sqlx::{sqlite::SqlitePool, Executor, Row as SqlxRow, Sqlite};
+use sqlx::{
+    sqlite::{SqlitePool, SqliteRow},
+    Executor, Row as SqlxRow, Sqlite,
+};
 use std::convert::TryFrom;
 use tracing::debug;
 use tracing::info;
@@ -265,6 +268,24 @@ impl SnapshotMetaRecord {
         Ok(())
     }
 
+    /// Build a record from a row selected with [`SNAPSHOT_META_COLUMNS`].
+    fn from_row(row: &SqliteRow) -> Result<SnapshotMetaRecord> {
+        Ok(SnapshotMetaRecord {
+            network: row.get("network"),
+            slot: row.get::<i64, _>("slot") as u64,
+            merkle_root: row.get("merkle_root"),
+            snapshot_hash: row.get("snapshot_hash"),
+            created_at: row.get("created_at"),
+            // Checked, mirroring the write side. A negative value cannot
+            // be written, but `as u64` would turn one into an enormous
+            // quorum denominator, silently reporting participation as ~0%.
+            total_active_stake: row
+                .get::<Option<i64>, _>("total_active_stake")
+                .map(u64::try_from)
+                .transpose()?,
+        })
+    }
+
     /// Get the latest snapshot metadata for a network
     pub async fn get_latest(
         pool: &SqlitePool,
@@ -278,24 +299,29 @@ impl SnapshotMetaRecord {
         .fetch_optional(pool)
         .await?;
 
-        if let Some(row) = row_opt {
-            Ok(Some(SnapshotMetaRecord {
-                network: row.get("network"),
-                slot: row.get::<i64, _>("slot") as u64,
-                merkle_root: row.get("merkle_root"),
-                snapshot_hash: row.get("snapshot_hash"),
-                created_at: row.get("created_at"),
-                // Checked, mirroring the write side. A negative value cannot
-                // be written, but `as u64` would turn one into an enormous
-                // quorum denominator, silently reporting participation as ~0%.
-                total_active_stake: row
-                    .get::<Option<i64>, _>("total_active_stake")
-                    .map(u64::try_from)
-                    .transpose()?,
-            }))
-        } else {
-            Ok(None)
-        }
+        row_opt.as_ref().map(Self::from_row).transpose()
+    }
+
+    /// Get the metadata for one snapshot.
+    ///
+    /// A proposal votes against the snapshot frozen at activation, which stops
+    /// being the newest as soon as another is uploaded, so quorum for it cannot
+    /// be read from [`get_latest`].
+    pub async fn get_by_slot(
+        pool: &SqlitePool,
+        network: &str,
+        slot: u64,
+    ) -> Result<Option<SnapshotMetaRecord>> {
+        let row_opt = sqlx::query(&format!(
+            "SELECT {SNAPSHOT_META_COLUMNS} FROM snapshot_meta \
+             WHERE network = ? AND slot = ?"
+        ))
+        .bind(network)
+        .bind(i64::try_from(slot)?)
+        .fetch_optional(pool)
+        .await?;
+
+        row_opt.as_ref().map(Self::from_row).transpose()
     }
 
     /// Get the latest slot for a network

--- a/ncn/verifier-service/src/main.rs
+++ b/ncn/verifier-service/src/main.rs
@@ -180,16 +180,25 @@ async fn get_meta(
     validate_network(network)?;
 
     let meta_record_option = db_operation(
-        || SnapshotMetaRecord::get_latest(&pool, network),
+        || async {
+            match params.slot {
+                Some(slot) => SnapshotMetaRecord::get_by_slot(&pool, network, slot).await,
+                None => SnapshotMetaRecord::get_latest(&pool, network).await,
+            }
+        },
         "Failed to get snapshot meta record",
     )
     .await?;
 
-    if let Some(record) = meta_record_option {
-        Ok(Json(record))
-    } else {
-        info!("No snapshots found for network: {}", network);
-        Err(StatusCode::NOT_FOUND)
+    match meta_record_option {
+        Some(record) => Ok(Json(record)),
+        None => {
+            match params.slot {
+                Some(slot) => info!("No snapshot at slot {} for network: {}", slot, network),
+                None => info!("No snapshots found for network: {}", network),
+            }
+            Err(StatusCode::NOT_FOUND)
+        }
     }
 }
 

--- a/ncn/verifier-service/src/main.rs
+++ b/ncn/verifier-service/src/main.rs
@@ -21,7 +21,7 @@ use tower_governor::{governor::GovernorConfigBuilder, GovernorLayer};
 use tower_http::cors::{Any, CorsLayer};
 use tower_http::trace::{DefaultMakeSpan, DefaultOnResponse, TraceLayer};
 use tracing::{debug, info, Level};
-use types::{NetworkQuery, VoterQuery};
+use types::{MetasQuery, NetworkQuery, VoterQuery};
 use upload::handle_upload;
 
 use crate::{
@@ -33,6 +33,8 @@ use crate::{
 const DEFAULT_BODY_LIMIT: usize = 100 * 1024 * 1024; // 100MB for uploads
 const DEFAULT_PORT: u16 = 3000; // override with PORT env var
 const DEFAULT_NETWORK: &str = "mainnet";
+/// Cap on `/metas?slots=`, so one request cannot ask for an unbounded `IN` list.
+const MAX_METAS_SLOTS: usize = 100;
 
 // Get the latest snapshot slot if not specified
 async fn get_snapshot_slot(
@@ -110,6 +112,7 @@ async fn main() -> anyhow::Result<()> {
             .route("/healthz", get(health_check))
             .route("/version", get(get_version))
             .route("/meta", get(get_meta))
+            .route("/metas", get(get_metas))
             .route("/voter/{voting_wallet}", get(get_voter_summary))
             .route("/proof/vote_account/{vote_account}", get(get_vote_proof))
             .route("/proof/stake_account/{stake_account}", get(get_stake_proof))
@@ -200,6 +203,45 @@ async fn get_meta(
             Err(StatusCode::NOT_FOUND)
         }
     }
+}
+
+/// Metadata for several snapshots at once.
+///
+/// A page listing proposals needs the snapshot each one was activated against.
+/// Requesting them individually would be one request per proposal, which a
+/// client can exhaust the rate limit with before the page has rendered.
+async fn get_metas(
+    State(pool): State<SqlitePool>,
+    Query(params): Query<MetasQuery>,
+) -> Result<Json<Vec<SnapshotMetaRecord>>, StatusCode> {
+    let network = params.network.as_deref().unwrap_or(DEFAULT_NETWORK);
+    validate_network(network)?;
+
+    let slots = params
+        .slots
+        .split(',')
+        .map(str::trim)
+        .filter(|slot| !slot.is_empty())
+        .map(str::parse::<u64>)
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|_| StatusCode::BAD_REQUEST)?;
+
+    if slots.len() > MAX_METAS_SLOTS {
+        info!(
+            "Rejected /metas asking for {} slots (max {})",
+            slots.len(),
+            MAX_METAS_SLOTS
+        );
+        return Err(StatusCode::BAD_REQUEST);
+    }
+
+    let records = db_operation(
+        || SnapshotMetaRecord::get_by_slots(&pool, network, &slots),
+        "Failed to get snapshot meta records",
+    )
+    .await?;
+
+    Ok(Json(records))
 }
 
 async fn get_voter_summary(

--- a/ncn/verifier-service/src/types.rs
+++ b/ncn/verifier-service/src/types.rs
@@ -9,6 +9,14 @@ pub struct NetworkQuery {
     pub slot: Option<u64>,
 }
 
+/// Query for the batch metadata endpoint.
+#[derive(Debug, Deserialize)]
+pub struct MetasQuery {
+    pub network: Option<String>,
+    /// Comma-separated snapshot slots.
+    pub slots: String,
+}
+
 #[derive(Debug, Deserialize)]
 pub struct VoterQuery {
     pub network: Option<String>,

--- a/ncn/verifier-service/src/types.rs
+++ b/ncn/verifier-service/src/types.rs
@@ -5,6 +5,8 @@ use serde::Deserialize;
 #[derive(Debug, Deserialize)]
 pub struct NetworkQuery {
     pub network: Option<String>,
+    /// Which snapshot to describe. Omitted means the newest.
+    pub slot: Option<u64>,
 }
 
 #[derive(Debug, Deserialize)]

--- a/ncn/verifier-service/tests/e2e_binary.rs
+++ b/ncn/verifier-service/tests/e2e_binary.rs
@@ -130,6 +130,39 @@ async fn e2e_binary_endpoints() -> anyhow::Result<()> {
         .await?;
     assert_eq!(missing_slot.status(), StatusCode::NOT_FOUND);
 
+    // A page listing proposals asks for every snapshot it needs in one request.
+    // Unknown slots are simply absent, so a pruned snapshot does not fail the
+    // whole batch.
+    let metas: serde_json::Value = client
+        .get(format!(
+            "{}/metas?network=testnet&slots={},{}",
+            base_url,
+            slot,
+            slot + 1
+        ))
+        .send()
+        .await?
+        .error_for_status()?
+        .json()
+        .await?;
+    assert_eq!(metas, serde_json::json!([expected_meta]));
+
+    let too_many = client
+        .get(format!(
+            "{}/metas?network=testnet&slots={}",
+            base_url,
+            vec!["1"; 101].join(",")
+        ))
+        .send()
+        .await?;
+    assert_eq!(too_many.status(), StatusCode::BAD_REQUEST);
+
+    let malformed = client
+        .get(format!("{}/metas?network=testnet&slots=abc", base_url))
+        .send()
+        .await?;
+    assert_eq!(malformed.status(), StatusCode::BAD_REQUEST);
+
     // Test GET /voter
     let voter: serde_json::Value = client
         .get(format!(

--- a/ncn/verifier-service/tests/e2e_binary.rs
+++ b/ncn/verifier-service/tests/e2e_binary.rs
@@ -1,5 +1,5 @@
 mod common;
-use common::setup_server;
+use common::{setup_server, setup_server_with_env};
 
 use anchor_lang::solana_program::hash::Hash;
 use ncn_snapshot::merkle_helper::verify_helper;
@@ -39,7 +39,11 @@ fn decode_proof_strings(proof: &[String]) -> Vec<[u8; 32]> {
 #[serial_test::serial]
 async fn e2e_binary_endpoints() -> anyhow::Result<()> {
     let keypair = Keypair::new();
-    let (base_url, _guard) = setup_server(&keypair).await?;
+    // This test walks every endpoint, so the default global burst of 10 would
+    // start returning 429 partway through and mask the status each request is
+    // actually asserting. Rate limiting itself is covered in rate_limit.rs.
+    let (base_url, _guard) =
+        setup_server_with_env(&keypair, &[("GLOBAL_RATE_BURST", "100")]).await?;
 
     // Load and parse the snapshot that will be uploaded
     let snapshot_path = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
@@ -104,6 +108,27 @@ async fn e2e_binary_endpoints() -> anyhow::Result<()> {
         "total_active_stake": expected_total_active_stake,
     });
     assert_eq!(meta, expected_meta);
+
+    // A proposal votes against the snapshot frozen at its activation, so quorum
+    // for it has to be readable by slot once newer snapshots exist.
+    let meta_by_slot: serde_json::Value = client
+        .get(format!("{}/meta?network=testnet&slot={}", base_url, slot))
+        .send()
+        .await?
+        .error_for_status()?
+        .json()
+        .await?;
+    assert_eq!(meta_by_slot, expected_meta);
+
+    let missing_slot = client
+        .get(format!(
+            "{}/meta?network=testnet&slot={}",
+            base_url,
+            slot + 1
+        ))
+        .send()
+        .await?;
+    assert_eq!(missing_slot.status(), StatusCode::NOT_FOUND);
 
     // Test GET /voter
     let voter: serde_json::Value = client


### PR DESCRIPTION
## TLDR

This PR closes #195. `/meta` only served the newest snapshot, so quorum resolved for at most one proposal. It now takes an optional `slot`, and both the detail page and the table ask for the snapshot their proposal actually votes against

## Problem

`resolveQuorumDenominator` rejects metadata whose slot does not match the proposal's. This is correct, since a proposal votes against the snapshot frozen at activation and Art. IV.2 fixes that distribution for the whole voting period. But the only metadata available was the newest snapshot, so the guard rejected it for every proposal except one, and for none at all once a newer snapshot existed

The proposals table was worse than the issue describes: it fetched one latest meta and passed it to every row, so at most one row could ever resolve quorum regardless

## Changes

**Verifier**

- `/meta` accepts an optional `slot`; omitting it still returns the newest, so existing callers are unchanged
- `SnapshotMetaRecord::get_by_slot`, with `from_row` extracted so both getters share the row mapping

**Frontend**

- `useSnapshotMeta(slot?)` describes one snapshot
- `useSnapshotMetas(slots)` fetches several for list views, keyed by slot
- both build their query through one shared definition, so a slot fetched for the table and the same slot on a detail page hit one cache entry
- `Columns` takes a `Map<number, NetworkMetaResponse>` and looks up each proposal's own slot

## Tests

- Seven new frontend tests. I verified they catch the real bug by making the hook ignore its slot and 3 of the 6 fail, including the map-keying one, while the dedup and cache-sharing tests still pass, so they pin distinct behaviour
- We also have three e2e assertions: batch returns only the slots that exist, >100 slots is a 400, and `slots=abc` is a 400
- 45 Rust tests, 409 frontend tests, types/eslint/prettier/fmt clean, clippy clean on the touched files

Note that this fix only takes effect once the verifier is deployed