### PR TITLE
ci: update agave toolchain to 4.1.2

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -94,11 +94,19 @@ jobs:
 
       # Both programs live in the repo-root workspace; artifacts land in
       # target/deploy/ at the repo root, where the LiteSVM suites load them.
+      # Keep SBF intermediates out of the Rust target cache. cargo-build-sbf's
+      # platform-tools are not part of rust-cache's key, and restoring
+      # target/sbpf-solana-solana across Agave versions can produce an invalid
+      # program binary. The final artifacts still go to target/deploy below.
       - name: Build ncn-snapshot program
-        run: cargo-build-sbf --manifest-path ncn/programs/ncn-snapshot/Cargo.toml -- --locked
+        env:
+          CARGO_TARGET_DIR: ${{ runner.temp }}/sbpf-target
+        run: cargo-build-sbf --sbf-out-dir target/deploy --manifest-path ncn/programs/ncn-snapshot/Cargo.toml -- --locked
 
       - name: Build svmgov program
-        run: cargo-build-sbf --manifest-path svmgov/program/programs/svmgov_program/Cargo.toml -- --locked
+        env:
+          CARGO_TARGET_DIR: ${{ runner.temp }}/sbpf-target
+        run: cargo-build-sbf --sbf-out-dir target/deploy --manifest-path svmgov/program/programs/svmgov_program/Cargo.toml -- --locked
 
       # ncn-merkle-tree is a root-workspace member both programs' proof
       # verification depends on, so its unit tests ride along here.

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,7 +21,7 @@ concurrency:
 env:
   RUST_VERSION: "1.93.1"
   # Agave release providing cargo-build-sbf for the on-chain program build.
-  AGAVE_VERSION: "3.1.10"
+  AGAVE_VERSION: "4.1.2"
 
 jobs:
   build:

--- a/.github/workflows/release-programs.yaml
+++ b/.github/workflows/release-programs.yaml
@@ -39,7 +39,7 @@ concurrency:
 env:
   RUST_VERSION: "1.93.1"
   # Agave release providing the solana CLI used by the deploy actions.
-  AGAVE_VERSION: "3.1.10"
+  AGAVE_VERSION: "4.1.2"
   # Pinned so verified builds stay reproducible: the executable hash depends
   # on the builder, and this is the version validated against this repo
   # (0.4.x fails to locate artifacts in this workspace layout).

--- a/.github/workflows/release-programs.yaml
+++ b/.github/workflows/release-programs.yaml
@@ -56,8 +56,8 @@ jobs:
       - id: set
         run: |
           ALL='[
-            {"program":"svmgov_program","program-id":"govYkyQ3ePtGULAtY6V75qjWE8UH4vCUVQ1W4HdCAZU","mount-path":".","base-image":"solanafoundation/solana-verifiable-build:3.1.10","idl-path":"svmgov/cli/idls/svmgov_program.json"},
-            {"program":"ncn_snapshot","program-id":"ncnwF8AgynRcdEnGLcprSQNaKvgSMTgk3yPRc8cf9Zf","mount-path":".","base-image":"solanafoundation/solana-verifiable-build:3.1.10","idl-path":"ncn/idl/ncn_snapshot.json"}
+            {"program":"svmgov_program","program-id":"govYkyQ3ePtGULAtY6V75qjWE8UH4vCUVQ1W4HdCAZU","mount-path":".","base-image":"solanafoundation/solana-verifiable-build:4.1.2","idl-path":"svmgov/cli/idls/svmgov_program.json"},
+            {"program":"ncn_snapshot","program-id":"ncnwF8AgynRcdEnGLcprSQNaKvgSMTgk3yPRc8cf9Zf","mount-path":".","base-image":"solanafoundation/solana-verifiable-build:4.1.2","idl-path":"ncn/idl/ncn_snapshot.json"}
           ]'
           if [ "${{ inputs.programs }}" = "both" ]; then
             SELECTED="$ALL"


### PR DESCRIPTION
The previous release programs workflow [failed](https://github.com/solana-foundation/solana-governance/actions/runs/33915332354/job/101161097681) with "Upgrade authority does not match program authority" when attempting to resize.

However, the extend program instruction is permissionless. This was a bug in the solana CLI v3.1.10 and beyond, fixed in 4.1.2.

This updates CI to use a more up to date toolchain that does not contain the bug