### PR TITLE
fix(frontend): Join Vote Records to Validators on the Identity They Record

### DIFF
--- a/frontend/src/components/governance/validator/ValidatorColumns.tsx
+++ b/frontend/src/components/governance/validator/ValidatorColumns.tsx
@@ -41,11 +41,11 @@ export const columns: ColumnDef<OldVoteAccountData>[] = [
     accessorKey: "identity",
     header: () => <span className="hidden sm:inline">IDENTITY</span>,
     cell: ({ row }) => {
-      const identity = row.original.identity?.toBase58();
-      let cellValue: string | undefined = formatAddress(identity || "", 6);
-      if (!identity) {
-        cellValue = row.original.name;
-      }
+      const { name, identity } = row.original;
+      // The name where the validator is known, the address otherwise; the
+      // column is too narrow for both.
+      const cellValue =
+        name ?? (identity ? formatAddress(identity.toBase58(), 6) : undefined);
 
       return (
         <p className="hidden sm:block font-mono text-xs lg:text-sm">

--- a/frontend/src/data/__tests__/getVoteAccounts.test.ts
+++ b/frontend/src/data/__tests__/getVoteAccounts.test.ts
@@ -1,0 +1,60 @@
+import { PublicKey } from "@solana/web3.js";
+import { BN } from "@coral-xyz/anchor";
+
+import { mapVoteAccountDto } from "../getVoteAccounts";
+import type { RawVoteAccountDataAccount } from "@/types";
+
+const key = (byte: number) => new PublicKey(new Uint8Array(32).fill(byte));
+
+function rawVoteAccount(): RawVoteAccountDataAccount {
+  return {
+    publicKey: key(3),
+    account: {
+      validator: key(1),
+      proposal: key(2),
+      forVotesBp: new BN(10_000),
+      againstVotesBp: new BN(0),
+      abstainVotesBp: new BN(0),
+      forVotesLamports: new BN(25_000_000_000),
+      againstVotesLamports: new BN(0),
+      abstainVotesLamports: new BN(0),
+      stake: new BN(25_000_000_000),
+      overrideLamports: new BN(0),
+      voteTimestamp: new BN(1_700_000_000),
+      bump: 254,
+    },
+  } as unknown as RawVoteAccountDataAccount;
+}
+
+describe("mapVoteAccountDto", () => {
+  it("leaves validator metadata unset", () => {
+    // None of this is on chain. Filling it with zeros renders a 0% commission
+    // validator with no credits, which reads as real data rather than as
+    // metadata that has not been joined yet.
+    const mapped = mapVoteAccountDto(rawVoteAccount());
+
+    expect(mapped.commission).toBeUndefined();
+    expect(mapped.lastVote).toBeUndefined();
+    expect(mapped.credits).toBeUndefined();
+    expect(mapped.epochCredits).toBeUndefined();
+    expect(mapped.activatedStake).toBeUndefined();
+  });
+
+  it("carries the fields the table needs from the account", () => {
+    // The proposal and the ballot are both on the record, so a row can be
+    // attributed to a proposal and show which way it voted.
+    const mapped = mapVoteAccountDto(rawVoteAccount());
+
+    expect(mapped.proposal.equals(key(2))).toBe(true);
+    expect(mapped.identity?.equals(key(1))).toBe(true);
+    expect(mapped.forVotesBp.toNumber()).toBe(10_000);
+    expect(mapped.activeStake).toBe(25_000_000_000);
+  });
+
+  it("uses the record's own address as the row key", () => {
+    // This is the Vote PDA, not the validator's vote account.
+    expect(mapVoteAccountDto(rawVoteAccount()).voteAccount.equals(key(3))).toBe(
+      true,
+    );
+  });
+});

--- a/frontend/src/data/getVoteAccounts.ts
+++ b/frontend/src/data/getVoteAccounts.ts
@@ -31,11 +31,10 @@ export function mapVoteAccountDto(
     // validator data
     activeStake: raw.stake ? +raw.stake.toString() : 0,
     identity: raw.validator,
-    commission: 0,
-    lastVote: 0,
-    credits: 0,
-    epochCredits: 0,
-    activatedStake: 0,
+    // Validator metadata is not on chain; useVoteAccountsWithValidators fills
+    // it in from the RPC and StakeWiz. Left unset so an unmatched row renders
+    // as unknown.
+
     // vote data
     forVotesBp: raw.forVotesBp,
     againstVotesBp: raw.againstVotesBp,

--- a/frontend/src/hooks/__tests__/useVoteAccountsWithValidators.test.tsx
+++ b/frontend/src/hooks/__tests__/useVoteAccountsWithValidators.test.tsx
@@ -1,0 +1,129 @@
+import * as React from "react";
+import { renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { PublicKey } from "@solana/web3.js";
+
+const mockUseGetValidators = jest.fn();
+const mockUseVoteAccounts = jest.fn();
+
+jest.mock("../useGetValidators", () => ({
+  useGetValidators: () => mockUseGetValidators(),
+}));
+jest.mock("../useVoteAccounts", () => ({
+  useVoteAccounts: () => mockUseVoteAccounts(),
+}));
+
+import { useVoteAccountsWithValidators } from "../useVoteAccountsWithValidators";
+
+const key = (byte: number) => new PublicKey(new Uint8Array(32).fill(byte));
+
+/** A validator signs governance votes with its identity, not its vote account. */
+const IDENTITY = key(1);
+const VOTE_ACCOUNT = key(2);
+const VOTE_PDA = key(3);
+
+const validator = {
+  name: "Real Validator",
+  vote_identity: VOTE_ACCOUNT.toBase58(),
+  identity: IDENTITY.toBase58(),
+  activated_stake: 25_000_000_000,
+  commission: 5,
+  epoch_credits: 111,
+  last_vote: 222,
+  credits: 333,
+};
+
+/** A validator the vote record does not belong to. */
+const OTHER_VALIDATOR = {
+  ...validator,
+  vote_identity: key(8).toBase58(),
+  identity: key(9).toBase58(),
+};
+
+/** As mapVoteAccountDto builds it: validator metadata is left unset. */
+const voteRecord = {
+  voteAccount: VOTE_PDA,
+  identity: IDENTITY,
+  activeStake: 25_000_000_000,
+};
+
+function wrapper({ children }: { children: React.ReactNode }) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+}
+
+function renderWith(validators: unknown[], votes: unknown[]) {
+  mockUseGetValidators.mockReturnValue({
+    data: validators,
+    isLoading: false,
+  });
+  mockUseVoteAccounts.mockReturnValue({ data: votes, isLoading: false });
+
+  return renderHook(() => useVoteAccountsWithValidators(), { wrapper });
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  jest.spyOn(console, "warn").mockImplementation(() => {});
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+describe("useVoteAccountsWithValidators", () => {
+  it("matches a vote record on the validator identity it records", async () => {
+    // The reported bug: the lookup compared the recorded identity against
+    // vote_identity, which holds the vote account address, so no row ever
+    // matched and every one kept the placeholder metadata.
+    const { result } = renderWith([validator], [voteRecord]);
+
+    await waitFor(() => expect(result.current.data).toBeDefined());
+
+    const entry = result.current.data!.voteMap[VOTE_PDA.toBase58()];
+    expect(entry.validator?.name).toBe("Real Validator");
+    expect(entry.voteAccount.commission).toBe(5);
+    expect(entry.voteAccount.lastVote).toBe(222);
+  });
+
+  it("also matches on the vote account address", async () => {
+    // Sibling hooks index both keys; a record carrying the vote account instead
+    // of the identity has to resolve the same validator.
+    const { result } = renderWith(
+      [validator],
+      [{ ...voteRecord, identity: VOTE_ACCOUNT }],
+    );
+
+    await waitFor(() => expect(result.current.data).toBeDefined());
+
+    expect(
+      result.current.data!.voteMap[VOTE_PDA.toBase58()].validator?.name,
+    ).toBe("Real Validator");
+  });
+
+  it("leaves metadata unset when no validator matches", async () => {
+    // Zeros here would render as a real 0% commission with no credits, which is
+    // indistinguishable from a validator that genuinely has those values.
+    const { result } = renderWith([OTHER_VALIDATOR], [voteRecord]);
+
+    await waitFor(() => expect(result.current.data).toBeDefined());
+
+    const entry = result.current.data!.voteMap[VOTE_PDA.toBase58()];
+    expect(entry.validator).toBeUndefined();
+    expect(entry.voteAccount.commission).toBeUndefined();
+    expect(entry.voteAccount.lastVote).toBeUndefined();
+    expect(entry.voteAccount.credits).toBeUndefined();
+  });
+
+  it("reports how many records went unmatched", async () => {
+    // The previous code swallowed this, so a wholly broken join looked normal.
+    const warn = jest.spyOn(console, "warn");
+
+    const { result } = renderWith([OTHER_VALIDATOR], [voteRecord]);
+    await waitFor(() => expect(result.current.data).toBeDefined());
+
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining("1 of 1"));
+  });
+});

--- a/frontend/src/hooks/__tests__/useVoteAccountsWithValidators.test.tsx
+++ b/frontend/src/hooks/__tests__/useVoteAccountsWithValidators.test.tsx
@@ -88,6 +88,18 @@ describe("useVoteAccountsWithValidators", () => {
     expect(entry.voteAccount.lastVote).toBe(222);
   });
 
+  it("keeps the identity on a matched record", async () => {
+    // The mobile drawer reads this field directly and has no name to fall back
+    // on, so enriching a row must not cost it the address.
+    const { result } = renderWith([validator], [voteRecord]);
+
+    await waitFor(() => expect(result.current.data).toBeDefined());
+
+    const entry = result.current.data!.voteMap[VOTE_PDA.toBase58()];
+    expect(entry.voteAccount.identity?.equals(IDENTITY)).toBe(true);
+    expect(entry.voteAccount.name).toBe("Real Validator");
+  });
+
   it("also matches on the vote account address", async () => {
     // Sibling hooks index both keys; a record carrying the vote account instead
     // of the identity has to resolve the same validator.

--- a/frontend/src/hooks/useVoteAccountsWithValidators.ts
+++ b/frontend/src/hooks/useVoteAccountsWithValidators.ts
@@ -69,8 +69,6 @@ export const useVoteAccountsWithValidators = () => {
             // enrich vote account info with matched validator data
             voteAccount: {
               ...vote,
-              // Cleared so the identity column falls back to the name.
-              identity: undefined,
               name: validator.name,
               commission: validator.commission,
               credits: validator.credits,

--- a/frontend/src/hooks/useVoteAccountsWithValidators.ts
+++ b/frontend/src/hooks/useVoteAccountsWithValidators.ts
@@ -47,10 +47,21 @@ export const useVoteAccountsWithValidators = () => {
       const voteMap: VoteMap = {};
       const validatorMap: ValidatorMap = {};
 
+      // A Vote account records the validator's identity, while StakeWiz keys on
+      // the vote account address. Index both so a lookup succeeds with either.
+      const validatorByKey: Record<string, Validator> = {};
+      for (const v of validators) {
+        validatorByKey[v.vote_identity] = v;
+        if (v.identity) {
+          validatorByKey[v.identity] = v;
+        }
+      }
+
+      let unmatched = 0;
+
       for (const vote of votes) {
-        const validator = validators.find(
-          (v) => vote.identity?.toBase58() === v.vote_identity,
-        );
+        const identity = vote.identity?.toBase58();
+        const validator = identity ? validatorByKey[identity] : undefined;
         const votePk = vote.voteAccount.toBase58();
         if (validator) {
           const entry: VoteValidatorEntry = {
@@ -58,8 +69,10 @@ export const useVoteAccountsWithValidators = () => {
             // enrich vote account info with matched validator data
             voteAccount: {
               ...vote,
+              // Cleared so the identity column falls back to the name.
               identity: undefined,
               name: validator.name,
+              commission: validator.commission,
               credits: validator.credits,
               lastVote: validator.last_vote,
               activeStake: validator.activated_stake,
@@ -76,7 +89,7 @@ export const useVoteAccountsWithValidators = () => {
           }
           validatorMap[valId].push(entry);
         } else {
-          // console.warn("no validator found");
+          unmatched += 1;
           const entry: VoteValidatorEntry = {
             votePDA: vote.voteAccount.toBase58(),
             voteAccount: {
@@ -87,6 +100,12 @@ export const useVoteAccountsWithValidators = () => {
           };
           voteMap[votePk] = entry;
         }
+      }
+
+      if (unmatched > 0) {
+        console.warn(
+          `No validator metadata for ${unmatched} of ${votes.length} vote records; those rows report unknown rather than zero.`,
+        );
       }
 
       return {


### PR DESCRIPTION
## TLDR

This PR addresses part of #185. The Vote Accounts table showed `0%` commission and `0` credits for every validator because the join to validator metadata could never match

## The join

A `Vote` account records `validator: self.signer.key()`, which is the validator identity. StakeWiz keys on `vote_identity`, which is the vote account address. The lookup compared one against the other:

```ts
validators.find((v) => vote.identity?.toBase58() === v.vote_identity)
```

So every row fell through to the unmatched branch and kept the placeholder metadata from `mapVoteAccountDto`

The repo already knew this. `useGetValidators.ts:56-58` says "StakeWiz vote_identity is the vote account address — match to vote.votePubkey, not nodePubkey", and `useProposalVotes` and `useProposalSupporters` both index by identity and vote account. This hook was the one that never got the same treatment, so it now follows their pattern

The enrichment also copies `name`, `credits`, `lastVote`, `activeStake` and `epochCredits` but not `commission`. Fixing only the join would have left the reported `COMMISSION 0%` wrong

## The swallowed signal

The unmatched branch opened with `// console.warn("no validator found")`, commented out, so a join matching nothing looked entirely normal. Unmatched records are now counted and reported once with a ratio. Because `useGetValidators` synthesizes an entry for every RPC vote account, this should now be rare, which is what makes it worth logging

## Expect this visible change

**Matched rows will show the validator name in the identity column.** Clearing `identity` on matched rows makes the column fall back to `name`—that was always the intent; it just never fired

`credits` may still show `-` for some validators: it is optional on `Validator` and the RPC-only fallback does not set it. That is an honest unknown rather than a regression

## Tests

Verified by reverting each fix:

- the identity-match test fails against the original lookup
- the mapper test fails against the restored zeros

My first attempt had a gap this caught—the hook test passed even with the zeros restored, because it builds a record directly and bypasses the mapper. Hence the separate `mapVoteAccountDto` tests

We also have `424 passed`, types, eslint and prettier clean