### PR TITLE
ci: point `solana config set` to a keypair that exists

### DIFF
--- a/.github/workflows/release-programs.yaml
+++ b/.github/workflows/release-programs.yaml
@@ -126,7 +126,7 @@ jobs:
           echo "pubkey=$PUBKEY" >> "$GITHUB_OUTPUT"
 
       - name: Configure Solana CLI
-        run: solana config set --url "$RPC_URL" --keypair "$HOME/.config/solana/id.json" > /dev/null
+        run: solana config set --url "$RPC_URL" --keypair "/tmp/deployer.json" > /dev/null
 
       # Equivalent of the build-verified composite action, inlined so the
       # base image can be pinned per program (its positional mount-dir


### PR DESCRIPTION
It looks like the [verify step](https://github.com/solana-foundation/solana-governance/actions/runs/33911792205/job/101149693094) is failing in CI due to not finding the keypair. 

The previous steps work. It looks like the previous steps are using the `keypair: ${{ env.DEPLOYER_KEYPAIR }}` provided, but this step is falling back to the default keypair. 

Currently `solana config set` was pointing to a nonexistent keypair - this updates to actually point to the real one so when the verify step falls back to the default, things work.