### PR TITLE
fix(frontend): Tolerate a Concurrently Created Meta Merkle Proof

### DIFF
--- a/frontend/src/chain/instructions/__tests__/castVote.test.ts
+++ b/frontend/src/chain/instructions/__tests__/castVote.test.ts
@@ -41,7 +41,7 @@ import { BN } from "@coral-xyz/anchor";
 import type { AnchorWallet } from "@solana/wallet-adapter-react";
 
 import { castVote } from "../castVote";
-import { SVMGOV_PROGRAM_ID } from "../types";
+import { SVMGOV_PROGRAM_ID, SNAPSHOT_PROGRAM_ID } from "../types";
 import type { RpcNetwork } from "@/types";
 
 // Distinct, valid 32-byte public keys used as stand-ins.
@@ -134,7 +134,12 @@ describe("castVote", () => {
       current: [{ nodePubkey: SIGNER, votePubkey: VOTE_ACCOUNT }],
       delinquent: [],
     });
-    mockGetAccountInfo.mockResolvedValue({ data: Buffer.alloc(0) });
+    // An initialized proof: owned by the snapshot program with data. Lamports
+    // alone would not qualify — see isMetaMerkleProofInitialized.
+    mockGetAccountInfo.mockResolvedValue({
+      owner: SNAPSHOT_PROGRAM_ID,
+      data: Buffer.alloc(32),
+    });
     mockGetLatestBlockhash.mockResolvedValue({
       blockhash: BLOCKHASH,
       lastValidBlockHeight: 123,

--- a/frontend/src/chain/instructions/__tests__/castVoteOverride.test.ts
+++ b/frontend/src/chain/instructions/__tests__/castVoteOverride.test.ts
@@ -1,5 +1,6 @@
 import {
   PublicKey,
+  SystemProgram,
   Transaction,
   TransactionInstruction,
 } from "@solana/web3.js";
@@ -56,7 +57,7 @@ import { BN } from "@coral-xyz/anchor";
 import type { AnchorWallet } from "@solana/wallet-adapter-react";
 
 import { castVoteOverride } from "../castVoteOverride";
-import { SVMGOV_PROGRAM_ID } from "../types";
+import { SVMGOV_PROGRAM_ID, SNAPSHOT_PROGRAM_ID } from "../types";
 import type { RpcNetwork } from "@/types";
 
 // Distinct, valid 32-byte public keys used as stand-ins (byte-filled so PDA derivation always
@@ -81,6 +82,12 @@ const META_MERKLE_PROOF_PDA = new PublicKey(keyFromByte(20));
 const VALIDATOR_VOTE_PDA = new PublicKey(keyFromByte(21));
 const VOTE_OVERRIDE_PDA = new PublicKey(keyFromByte(22));
 const VOTE_OVERRIDE_CACHE_PDA = new PublicKey(keyFromByte(23));
+
+/** A created proof: owned by the snapshot program, with data. */
+const INITIALIZED_PROOF_ACCOUNT = {
+  owner: SNAPSHOT_PROGRAM_ID,
+  data: Buffer.alloc(32),
+};
 
 describe("castVoteOverride", () => {
   let recordedAccounts: Record<string, PublicKey>;
@@ -163,7 +170,9 @@ describe("castVoteOverride", () => {
     mockCreateProgramWithWallet.mockReturnValue(buildFakeProgram());
     mockCreateGovV1ProgramWithWallet.mockReturnValue(buildFakeGovV1Program());
     mockComputeProofCloseTimestamp.mockResolvedValue(2_000_000_000);
-    mockGetAccountInfo.mockResolvedValue({ data: Buffer.alloc(0) });
+    // An initialized proof: owned by the snapshot program with data. Lamports
+    // alone would not qualify — see isMetaMerkleProofInitialized.
+    mockGetAccountInfo.mockResolvedValue(INITIALIZED_PROOF_ACCOUNT);
     mockGetLatestBlockhash.mockResolvedValue({
       blockhash: BLOCKHASH,
       lastValidBlockHeight: 123,
@@ -373,6 +382,52 @@ describe("castVoteOverride", () => {
     );
     expect(mockSignTransaction).toHaveBeenCalledTimes(1);
     expect(mockSendRawTransaction).toHaveBeenCalledTimes(1);
+  });
+
+  it("proceeds when another delegator creates the shared proof first", async () => {
+    // Every delegator under a validator shares one proof account, so one can
+    // create it between the existence check and this transaction landing.
+    // Preflight rejects the duplicate creation before a signature comes back.
+    mockGetAccountInfo
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(INITIALIZED_PROOF_ACCOUNT);
+    mockSendRawTransaction
+      .mockRejectedValueOnce(new Error("Allocate: account already in use"))
+      .mockResolvedValueOnce("vote-signature");
+
+    const result = await castVoteOverride(params, blockchainParams);
+
+    expect(result).toEqual({ signature: "vote-signature", success: true });
+  });
+
+  it("still fails when initialization fails and no proof appears", async () => {
+    // Recovery is conditional on the account existing, so an underfunded payer
+    // or a rejected signature is not mistaken for a lost race.
+    mockGetAccountInfo.mockResolvedValue(null);
+    mockSendRawTransaction.mockRejectedValueOnce(
+      new Error("insufficient funds"),
+    );
+
+    await expect(castVoteOverride(params, blockchainParams)).rejects.toThrow(
+      /insufficient funds/,
+    );
+  });
+
+  it("initializes the proof when the address only holds lamports", async () => {
+    // The address is derivable, so anyone can fund it before it exists. Treating
+    // that as initialized would skip creation and fail the program's owner check.
+    mockGetAccountInfo.mockResolvedValue({
+      owner: SystemProgram.programId,
+      data: Buffer.alloc(0),
+    });
+    mockSendRawTransaction
+      .mockResolvedValueOnce("init-signature")
+      .mockResolvedValueOnce("vote-signature");
+
+    const result = await castVoteOverride(params, blockchainParams);
+
+    expect(result).toEqual({ signature: "vote-signature", success: true });
+    expect(mockSignTransaction).toHaveBeenCalledTimes(2);
   });
 
   it("reports an unsigned wallet response without submitting the transaction", async () => {

--- a/frontend/src/chain/instructions/__tests__/helpers.test.ts
+++ b/frontend/src/chain/instructions/__tests__/helpers.test.ts
@@ -9,6 +9,7 @@ jest.mock("@/contexts/EndpointContext", () => ({
 import { BN } from "@coral-xyz/anchor";
 import {
   PublicKey,
+  SystemProgram,
   TransactionExpiredBlockheightExceededError,
 } from "@solana/web3.js";
 
@@ -16,6 +17,7 @@ import {
   assertOverrideProofLineage,
   confirmTransactionByPolling,
   computeProofCloseTimestamp,
+  isMetaMerkleProofInitialized,
   resolveProposalSnapshotSlot,
   resolveSnapshotVoteAccount,
 } from "../helpers";
@@ -83,7 +85,7 @@ function mockConnection(
     epoch: number;
     slotsInEpoch: number;
   },
-  getBlockTime: (slot: number) => Promise<number | null>
+  getBlockTime: (slot: number) => Promise<number | null>,
 ): { connection: Connection; getBlockTime: jest.Mock } {
   const getBlockTimeMock = jest.fn(getBlockTime);
   const connection = {
@@ -102,7 +104,7 @@ describe("computeProofCloseTimestamp", () => {
         epoch: 100,
         slotsInEpoch: 432_000,
       },
-      async () => 1_700_000_000
+      async () => 1_700_000_000,
     );
 
     const ts = await computeProofCloseTimestamp(connection, 102);
@@ -126,7 +128,7 @@ describe("computeProofCloseTimestamp", () => {
         epoch: 100,
         slotsInEpoch: 432_000,
       },
-      async (slot: number) => (slot === 500_000 ? null : 1_700_000_000)
+      async (slot: number) => (slot === 500_000 ? null : 1_700_000_000),
     );
 
     const ts = await computeProofCloseTimestamp(connection, 102);
@@ -146,7 +148,7 @@ describe("computeProofCloseTimestamp", () => {
         epoch: 200,
         slotsInEpoch: 432_000,
       },
-      async () => 1_700_000_000
+      async () => 1_700_000_000,
     );
 
     const ts = await computeProofCloseTimestamp(connection, 199);
@@ -166,13 +168,13 @@ describe("computeProofCloseTimestamp", () => {
         epoch: 100,
         slotsInEpoch: 432_000,
       },
-      async () => null
+      async () => null,
     );
 
     // Walks back from absoluteSlot (500_000) over MAX_ATTEMPTS = 8 slots, so the
     // lowest slot actually tried — and thus the reported "ending at" — is 499_993.
     await expect(computeProofCloseTimestamp(connection, 102)).rejects.toThrow(
-      /Failed to fetch a recent block time \(tried 8 slots ending at 499993\)/
+      /Failed to fetch a recent block time \(tried 8 slots ending at 499993\)/,
     );
     expect(getBlockTime).toHaveBeenCalledTimes(8);
   });
@@ -189,7 +191,7 @@ describe("assertOverrideProofLineage", () => {
   const DELEGATOR_WALLET = "DelegatorWallet4444444444444444444444444444";
 
   function stakeProof(
-    overrides: Partial<StakeAccountProofResponse> = {}
+    overrides: Partial<StakeAccountProofResponse> = {},
   ): StakeAccountProofResponse {
     return {
       network: "testnet",
@@ -206,7 +208,7 @@ describe("assertOverrideProofLineage", () => {
   }
 
   function metaProof(
-    overrides: Partial<VoteAccountProofResponse["meta_merkle_leaf"]> = {}
+    overrides: Partial<VoteAccountProofResponse["meta_merkle_leaf"]> = {},
   ): VoteAccountProofResponse {
     return {
       network: "testnet",
@@ -225,7 +227,7 @@ describe("assertOverrideProofLineage", () => {
   it("passes when proofs share the snapshot vote account, even if voting wallets differ", () => {
     expect(VALIDATOR_WALLET).not.toBe(DELEGATOR_WALLET);
     expect(() =>
-      assertOverrideProofLineage(stakeProof(), metaProof())
+      assertOverrideProofLineage(stakeProof(), metaProof()),
     ).not.toThrow();
   });
 
@@ -235,8 +237,8 @@ describe("assertOverrideProofLineage", () => {
     expect(() =>
       assertOverrideProofLineage(
         stakeProof(),
-        metaProof({ vote_account: LIVE_VOTE_ACCOUNT })
-      )
+        metaProof({ vote_account: LIVE_VOTE_ACCOUNT }),
+      ),
     ).toThrow(/does not match meta proof vote account/);
   });
 
@@ -246,8 +248,10 @@ describe("assertOverrideProofLineage", () => {
     expect(() =>
       assertOverrideProofLineage(
         stakeProof(),
-        metaProof({ voting_wallet: "OtherWallet66666666666666666666666666666666" })
-      )
+        metaProof({
+          voting_wallet: "OtherWallet66666666666666666666666666666666",
+        }),
+      ),
     ).not.toThrow();
   });
 });
@@ -256,7 +260,7 @@ describe("resolveSnapshotVoteAccount", () => {
   const VOTE_ACCOUNT = new PublicKey(new Uint8Array(32).fill(1)).toBase58();
 
   function stakeProof(
-    overrides: Partial<StakeAccountProofResponse> = {}
+    overrides: Partial<StakeAccountProofResponse> = {},
   ): StakeAccountProofResponse {
     return {
       network: "testnet",
@@ -285,7 +289,7 @@ describe("resolveSnapshotVoteAccount", () => {
       vote_account: undefined as unknown as string,
     });
     expect(() => resolveSnapshotVoteAccount(proof)).toThrow(
-      /missing the snapshot vote_account/
+      /missing the snapshot vote_account/,
     );
   });
 });
@@ -297,7 +301,63 @@ describe("resolveProposalSnapshotSlot", () => {
 
   it("throws when voting has not been activated (slot is 0)", () => {
     expect(() => resolveProposalSnapshotSlot(new BN(0))).toThrow(
-      /no snapshot slot/
+      /no snapshot slot/,
     );
+  });
+});
+
+describe("isMetaMerkleProofInitialized", () => {
+  const PROOF_PDA = new PublicKey(new Uint8Array(32).fill(9));
+  const SNAPSHOT_PROGRAM = new PublicKey(new Uint8Array(32).fill(4));
+
+  function connectionReturning(info: unknown) {
+    return {
+      getAccountInfo: jest.fn(async () => info),
+    } as unknown as Connection;
+  }
+
+  it("accepts an account the snapshot program owns", async () => {
+    const connection = connectionReturning({
+      owner: SNAPSHOT_PROGRAM,
+      data: Buffer.alloc(32),
+    });
+
+    await expect(
+      isMetaMerkleProofInitialized(connection, PROOF_PDA, SNAPSHOT_PROGRAM),
+    ).resolves.toBe(true);
+  });
+
+  it("rejects an address that only holds lamports", async () => {
+    // The address is derivable, so anyone can fund it before it is created;
+    // only the snapshot program owning it means the proof is there.
+    const connection = connectionReturning({
+      owner: SystemProgram.programId,
+      data: Buffer.alloc(0),
+    });
+
+    await expect(
+      isMetaMerkleProofInitialized(connection, PROOF_PDA, SNAPSHOT_PROGRAM),
+    ).resolves.toBe(false);
+  });
+
+  it("rejects an account with no data", async () => {
+    const connection = connectionReturning({
+      owner: SNAPSHOT_PROGRAM,
+      data: Buffer.alloc(0),
+    });
+
+    await expect(
+      isMetaMerkleProofInitialized(connection, PROOF_PDA, SNAPSHOT_PROGRAM),
+    ).resolves.toBe(false);
+  });
+
+  it("rejects a missing account", async () => {
+    await expect(
+      isMetaMerkleProofInitialized(
+        connectionReturning(null),
+        PROOF_PDA,
+        SNAPSHOT_PROGRAM,
+      ),
+    ).resolves.toBe(false);
   });
 });

--- a/frontend/src/chain/instructions/__tests__/modifyVote.test.ts
+++ b/frontend/src/chain/instructions/__tests__/modifyVote.test.ts
@@ -36,7 +36,7 @@ import { BN } from "@coral-xyz/anchor";
 import type { AnchorWallet } from "@solana/wallet-adapter-react";
 
 import { modifyVote } from "../modifyVote";
-import { SVMGOV_PROGRAM_ID } from "../types";
+import { SVMGOV_PROGRAM_ID, SNAPSHOT_PROGRAM_ID } from "../types";
 import type { RpcNetwork } from "@/types";
 
 const keyFromByte = (b: number): string =>
@@ -127,7 +127,12 @@ describe("modifyVote", () => {
       current: [{ nodePubkey: SIGNER, votePubkey: VOTE_ACCOUNT }],
       delinquent: [],
     });
-    mockGetAccountInfo.mockResolvedValue({ data: Buffer.alloc(0) });
+    // An initialized proof: owned by the snapshot program with data. Lamports
+    // alone would not qualify — see isMetaMerkleProofInitialized.
+    mockGetAccountInfo.mockResolvedValue({
+      owner: SNAPSHOT_PROGRAM_ID,
+      data: Buffer.alloc(32),
+    });
     mockGetLatestBlockhash.mockResolvedValue({
       blockhash: BLOCKHASH,
       lastValidBlockHeight: 123,

--- a/frontend/src/chain/instructions/castVote.ts
+++ b/frontend/src/chain/instructions/castVote.ts
@@ -19,6 +19,7 @@ import {
   createGovV1ProgramWithWallet,
   getVoteAccountProof,
   getMetaMerkleProofPda,
+  isMetaMerkleProofInitialized,
   computeProofCloseTimestamp,
   resolveProposalSnapshotSlot,
   signTransactionForWallet,
@@ -103,14 +104,14 @@ export async function castVote(
     consensusResult
   );
 
-  const merkleAccountInfo = await program.provider.connection.getAccountInfo(
-    metaMerkleProofPda,
-    "confirmed"
+  const proofInitialized = await isMetaMerkleProofInitialized(
+    program.provider.connection,
+    metaMerkleProofPda
   );
 
   const instructions: TransactionInstruction[] = [];
 
-  if (!merkleAccountInfo) {
+  if (!proofInitialized) {
     // Set close_timestamp to the proposal's vote expiry so the proof cannot be closed
     // permissionlessly while voting is open. See computeProofCloseTimestamp.
     const closeTimestamp = await computeProofCloseTimestamp(

--- a/frontend/src/chain/instructions/castVoteOverride.ts
+++ b/frontend/src/chain/instructions/castVoteOverride.ts
@@ -24,6 +24,7 @@ import {
   deriveVoteOverridePda,
   deriveVoteOverrideCachePda,
   getMetaMerkleProofPda,
+  isMetaMerkleProofInitialized,
   computeProofCloseTimestamp,
   signTransactionForWallet,
   confirmTransactionByPolling,
@@ -97,13 +98,14 @@ export async function castVoteOverride(
     consensusResult
   );
 
-  // Check if merkle account exists
-  const merkleAccountInfo = await program.provider.connection.getAccountInfo(
-    metaMerkleProofPda,
-    "confirmed"
+  // Every delegator under this validator shares one proof account, so it may
+  // already exist.
+  const proofInitialized = await isMetaMerkleProofInitialized(
+    program.provider.connection,
+    metaMerkleProofPda
   );
 
-  if (!merkleAccountInfo) {
+  if (!proofInitialized) {
     const govV1Program = createGovV1ProgramWithWallet(
       wallet,
       blockchainParams.endpoint
@@ -163,26 +165,41 @@ export async function castVoteOverride(
     initTransaction.recentBlockhash = initBlockhash.blockhash;
     initTransaction.lastValidBlockHeight = initBlockhash.lastValidBlockHeight;
 
-    const signedInitTransaction = await signTransactionForWallet(
-      wallet,
-      initTransaction,
-      signer
-    );
-    const initSignature =
-      await program.provider.connection.sendRawTransaction(
-        signedInitTransaction.serialize(),
-        { preflightCommitment: "confirmed" }
+    try {
+      const signedInitTransaction = await signTransactionForWallet(
+        wallet,
+        initTransaction,
+        signer
       );
-    const initConfirmation = await confirmTransactionByPolling(
-      program.provider.connection,
-      initSignature,
-      initBlockhash.lastValidBlockHeight
-    );
+      const initSignature =
+        await program.provider.connection.sendRawTransaction(
+          signedInitTransaction.serialize(),
+          { preflightCommitment: "confirmed" }
+        );
+      const initConfirmation = await confirmTransactionByPolling(
+        program.provider.connection,
+        initSignature,
+        initBlockhash.lastValidBlockHeight
+      );
 
-    if (initConfirmation.value.err) {
-      throw new Error(
-        `Failed to initialize meta merkle proof: ${JSON.stringify(initConfirmation.value.err)}`
+      if (initConfirmation.value.err) {
+        throw new Error(
+          `Failed to initialize meta merkle proof: ${JSON.stringify(initConfirmation.value.err)}`
+        );
+      }
+    } catch (error) {
+      // Another delegator can create the shared proof between the check above
+      // and this transaction landing. Preflight rejects the duplicate before a
+      // signature returns, so the send is inside the try as well. Recovery is
+      // conditional on the account existing, so a rejected signature or an
+      // underfunded payer still surfaces.
+      const createdConcurrently = await isMetaMerkleProofInitialized(
+        program.provider.connection,
+        metaMerkleProofPda
       );
+      if (!createdConcurrently) {
+        throw error;
+      }
     }
   }
 

--- a/frontend/src/chain/instructions/helpers.ts
+++ b/frontend/src/chain/instructions/helpers.ts
@@ -314,6 +314,26 @@ export function getMetaMerkleProofPda(
 }
 
 /**
+ * Whether the shared meta merkle proof exists and the vote instructions will
+ * accept it.
+ *
+ * Lamports alone do not qualify: the address is derivable, so anyone can fund it
+ * before it is created, and the vote instructions require the snapshot program
+ * to own the account.
+ */
+export async function isMetaMerkleProofInitialized(
+  connection: Connection,
+  metaMerkleProofPda: PublicKey,
+  snapshotProgramId: PublicKey = SNAPSHOT_PROGRAM_ID
+): Promise<boolean> {
+  const info = await connection.getAccountInfo(metaMerkleProofPda, "confirmed");
+
+  return (
+    info !== null && info.owner.equals(snapshotProgramId) && info.data.length > 0
+  );
+}
+
+/**
  * Resolve the snapshot validator vote account from a stake proof, guarding against a verifier
  * response that omits the field. `vote_account` is typed as `string` but comes from an
  * unvalidated JSON response — an older backend that predates surfacing `vote_account` on the

--- a/frontend/src/chain/instructions/modifyVote.ts
+++ b/frontend/src/chain/instructions/modifyVote.ts
@@ -18,6 +18,7 @@ import {
   createGovV1ProgramWithWallet,
   getVoteAccountProof,
   getMetaMerkleProofPda,
+  isMetaMerkleProofInitialized,
   computeProofCloseTimestamp,
   resolveProposalSnapshotSlot,
   signTransactionForWallet,
@@ -98,14 +99,14 @@ export async function modifyVote(
     consensusResult
   );
 
-  const merkleAccountInfo = await program.provider.connection.getAccountInfo(
-    metaMerkleProofPda,
-    "confirmed"
+  const proofInitialized = await isMetaMerkleProofInitialized(
+    program.provider.connection,
+    metaMerkleProofPda
   );
 
   const instructions: TransactionInstruction[] = [];
 
-  if (!merkleAccountInfo) {
+  if (!proofInitialized) {
     // Set close_timestamp to the proposal's vote expiry so the proof cannot be closed
     // permissionlessly while voting is open. See computeProofCloseTimestamp.
     const closeTimestamp = await computeProofCloseTimestamp(

--- a/frontend/src/chain/instructions/modifyVoteOverride.ts
+++ b/frontend/src/chain/instructions/modifyVoteOverride.ts
@@ -24,6 +24,7 @@ import {
   deriveVoteOverrideCachePda,
   deriveVotePda,
   getMetaMerkleProofPda,
+  isMetaMerkleProofInitialized,
   computeProofCloseTimestamp,
   signTransactionForWallet,
   confirmTransactionByPolling,
@@ -97,13 +98,14 @@ export async function modifyVoteOverride(
     consensusResult
   );
 
-  // Check if merkle account exists
-  const merkleAccountInfo = await program.provider.connection.getAccountInfo(
-    metaMerkleProofPda,
-    "confirmed"
+  // Every delegator under this validator shares one proof account, so it may
+  // already exist.
+  const proofInitialized = await isMetaMerkleProofInitialized(
+    program.provider.connection,
+    metaMerkleProofPda
   );
 
-  if (!merkleAccountInfo) {
+  if (!proofInitialized) {
     console.log("merkle proof does not exist, initializing");
     const govV1Program = createGovV1ProgramWithWallet(
       wallet,
@@ -164,26 +166,41 @@ export async function modifyVoteOverride(
     initTransaction.recentBlockhash = initBlockhash.blockhash;
     initTransaction.lastValidBlockHeight = initBlockhash.lastValidBlockHeight;
 
-    const signedInitTransaction = await signTransactionForWallet(
-      wallet,
-      initTransaction,
-      signer
-    );
-    const initSignature =
-      await program.provider.connection.sendRawTransaction(
-        signedInitTransaction.serialize(),
-        { preflightCommitment: "confirmed" }
+    try {
+      const signedInitTransaction = await signTransactionForWallet(
+        wallet,
+        initTransaction,
+        signer
       );
-    const initConfirmation = await confirmTransactionByPolling(
-      program.provider.connection,
-      initSignature,
-      initBlockhash.lastValidBlockHeight
-    );
+      const initSignature =
+        await program.provider.connection.sendRawTransaction(
+          signedInitTransaction.serialize(),
+          { preflightCommitment: "confirmed" }
+        );
+      const initConfirmation = await confirmTransactionByPolling(
+        program.provider.connection,
+        initSignature,
+        initBlockhash.lastValidBlockHeight
+      );
 
-    if (initConfirmation.value.err) {
-      throw new Error(
-        `Failed to initialize meta merkle proof: ${JSON.stringify(initConfirmation.value.err)}`
+      if (initConfirmation.value.err) {
+        throw new Error(
+          `Failed to initialize meta merkle proof: ${JSON.stringify(initConfirmation.value.err)}`
+        );
+      }
+    } catch (error) {
+      // Another delegator can create the shared proof between the check above
+      // and this transaction landing. Preflight rejects the duplicate before a
+      // signature returns, so the send is inside the try as well. Recovery is
+      // conditional on the account existing, so a rejected signature or an
+      // underfunded payer still surfaces.
+      const createdConcurrently = await isMetaMerkleProofInitialized(
+        program.provider.connection,
+        metaMerkleProofPda
       );
+      if (!createdConcurrently) {
+        throw error;
+      }
     }
   }
 


### PR DESCRIPTION
## TLDR

This PR closes #175. Every delegator under a validator shares one proof account, so creating it is a race. The override paths aborted instead of using the account that now exists, and the existence check treated a funded-but-uncreated address as
initialized

## The race

The PDA is `(MetaMerkleProof, consensusResult, meta_merkle_leaf.vote_account)`. A delegator derives it from the validator they delegated to, so a validator and all of their delegators contend on a single account. The issue describes two delegators: a validator voting while one of their delegators overrides, colliding identically

| Path | Creation | On collision |
|---|---|---|
| `castVoteOverride`, `modifyVoteOverride` | separate transaction | threw, override never submitted |
| `castVote`, `modifyVote` | bundled into the vote tx | whole vote fails atomically |

One correction to the issue: both self-heal on a manual retry, since the next attempt finds the account. So this is a cryptic failure needing a retry rather than a permanently blocked vote, though during a live vote plenty of delegators will read `Failed to initialize meta merkle proof` as "voting is broken"

Note that `skipPreflight` is never set, so preflight rejects the duplicate creation and `sendRawTransaction` throws rather than returning a signature. The existing `initConfirmation.value.err` guard is not on the path the race takes, so guarding it alone would not have fixed anything. The `try` spans sign, send, and confirm

Recovery is conditional on the account actually being present afterward, not on classifying an error, so a rejected signature or an underfunded payer still fails

## A second bug in the same check

`if (!merkleAccountInfo)` treated any account as initialized, including one holding only lamports. The address is derivable, so anyone can fund it, and `cast_vote_override.rs:116` requires the snapshot program to own it, so a dusted address skipped creation and failed the vote on chain. This is a clear griefing vector against the UI; the program was hardened against this in `prefunded_pdas_do_not_block_voting`, but the frontend was
not

`isMetaMerkleProofInitialized` checks owner and data, and all four vote paths use it. The existing tests encoded the old behaviour by mocking `{ data: Buffer.alloc(0) }`—exactly the dust shape—as initialized

## Reuse is safe

`init_meta_merkle_proof` verifies the leaf against the consensus root before returning, so an account created by another delegator cannot hold contents that would fail the vote

## Tests

- Seven new tests that cover race recovery, genuine failure still throws, dust triggers creation, and four direct cases on the predicate Verified by removal, not just by passing
- `420 passed`, types and eslint clean
